### PR TITLE
chore: reduce chance of conversion orbs by half

### DIFF
--- a/data/global/excel/treasureclassex.txt
+++ b/data/global/excel/treasureclassex.txt
@@ -3,9 +3,9 @@ Gold			1					4	gld,mul=1024	1																									0
 Gold 2x			1					4	gld,mul=2048	1																									0
 Gold 2.5x			1					4	gld,mul=2560	1																									0
 Gold 3x			1					4	gld,mul=3072	1																									0
-Jewelry A			1					0	rin	80	amu	40	jew	20	cm3	20	cm2	20	cm1	20	ooc	1													0
-Jewelry B			1					0	rin	80	amu	40	jew	20	cm3	20	cm2	20	cm1	20	ooc	1													0
-Jewelry C			1					0	rin	80	amu	40	jew	20	cm3	20	cm2	20	cm1	20	ooc	1													0
+Jewelry A			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	ooc	1													0
+Jewelry B			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	ooc	1													0
+Jewelry C			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	ooc	1													0
 Chipped Gem			1					0	gcv	3	gcy	3	gcb	3	gcg	3	gcr	3	gcw	3	skc	2													0
 Flawed Gem			1					0	gfv	3	gfy	3	gfb	3	gfg	3	gfr	3	gfw	3	skf	2													0
 Normal Gem			1					0	gsv	3	gsy	3	gsb	3	gsg	3	gsr	3	gsw	3	sku	2													0

--- a/data/global/excel/treasureclassex.txt
+++ b/data/global/excel/treasureclassex.txt
@@ -689,14 +689,14 @@ Andarielq (N)			7	995	995	1024	1024	5	Act 2 (N) Equip A	19	Act 2 (N) Good	3					
 Andarielq (N) Desecrated A	20	43	7	995	995	1024	1024	19	Act 2 (N) Equip A	19	Act 2 (N) Good	3	ka3	2																					0
 Andarielq (N) Desecrated B	20	57	7	995	995	1024	1024	19	Act 4 (N) Equip B	19	Act 4 (N) Good	3	ka3	2																					0
 Andarielq (N) Desecrated C	20	73	7	995	995	1024	1024	19	Act 3 (H) Equip A	19	Act 3 (H) Good	3	ka3	2																					0
-Andarielq (H) Desecrated A	20	74	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated A	1																							0
-Andarielq (H) Desecrated B	20	78	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated B	1																							0
-Andarielq (H) Desecrated C	20	81	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated C	1																							0
-Andarielq (H) Desecrated D	20	84	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated D	1																							0
-Andarielq (H) Desecrated E	20	87	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated E	1																							0
-Andarielq (H) Desecrated F	20	90	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated F	1																							0
-Andarielq (H) Desecrated G	20	93	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated G	1																							0
-Andarielq (H) Desecrated H	20	96	-2					0	Sunder Charms	1	Andarielq Item (H) Desecrated H	1																							0
+Andarielq (H) Desecrated A	20	74	-1					0	Andarielq Item (H) Desecrated A	1																									0
+Andarielq (H) Desecrated B	20	78	-1					0	Andarielq Item (H) Desecrated B	1																									0
+Andarielq (H) Desecrated C	20	81	-1					0	Andarielq Item (H) Desecrated C	1																									0
+Andarielq (H) Desecrated D	20	84	-1					0	Andarielq Item (H) Desecrated D	1																									0
+Andarielq (H) Desecrated E	20	87	-1					0	Andarielq Item (H) Desecrated E	1																									0
+Andarielq (H) Desecrated F	20	90	-1					0	Andarielq Item (H) Desecrated F	1																									0
+Andarielq (H) Desecrated G	20	93	-1					0	Andarielq Item (H) Desecrated G	1																									0
+Andarielq (H) Desecrated H	20	96	-1					0	Andarielq Item (H) Desecrated H	1																									0
 Andarielq (H)			7	995	995	1024	1024	5	Act 2 (H) Equip A	19	Act 2 (H) Good	3	oos	1																					0
 Andarielq Item (H) Desecrated A			7	995	995	1024	1024	19	Act 3 (H) Equip B	19	Act 3 (H) Good	3	oos	1	ka3	3																			0
 Andarielq Item (H) Desecrated B			7	995	995	1024	1024	19	Act 3 (H) Equip C	19	Act 3 (H) Good	3	oos	1	ka3	3																			0
@@ -1023,10 +1023,10 @@ Duriel (H) Desecrated Five			5					0	Duriel (H) - Base Desecrated A	2	ka3	3					
 Duriel (H) Desecrated Town Portal			5					0	Duriel (H) - Base Desecrated B	2	ka3	3																							0
 Duriel (H) Desecrated Scrolls			5					0	Duriel (H) - Base Desecrated C	2	ka3	3																							0
 Duriel (H) Desecrated Incoming			5					0	Duriel (H) - Base Desecrated D	2	ka3	3																							0
