### PR TITLE
chore: add png files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.idea
 *.iml
 *.bak
+*.png


### PR DESCRIPTION
Adding ignore pngs to gitignore so we don't accidently upload sprite conversions 