### PR TITLE
fix: attributes for Peril runeword

### DIFF
--- a/data/global/excel/runes.txt
+++ b/data/global/excel/runes.txt
@@ -106,7 +106,7 @@ Runeword96	Patience	1				weap	armo	shld							NefEldRal	r04	r02	r08				Balance2	
 Runeword97	Pattern	1			 D2R  Ladder  1 	h2h									TalOrtThul	r07	r09	r10				att%		10	10	dmg%		40	80	dmg-fire		12	32	res-all		15	15	str		6	6	dex		6	6	block2		30	30	0
 Runeword98	Peace	1				mele									TirEthEl	r03	r05	r01				levelreq		6	6	dmg-norm		20	40	swing1		20	20	Balance2		20	20	block2		20	20	fade		1	1	res-all		15	15	0
 Runeword100	Penitence	1				armo	shld								IthTir	r06	r03					block1		15	15	balance1		15	15	rep-dur	10			half-freeze		1	1	res-pois-len		50	50									0
-Runeword101	Peril	1				miss									ChamLoBerBerLoCham	r32	r28	r30	r30	r28	r32	levelreq		11	11	dmg-min		100	200	dmg-max		300	400	swing3		75	75	allskills		1	1	mag%/lvl	8			all-stats		20	30	0
+Runeword101	Peril	1				miss									ChamLoBerBerLoCham	r32	r28	r30	r30	r28	r32	levelreq		11	11	dmg%		250	250	dmg/lvl	25			swing3		75	75	allskills		1	1	mag%/lvl	8			all-stats		20	30	0
 Runeword102	Pestilence	1				axe									SolKoIo	r12	r18	r16				dmg-pois	100	800	800	noheal		1	1	mag%		20	35	dmg%		188	188	extra-pois		20	20	oskill	Poison Explosion	3	3	res-pois-len		50	50	0
 Runeword103	Phoenix	1				weap	shld								VexVexLoJah	r26	r26	r28	r31			levelup-skill	Blaze	100	40	hit-skill	Firestorm	40	22	aura	Redemption	13	13	dmg%		350	400	pierce-fire		28	28	ac-miss		350	400	abs-fire		15	21	0
 Runeword104	Piety	1				helm									LemNefShael	r20	r04	r13				ac%		90	125	enr		20	20	mana/lvl	8			allskills		1	1	cast2		20	20	res-all		15	25	res-mag		15	25	0


### PR DESCRIPTION
# Proposition to change the Peril runeword

I opened an [issue](https://github.com/D2R-Reimagined/d2r-reimagined-mod/issues/75) regarding Peril's attributes being incorrect, I did some testing and realized that min and max damage are limited to 63-127 respectively, given that the weapon's damage was not nearly enough the initially proposed,

I'm proposing replacing:

```
dmg-min		100	200
dmg-max	300	400
```

With:
```
dmg%		250	250
dmg/lvl	        25
```

I copied those 2 attrs from Windforce.

Here's how it looks like now (level 66 while looking at the item):

![peril-proposition](https://github.com/user-attachments/assets/7bc3b8ed-a43e-4c8c-80d5-7314be493107)