-Duriel (H) Desecrated A	34	88	-2					0	Sunder Charms	1	Duriel (H) Desecrated Five	1	ka3	3																					0
-Duriel (H) Desecrated B	34	90	-2					0	Sunder Charms	1	Duriel (H) Desecrated Town Portal	1	ka3	3																					0
-Duriel (H) Desecrated C	34	93	-2					0	Sunder Charms	1	Duriel (H) Desecrated Scrolls	1	ka3	3																					0
-Duriel (H) Desecrated D	34	96	-2					0	Sunder Charms	1	Duriel (H) Desecrated Incoming	1	ka3	3																					0
+Duriel (H) Desecrated A	34	88	-2					0	Duriel (H) Desecrated Five	1	ka3	1																							0
+Duriel (H) Desecrated B	34	90	-2					0	Duriel (H) Desecrated Town Portal	1	ka3	1																							0
+Duriel (H) Desecrated C	34	93	-2					0	Duriel (H) Desecrated Scrolls	1	ka3	1																							0
+Duriel (H) Desecrated D	34	96	-2					0	Duriel (H) Desecrated Incoming	1	ka3	1																							0
 Durielq			5					0	Durielq - Base	2																									0
 Durielq (N)			5					0	Durielq (N) - Base	2																									0
 Durielq (H)			5					0	Durielq (H) - Base	2																									0

--- a/data/global/excel/treasureclassex.txt
+++ b/data/global/excel/treasureclassex.txt
@@ -689,14 +689,14 @@ Andarielq (N)			7	995	995	1024	1024	5	Act 2 (N) Equip A	19	Act 2 (N) Good	3					
 Andarielq (N) Desecrated A	20	43	7	995	995	1024	1024	19	Act 2 (N) Equip A	19	Act 2 (N) Good	3	ka3	2																					0
 Andarielq (N) Desecrated B	20	57	7	995	995	1024	1024	19	Act 4 (N) Equip B	19	Act 4 (N) Good	3	ka3	2																					0
 Andarielq (N) Desecrated C	20	73	7	995	995	1024	1024	19	Act 3 (H) Equip A	19	Act 3 (H) Good	3	ka3	2																					0
-Andarielq (H) Desecrated A	20	74	-1					0	Andarielq Item (H) Desecrated A	1																									0
-Andarielq (H) Desecrated B	20	78	-1					0	Andarielq Item (H) Desecrated B	1																									0
-Andarielq (H) Desecrated C	20	81	-1					0	Andarielq Item (H) Desecrated C	1																									0
-Andarielq (H) Desecrated D	20	84	-1					0	Andarielq Item (H) Desecrated D	1																									0
-Andarielq (H) Desecrated E	20	87	-1					0	Andarielq Item (H) Desecrated E	1																									0
-Andarielq (H) Desecrated F	20	90	-1					0	Andarielq Item (H) Desecrated F	1																									0
-Andarielq (H) Desecrated G	20	93	-1					0	Andarielq Item (H) Desecrated G	1																									0
-Andarielq (H) Desecrated H	20	96	-1					0	Andarielq Item (H) Desecrated H	1																									0
+Andarielq (H) Desecrated A	20	74	-2					0	Andarielq Item (H) Desecrated A	1																									0
+Andarielq (H) Desecrated B	20	78	-2					0	Andarielq Item (H) Desecrated B	1																									0
+Andarielq (H) Desecrated C	20	81	-2					0	Andarielq Item (H) Desecrated C	1																									0
+Andarielq (H) Desecrated D	20	84	-2					0	Andarielq Item (H) Desecrated D	1																									0
+Andarielq (H) Desecrated E	20	87	-2					0	Andarielq Item (H) Desecrated E	1																									0
+Andarielq (H) Desecrated F	20	90	-2					0	Andarielq Item (H) Desecrated F	1																									0
+Andarielq (H) Desecrated G	20	93	-2					0	Andarielq Item (H) Desecrated G	1																									0
+Andarielq (H) Desecrated H	20	96	-2					0	Andarielq Item (H) Desecrated H	1																									0
 Andarielq (H)			7	995	995	1024	1024	5	Act 2 (H) Equip A	19	Act 2 (H) Good	3	oos	1																					0
 Andarielq Item (H) Desecrated A			7	995	995	1024	1024	19	Act 3 (H) Equip B	19	Act 3 (H) Good	3	oos	1	ka3	3																			0
 Andarielq Item (H) Desecrated B			7	995	995	1024	1024	19	Act 3 (H) Equip C	19	Act 3 (H) Good	3	oos	1	ka3	3																			0
@@ -706,15 +706,15 @@ Andarielq Item (H) Desecrated E			7	995	995	1024	1024	19	Act 4 (H) Equip C	19	Ac
 Andarielq Item (H) Desecrated F			7	995	995	1024	1024	19	Act 5 (H) Equip A	19	Act 5 (H) Good	3	oos	1	ka3	3																			0
 Andarielq Item (H) Desecrated G			7	995	995	1024	1024	19	Act 5 (H) Equip B	19	Act 5 (H) Good	3	oos	1	ka3	3																			0
 Andarielq Item (H) Desecrated H			7	995	995	1024	1024	19	Act 5 (H) Equip C	19	Act 5 (H) Good	3	oos	1	ka3	3																			0
-Radament			5	900	900	900	1024	5	Gold x2	5	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
+Radament			5	900	900	900	1024	5	Gold 2x	5	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
 Radament Desecrated A	21	19	5	900	900	900	1024	19	gld,mul=1280	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3	ka3	1																	0
 Radament Desecrated B	21	33	5	900	900	900	1024	19	gld,mul=1280	11	Act 4 Equip B	19	Act 4 Junk	15	Act 4 Good	3	ka3	1																	0
 Radament Desecrated C	21	48	5	900	900	900	1024	19	gld,mul=1280	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3	ka3	1																	0
-Radament (N)			5	900	900	900	1024	5	Gold x2.5	5	Act 3 (N) Equip B	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
+Radament (N)			5	900	900	900	1024	5	Gold 2.5x	5	Act 3 (N) Equip B	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
 Radament (N) Desecrated A	21	52	5	900	900	900	1024	19	gld,mul=1536	11	Act 3 (N) Equip C	19	Act 3 (N) Junk	15	Act 3 (N) Good	3	ka3	2																	0
 Radament (N) Desecrated B	21	62	5	900	900	900	1024	19	gld,mul=1536	11	Act 5 (N) Equip A	19	Act 5 (N) Junk	15	Act 5 (N) Good	3	ka3	2																	0
 Radament (N) Desecrated C	21	73	5	900	900	900	1024	19	gld,mul=1536	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3	ka3	1																	0
-Radament (H)			5	900	900	900	1024	5	Gold x3	5	Act 3 (H) Equip C	19	Act 3 (H) Junk	10	Act 3 (H) Good	3																			0
+Radament (H)			5	900	900	900	1024	5	Gold 3x	5	Act 3 (H) Equip C	19	Act 3 (H) Junk	10	Act 3 (H) Good	3																			0
 Radament Item (H) Desecrated A			5	900	900	900	1024	19	gld,mul=2048	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	ka3	3																	0
 Radament Item (H) Desecrated B			5	900	900	900	1024	19	gld,mul=2048	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3	ka3	3																	0
 Radament Item (H) Desecrated C			5	900	900	900	1024	19	gld,mul=2048	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3	ka3	3																	0
@@ -726,15 +726,15 @@ Radament (H) Desecrated D	21	96	-2					0	Sunder Charms	1	Radament Item (H) Desec
 Flying Scimitar			1					60	Act 2 Good	3	scm	57																							0
 Flying Scimitar (N)			1					60	Act 2 (N) Good	3	scm	25	9sm	32																					0
 Flying Scimitar (H)			1					60	Act 2 (H) Good	3	scm	7	9sm	18	7sm	32																			0
-Mephisto			7	983	983	983	1024	5	Gold x2	2	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3																			0
+Mephisto			7	983	983	983	1024	5	Gold 2x	2	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3																			0
 Mephisto Desecrated A	22	26	7	983	983	983	1024	15	gld,mul=1280	5	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3	ka3	3																	0
 Mephisto Desecrated B	22	38	7	983	983	983	1024	15	gld,mul=1280	5	Act 5 Equip C	52	Act 5 Junk	5	Act 5 Good	3	ka3	3																	0
 Mephisto Desecrated C	22	48	7	983	983	983	1024	15	gld,mul=1280	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	3																	0
-Mephisto (N)			7	983	983	983	1024	5	Gold x2.5	2	Act 4 (N) Equip A	52	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
+Mephisto (N)			7	983	983	983	1024	5	Gold 2.5x	2	Act 4 (N) Equip A	52	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
 Mephisto (N) Desecrated A	22	59	7	983	983	983	1024	15	gld,mul=1536	5	Act 4 (N) Equip B	52	Act 4 (N) Junk	5	Act 4 (N) Good	3	ka3	3																	0
 Mephisto (N) Desecrated B	22	66	7	983	983	983	1024	15	gld,mul=1536	5	Act 5 (N) Equip C	52	Act 5 (N) Junk	5	Act 5 (N) Good	3	ka3	3																	0
 Mephisto (N) Desecrated C	22	73	7	983	983	983	1024	15	gld,mul=1536	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	3																	0
-Mephisto (H)			7	983	983	983	1024	5	Gold x3	2	Act 4 (H) Equip A	52	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
+Mephisto (H)			7	983	983	983	1024	5	Gold 2.5x	2	Act 4 (H) Equip A	52	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
 Mephisto Item (H) Desecrated A			7	983	983	983	1024	15	gld,mul=2048	5	Act 4 (H) Equip B	52	Act 4 (H) Junk	5	Act 4 (H) Good	3	oos	1	ka3	3															0
 Mephisto Item (H) Desecrated B			7	983	983	983	1024	15	gld,mul=2048	5	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1	ka3	3															0
 Mephisto Item (H) Desecrated C			7	983	983	983	1024	15	gld,mul=2048	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1	ka3	3															0
@@ -746,14 +746,14 @@ Mephisto (H) Desecrated D	22	96	-2					0	Sunder Charms	1	Mephisto Item (H) Desec
 Mephistoq			7	993	993	1024	1024	5	Act 4 Equip A	52	Act 4 Good	3																							0
 Mephistoq (N)			7	993	993	1024	1024	5	Act 4 (N) Equip A	52	Act 4 (N) Good	3																							0
 Mephistoq (H)			7	993	993	1024	1024	5	Act 4 (H) Equip A	52	Act 4 (H) Good	3	oos	1																					0
-Diablo			7	983	983	983	1024	5	Gold x2	2	Act 5 Equip A	52	Act 5 Junk	5	Act 5 Good	3																			0
+Diablo			7	983	983	983	1024	5	Gold 2x	2	Act 5 Equip A	52	Act 5 Junk	5	Act 5 Good	3																			0
 Diablo Desecrated A	23	40	7	983	983	983	1024	15	gld,mul=1280	5	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3	ka3	3																	0
 Diablo Desecrated B	23	48	7	983	983	983	1024	15	gld,mul=1280	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	3																	0
-Diablo (N)			7	983	983	983	1024	5	Gold x2.5	2	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Diablo (N)			7	983	983	983	1024	5	Gold 2.5x	2	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Diablo (N) Desecrated A	23	62	7	983	983	983	1024	15	gld,mul=1536	5	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3	ka3	2																	0
 Diablo (N) Desecrated B	23	67	7	983	983	983	1024	15	gld,mul=1536	5	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3	ka3	2																	0
 Diablo (N) Desecrated C	23	73	7	983	983	983	1024	15	gld,mul=1536	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	3																	0
-Diablo (H)			7	983	983	983	1024	5	Gold x3	2	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1																	0
+Diablo (H)			7	983	983	983	1024	5	Gold 3x	2	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1																	0
 Diablo Item (H) Desecrated A			7	983	983	983	1024	15	gld,mul=2048	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1	ka3	3															0
 Diablo Item (H) Desecrated B			7	983	983	983	1024	15	gld,mul=2048	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1	ka3	3															0
 Diablo (H) Desecrated A	23	94	-2					0	Sunder Charms	1	Diablo Item (H) Desecrated A	1																							0
@@ -761,15 +761,15 @@ Diablo (H) Desecrated B	23	96	-2					0	Sunder Charms	1	Diablo Item (H) Desecrate
 Diabloq			7	993	993	1024	1024	5	Act 5 Equip A	52	Act 5 Good	3																							0
 Diabloq (N)			7	993	993	1024	1024	5	Act 5 (N) Equip A	52	Act 5 (N) Good	3																							0
 Diabloq (H)			7	993	993	1024	1024	5	Act 5 (H) Equip A	52	Act 5 (H) Good	3	oos	1																					0
-Summoner			5	900	900	972	1024	5	Gold x2	4	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4																	0
+Summoner			5	900	900	972	1024	5	Gold 2x	4	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4																	0
 Summoner Desecrated A	24	18	5	900	900	972	1024	19	gld,mul=1280	9	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4	ka3	1															0
 Summoner Desecrated B	24	32	5	900	900	972	1024	19	gld,mul=1280	9	Act 4 Equip B	15	Act 5 Junk	5	Act 4 Good	3	Act 5 Magic A	4	ka3	1															0
 Summoner Desecrated C	24	48	5	900	900	972	1024	19	gld,mul=1280	9	Act 3 (N) Equip C	15	Act 4 (N) Junk	5	Act 3 (N) Good	3	Act 4 (N) Magic A	4	ka3	1															0
-Summoner (N)			5	900	900	972	1024	5	Gold x2.5	4	Act 2 (N) Equip C	15	Act 3 (N) Junk	5	Act 2 (N) Good	3	Act 3 (N) Magic A	4																	0
+Summoner (N)			5	900	900	972	1024	5	Gold 2.5x	4	Act 2 (N) Equip C	15	Act 3 (N) Junk	5	Act 2 (N) Good	3	Act 3 (N) Magic A	4																	0
 Summoner (N) Desecrated A	24	55	5	900	900	972	1024	19	gld,mul=1536	9	Act 4 (N) Equip A	15	Act 5 (N) Junk	5	Act 4 (N) Good	3	Act 5 (N) Magic A	4	ka3	2															0
 Summoner (N) Desecrated B	24	63	5	900	900	972	1024	19	gld,mul=1536	9	Act 5 (N) Equip A	15	Act 1 (H) Junk	5	Act 5 (N) Good	3	Act 1 (H) Magic A	4	ka3	2															0
 Summoner (N) Desecrated C	24	73	5	900	900	972	1024	19	gld,mul=1536	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4	ka3	2															0
-Summoner (H)			5	900	900	972	1024	5	Gold x3	4	Act 2 (H) Equip C	15	Act 3 (H) Junk	5	Act 2 (H) Good	3	Act 3 (H) Magic A	4	pk2	2															0
+Summoner (H)			5	900	900	972	1024	5	Gold 3x	4	Act 2 (H) Equip C	15	Act 3 (H) Junk	5	Act 2 (H) Good	3	Act 3 (H) Magic A	4	pk2	2															0
 Summoner Item (H) Desecrated A			5	900	900	972	1024	19	gld,mul=2048	9	Act 4 (H) Equip A	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	1	ka3	3													0
 Summoner Item (H) Desecrated B			5	900	900	972	1024	19	gld,mul=2048	9	Act 4 (H) Equip B	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic B	4	pk2	1	ka3	3													0
 Summoner Item (H) Desecrated C			5	900	900	972	1024	19	gld,mul=2048	9	Act 4 (H) Equip C	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	1	ka3	3													0
@@ -782,15 +782,15 @@ Summoner (H) Desecrated C	24	87	-2					0	Sunder Charms	1	Summoner Item (H) Desec
 Summoner (H) Desecrated D	24	90	-2					0	Sunder Charms	1	Summoner Item (H) Desecrated D	1																							0
 Summoner (H) Desecrated E	24	93	-2					0	Sunder Charms	1	Summoner Item (H) Desecrated E	1																							0
 Summoner (H) Desecrated F	24	96	-2					0	Sunder Charms	1	Summoner Item (H) Desecrated F	1																							0
-Council			3	650	800	800	1024	5	Gold x2	4	Act 4 Equip A	15	Act 4 Junk	5	Act 4 Good	3	Act 4 Magic A	4																	0
+Council			3	650	800	800	1024	5	Gold 2x	4	Act 4 Equip A	15	Act 4 Junk	5	Act 4 Good	3	Act 4 Magic A	4																	0
 Council Desecrated A	25	28	3	650	800	800	1024	38	gld,mul=1280	18	Act 4 Equip B	30	Act 4 Junk	10	Act 4 Good	6	Act 4 Magic B	8	ka3	1															0
 Council Desecrated B	25	38	3	650	800	800	1024	38	gld,mul=1280	18	Act 5 Equip C	30	Act 5 Junk	10	Act 5 Good	6	Act 5 Magic C	8	ka3	1															0
 Council Desecrated C	25	48	3	650	800	800	1024	38	gld,mul=1280	18	Act 3 (N) Equip A	30	Act 3 (N) Junk	10	Act 3 (N) Good	6	Act 3 (N) Magic A	8	ka3	1															0
-Council (N)			3	650	800	800	1024	5	Gold x2.5	4	Act 4 (N) Equip A	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic A	4																	0
+Council (N)			3	650	800	800	1024	5	Gold 2.5x	4	Act 4 (N) Equip A	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic A	4																	0
 Council (N) Desecrated A	25	57	3	650	800	800	1024	19	gld,mul=1536	9	Act 4 (N) Equip B	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic B	4	ka3	1															0
 Council (N) Desecrated B	25	66	3	650	800	800	1024	19	gld,mul=1536	9	Act 5 (N) Equip C	15	Act 5 (N) Junk	5	Act 5 (N) Good	3	Act 5 (N) Magic C	4	ka3	1															0
 Council (N) Desecrated C	25	73	3	650	800	800	1024	19	gld,mul=1536	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4	ka3	1															0
-Council (H)			3	650	800	800	1024	5	Gold x3	4	Act 4 (H) Equip A	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic A	4																	0
+Council (H)			3	650	800	800	1024	5	Gold 3x	4	Act 4 (H) Equip A	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic A	4																	0
 Council Item (H) Desecrated A			3	650	800	800	1024	19	gld,mul=2048	9	Act 4 (H) Equip B	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4	ka3	1															0
 Council Item (H) Desecrated B			3	650	800	800	1024	19	gld,mul=2048	9	Act 4 (H) Equip C	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4	ka3	1															0
 Council Item (H) Desecrated C			3	650	800	800	1024	19	gld,mul=2048	9	Act 5 (H) Equip A	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic A	4	ka3	1															0
@@ -820,47 +820,47 @@ Cow (H)			1	3	5	7	9	60	Gold	15	Act 5 (H) Equip B	30	Act 5 (H) Junk	1	Act 5 (H) G
 Trapped Soul			1					60	Gold	9	Act 4 Equip A	8	Act 4 Junk	33																					0
 Trapped Soul (N)			1					60	Gold	9	Act 4 (N) Equip A	8	Act 4 (N) Junk	33																					0
 Trapped Soul (H)			1					60	Gold	9	Act 4 (H) Equip A	8	Act 4 (H) Junk	33																					0
-Haphesto			5	800	800	900	1024	5	Gold x2	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
+Haphesto			5	800	800	900	1024	5	Gold 2x	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
 Haphesto Desecrated A	27	28	5	800	800	900	1024	19	gld,mul=1280	14	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3	ka3	1																	0
 Haphesto Desecrated B	27	38	5	800	800	900	1024	19	gld,mul=1280	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3	ka3	1																	0
 Haphesto Desecrated C	27	48	5	800	800	900	1024	19	gld,mul=1280	14	Act 3 (N) Equip C	19	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	1																	0
-Haphesto (N)			5	800	800	900	1024	5	Gold x2.5	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Haphesto (N)			5	800	800	900	1024	5	Gold 2.5x	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Haphesto (N) Desecrated A	27	60	5	800	800	900	1024	19	gld,mul=1536	14	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3	ka3	2																	0
 Haphesto (N) Desecrated B	27	66	5	800	800	900	1024	19	gld,mul=1536	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3	ka3	2																	0
 Haphesto (N) Desecrated C	27	73	5	800	800	900	1024	19	gld,mul=1536	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	2																	0
-Haphesto (H)			5	800	800	900	1024	5	Gold x3	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Haphesto (H)			5	800	800	900	1024	5	Gold 3x	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Haphesto Item (H) Desecrated A			5	800	800	900	1024	19	gld,mul=2048	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
 Haphesto Item (H) Desecrated B			5	800	800	900	1024	19	gld,mul=2048	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
 Haphesto Item (H) Desecrated C			5	800	800	900	1024	19	gld,mul=2048	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
 Haphesto (H) Desecrated A	27	88	-2					0	Sunder Charms	1	Haphesto Item (H) Desecrated A	1																							0
 Haphesto (H) Desecrated B	27	93	-2					0	Sunder Charms	1	Haphesto Item (H) Desecrated B	1																							0
 Haphesto (H) Desecrated C	27	96	-2					0	Sunder Charms	1	Haphesto Item (H) Desecrated C	1																							0
-Nihlathak			5	900	900	900	1024	5	Gold x2	7	Act 5 Equip B	19	Act 5 Junk	5	Act 5 Good	3																			0
+Nihlathak			5	900	900	900	1024	5	Gold 2x	7	Act 5 Equip B	19	Act 5 Junk	5	Act 5 Good	3																			0
 Nihlathak Desecrated	28	68	5	900	900	900	1024	19	gld,mul=1280	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	1																	0
-Nihlathak (N)			5	900	900	900	1024	5	Gold x2.5	7	Act 5 (N) Equip B	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Nihlathak (N)			5	900	900	900	1024	5	Gold 2.5x	7	Act 5 (N) Equip B	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Nihlathak (N) Desecrated	28	73	5	900	900	900	1024	19	gld,mul=1280	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	2																	0
-Nihlathak (H)			5	900	900	900	1024	5	Gold x3	7	Act 5 (H) Equip B	19	Act 5 (H) Junk	3	Act 5 (H) Good	3	pk3	2																	0
+Nihlathak (H)			5	900	900	900	1024	5	Gold 3x	7	Act 5 (H) Equip B	19	Act 5 (H) Junk	3	Act 5 (H) Good	3	pk3	2																	0
 Nihlathak Item (H) Desecrated			5	900	900	900	1024	19	gld,mul=2048	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	pk3	1	ka3	3															0
 Nihlathak (H) Desecrated	28	95	-2						Sunder Charms	1	Nihlathak Item (H) Desecrated	1																							0
-Baal			7	983	983	983	1024	5	Gold x2	2	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
+Baal			7	983	983	983	1024	5	Gold 2.5x	2	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
 Baal Desecrated	29	60	7	983	983	983	1024	15	gld,mul=1280	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	1																	0
-Baal (N)			7	983	983	983	1024	5	Gold x2.5	2	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
+Baal (N)			7	983	983	983	1024	5	Gold 2.5x	2	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
 Baal (N) Desecrated	29	75	7	983	983	983	1024	15	gld,mul=1536	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	2																	0
-Baal (H)			7	983	983	983	1024	5	Gold x3	2	Act 5 (H) Equip B	52	Act 5 (H) Junk	3	Act 5 (H) Good	3	oos	1																	0
+Baal (H)			7	983	983	983	1024	5	Gold 3x	2	Act 5 (H) Equip B	52	Act 5 (H) Junk	3	Act 5 (H) Good	3	oos	1																	0
 Baal Item (H) Desecrated			7	983	983	983	1024	15	gld,mul=2048	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3	oos	1	ka3	3															0
 Baal (H) Desecrated	29	99	-2					0	Sunder Charms	1	Baal Item (H) Desecrated	1																							0
 Baalq			7	993	993	1024	1024	5	Act 1 (N) Equip A	52	Act 1 (N) Good	3																							0
 Baalq (N)			7	993	993	1024	1024	5	Act 1 (H) Equip A	52	Act 1 (H) Good	3																							0
 Baalq (H)			7	993	993	1024	1024	5	Act 5 (H) Equip B	52	Act 5 (H) Good	3	oos	1																					0
-Blood Raven			5	800	800	972	1024	5	Gold x2	7	Act 1 Equip B	19	Act 1 Junk	5	Act 1 Good	3																			0
+Blood Raven			5	800	800	972	1024	5	Gold 2.5x	7	Act 1 Equip B	19	Act 1 Junk	5	Act 1 Good	3																			0
 Blood Raven Desecrated A	30	10	5	800	800	972	1024	19	gld,mul=1280	14	Act 1 Equip C	19	Act 1 Junk	5	Act 1 Good	3	ka3	1																	0
 Blood Raven Desecrated B	30	29	5	800	800	972	1024	19	gld,mul=1280	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3	ka3	1																	0
 Blood Raven Desecrated C	30	48	5	800	800	972	1024	19	gld,mul=1280	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	1																	0
-Blood Raven (N)			5	800	800	972	1024	5	Gold x2.5	7	Act 1 (N) Equip B	19	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
+Blood Raven (N)			5	800	800	972	1024	5	Gold 2.5x	7	Act 1 (N) Equip B	19	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
 Blood Raven (N) Desecrated A	30	43	5	800	800	972	1024	19	gld,mul=1536	14	Act 1 (N) Equip C	19	Act 1 (N) Junk	5	Act 1 (N) Good	3	ka3	2																	0
 Blood Raven (N) Desecrated B	30	57	5	800	800	972	1024	19	gld,mul=1536	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3	ka3	2																	0
 Blood Raven (N) Desecrated C	30	73	5	800	800	972	1024	19	gld,mul=1536	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	2																	0
-Blood Raven (H)			5	800	800	972	1024	5	Gold x3	7	Act 1 (H) Equip B	19	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
+Blood Raven (H)			5	800	800	972	1024	5	Gold 3x	7	Act 1 (H) Equip B	19	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
 Blood Raven Item (H) Desecrated A			5	800	800	972	1024	19	gld,mul=2048	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3	ka3	3																	0
 Blood Raven Item (H) Desecrated B			5	800	800	972	1024	19	gld,mul=2048	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
 Blood Raven Item (H) Desecrated C			5	800	800	972	1024	19	gld,mul=2048	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
@@ -887,15 +887,15 @@ Smith (H) Desecrated F	31	87	6					20	Act 4 (H) Uitem B	2	Act 4 (H) Melee B	4	ka
 Smith (H) Desecrated G	31	90	6					20	Act 5 (H) Uitem A	2	Act 5 (H) Melee A	4	ka3	3																					0
 Smith (H) Desecrated H	31	93	6					20	Act 5 (H) Uitem B	2	Act 5 (H) Melee B	4	ka3	3																					0
 Smith (H) Desecrated I	31	96	6					20	Act 5 (H) Uitem C	2	Act 5 (H) Melee C	4	ka3	3																					0
-Izual			5	800	800	972	1024	5	Gold x2	7	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
+Izual			5	800	800	972	1024	5	Gold 2x	7	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
 Izual Desecrated A	32	29	5	800	800	972	1024	19	gld,mul=1280	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3	ka3	1																	0
 Izual Desecrated B	32	38	5	800	800	972	1024	19	gld,mul=1280	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3	ka3	1																	0
 Izual Desecrated C	32	48	5	800	800	972	1024	19	gld,mul=1280	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3	ka3	1																	0
-Izual (N)			5	800	800	972	1024	5	Gold x2.5	7	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
+Izual (N)			5	800	800	972	1024	5	Gold 2.5x	7	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
 Izual (N) Desecrated A	32	60	5	800	800	972	1024	19	gld,mul=1536	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3	ka3	2																	0
 Izual (N) Desecrated B	32	66	5	800	800	972	1024	19	gld,mul=1536	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3	ka3	2																	0
 Izual (N) Desecrated C	32	73	5	800	800	972	1024	19	gld,mul=1536	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3	ka3	2																	0
-Izual (H)			5	800	800	972	1024	5	Gold x3	7	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
+Izual (H)			5	800	800	972	1024	5	Gold 3x	7	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
 Izual Item (H) Desecrated A			5	800	800	972	1024	19	gld,mul=2048	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3	ka3	3																	0
 Izual Item (H) Desecrated B			5	800	800	972	1024	19	gld,mul=2048	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
 Izual Item (H) Desecrated C			5	800	800	972	1024	19	gld,mul=2048	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	ka3	3																	0
@@ -1030,15 +1030,15 @@ Duriel (H) Desecrated D	34	96	-2					0	Duriel (H) Desecrated Incoming	1	ka3	1			
 Durielq			5					0	Durielq - Base	2																									0
 Durielq (N)			5					0	Durielq (N) - Base	2																									0
 Durielq (H)			5					0	Durielq (H) - Base	2																									0
-Duriel - Base			7	983	983	983	1024	5	Gold x2	5	Act 3 Equip A	19	Act 3 Junk	15	Act 3 Good	3																			0
+Duriel - Base			7	983	983	983	1024	5	Gold 2x	5	Act 3 Equip A	19	Act 3 Junk	15	Act 3 Good	3																			0
 Duriel - Base Desecrated A			7	983	983	983	1024	19	gld,mul=1280	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3	ka3	1																	0
 Duriel - Base Desecrated B			7	983	983	983	1024	19	gld,mul=1280	11	Act 5 Equip B	19	Act 5 Junk	15	Act 5 Good	3	ka3	1																	0
 Duriel - Base Desecrated C			7	983	983	983	1024	19	gld,mul=1280	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3	ka3	1																	0
-Duriel (N) - Base			7	983	983	983	1024	5	Gold x2.5	5	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
+Duriel (N) - Base			7	983	983	983	1024	5	Gold 2.5x	5	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
 Duriel (N) - Base Desecrated A			7	983	983	983	1024	19	gld,mul=1536	11	Act 4 (N) Equip A	19	Act 4 (N) Junk	15	Act 4 (N) Good	3	ka3	2																	0
 Duriel (N) - Base Desecrated B			7	983	983	983	1024	19	gld,mul=1536	11	Act 5 (N) Equip B	19	Act 5 (N) Junk	15	Act 5 (N) Good	3	ka3	2																	0
 Duriel (N) - Base Desecrated C			7	983	983	983	1024	19	gld,mul=1536	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3	ka3	2																	0
-Duriel (H) - Base			7	983	983	983	1024	5	Gold x3	5	Act 3 (H) Equip A	19	Act 3 (H) Junk	10	Act 3 (H) Good	3	oos	2																	0
+Duriel (H) - Base			7	983	983	983	1024	5	Gold 3x	5	Act 3 (H) Equip A	19	Act 3 (H) Junk	10	Act 3 (H) Good	3	oos	2																	0
 Duriel (H) - Base Desecrated A			7	983	983	983	1024	19	gld,mul=2048	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	oos	2	ka3	3															0
 Duriel (H) - Base Desecrated B			7	983	983	983	1024	19	gld,mul=2048	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3	oos	2	ka3	3															0
 Duriel (H) - Base Desecrated C			7	983	983	983	1024	19	gld,mul=2048	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3	oos	2	ka3	3															0
@@ -1052,15 +1052,15 @@ ROP (H)			1	1024				0	Annihilus	1																									0
 Countess Rune			3					2	Runes 2	30	Runes 3	15	Runes 4	15	Runes 5	15	Runes 6	15																	0
 Countess Rune (N)			3					2	Runes 7	15	Runes 8	15	Runes 9	15	Runes 10	15	Runes 11	15	Runes 12	15															0
 Countess Rune (H)			3					2	Runes 13	15	Runes 14	15	Runes 15	15	Runes 16	10	Runes 17	5																	0
-Countess Item			5					5	Gold x2	7	Act 1 Equip C	19	Act 2 Junk	15	Act 2 Good	3																			0
+Countess Item			5					5	Gold 2x	7	Act 1 Equip C	19	Act 2 Junk	15	Act 2 Good	3																			0
 Countess Item Desecrated A			5					19	gld,mul=1280	11	Act 2 Equip A	19	Act 3 Junk	15	Act 3 Good	3	ka3	1																	0
 Countess Item Desecrated B			5					19	gld,mul=1280	11	Act 5 Equip A	19	Act 1 (N) Junk	15	Act 1 (N) Good	3	ka3	1																	0
 Countess Item Desecrated C			5					19	gld,mul=1280	11	Act 3 (N) Equip A	19	Act 4 (N) Junk	15	Act 4 (N) Good	3	ka3	1																	0
-Countess Item (N)			5					5	Gold x2.5	7	Act 1 (N) Equip C	19	Act 2 (N) Junk	15	Act 2 (N) Good	3																			0
+Countess Item (N)			5					5	Gold 2.5x	7	Act 1 (N) Equip C	19	Act 2 (N) Junk	15	Act 2 (N) Good	3																			0
 Countess Item (N) Desecrated A			5					19	gld,mul=1536	11	Act 2 (N) Equip B	19	Act 3 (N) Junk	15	Act 3 (N) Good	3	ka3	2																	0
 Countess Item (N) Desecrated B			5					19	gld,mul=1536	11	Act 4 (N) Equip B	19	Act 5 (N) Junk	15	Act 5 (N) Good	3	ka3	2																	0
 Countess Item (N) Desecrated C			5					19	gld,mul=1536	11	Act 3 (H) Equip A	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	ka3	2																	0
-Countess Item (H)			5					5	Gold x3	7	Act 1 (H) Equip C	19	Act 2 (H) Junk	15	Act 2 (H) Good	3	pk1	2																	0
+Countess Item (H)			5					5	Gold 3x	7	Act 1 (H) Equip C	19	Act 2 (H) Junk	15	Act 2 (H) Good	3	pk1	2																	0
 Countess Item (H) Desecrated A			5					19	gld,mul=2048	11	Act 4 (H) Equip A	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	1	ka3	3															0
 Countess Item (H) Desecrated B			5					19	gld,mul=2048	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	1	ka3	3															0
 Countess Item (H) Desecrated C			5					19	gld,mul=2048	11	Act 4 (H) Equip C	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	1	ka3	3															0


### PR DESCRIPTION
* Reduces the drop chance of conversion orbs by half
* Hopefully fixes terror duriel not dropping anything
* Hopefully fixes terror andy not dropping anything
* Several mobs had incorrect gold droptables. These have been resolved. Things not dropping gold before should now