### PR TITLE
Unique changes

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1,1380 +1,1380 @@
 index	*ID	version	enabled	firstLadderSeason	lastLadderSeason	rarity	nolimit	lvl	lvl req	code	*ItemName	carry1	cost mult	cost add	chrtransform	invtransform	flippyfile	invfile	dropsound	dropsfxframe	usesound	prop1	par1	min1	max1	prop2	par2	min2	max2	prop3	par3	min3	max3	prop4	par4	min4	max4	prop5	par5	min5	max5	prop6	par6	min6	max6	prop7	par7	min7	max7	prop8	par8	min8	max8	prop9	par9	min9	max9	prop10	par10	min10	max10	prop11	par11	min11	max11	prop12	par12	min12	max12	diablocloneweight	*eol
-The Gnasher	0	0	1			1		7	5	hax	Hand Axe		5	5000	dyel			invhaxu				str		8	8	openwounds		50	50	crush		20	20	dmg%		60	70																																		0
-Deathspade	1	0	1			1		12	9	axe	Axe		5	5000	dgld			invaxeu				stupidity		1	1	dmg-min		8	8	att%		15	15	mana-kill		4	4	dmg%		60	70																														0
-Bladebone	2	0	1			1		20	15	2ax	Double Axe		5	5000	lgry	lgry						dmg-undead		100	100	att-undead		40	40	swing2		20	20	ac		20	20	fire-min		8	8	fire-max		12	12	dmg%		30	50																						0
-Mindrend	3	0	1			1		28	21	mpi	Military Pick		5	5000	lgrn			invmpiu				stupidity		2	2	regen-mana		20	20	ltng-min		1	1	ltng-max		12	15	att		50	100	dmg%		60	100	openwounds		15	15																						0
-Rakescar	4	0	1			1		36	27	wax	War Axe		5	5000	dgry	dgry						pois-min		128	128	pois-max		128	128	pois-len		75	75	att		50	50	res-pois		50	50	dmg%		75	150	swing2		30	30																						0
-Fechmars Axe	5	0	1			1		11	8	lax	Large Axe		5	5000	lpur	lpur						dmg%		70	90	freeze		3	3	res-cold		50	50	light		2	2																																		0
-Goreshovel	6	0	1			1		19	14	bax	Broad Axe		5	5000	dpur	dpur						swing3		30	30	str		25	25	openwounds		60	60	dmg%		40	50	dmg-max		9	9																														0
-The Chieftan	7	0	1			1		26	19	btx	Battle Axe		5	5000	oran			invbtxu				dmg%		100	100	res-all		10	20	mana-kill		6	6	swing2		20	20	dmg-ltng		1	40																														0
-Brainhew	8	0	1			1		34	25	gax	Great Axe		5	5000	whit			invgaxu				dmg-min		14	14	mana		25	25	light		4	4	manasteal		10	13	dmg%		50	80	dmg-fire		15	35																										0
-The Humongous	9	0	1			1		39	29	gix	Giant Axe		5	5000	blac	blac						str		20	30	dmg-min		8	8	dmg-max		15	25	crush		33	33	ease		20	20	dmg%		80	120																										0
-Iros Torch	10	0	1			1		7	5	wnd	Wand		5	5000	cred			invwndu				nec		1	1	lifesteal		6	6	dmg-fire		5	9	light		3	3	enr		10	10	regen-mana		5	5																										0
-Maelstromwrath	11	0	1			1		19	14	ywn	Yew Wand		5	5000	dblu	dblu						ltng-min		1	1	ltng-max		9	9	res-ltng		40	40	mana		13	13	cast2		30	30	skill	74	1	3	skill	77	1	3	skill	66	1	3	skill	76	1	3														0
-Gravenspine	12	0	1			1		27	20	bwn	Bone Wand		5	5000	cgrn			invbwnu				str		10	10	dex		10	10	cold-min		4	4	cold-max		8	8	cold-len		75	75	manasteal		5	5	nec		2	2	mana		25	50																		0
-Umes Lament	13	0	1			1		38	28	gwn	Grim Wand		5	5000	lblu	lblu						nec		2	2	mana		40	40	cast2		20	20	howl		64	64	skill	77	3	3	skill	87	2	2																										0
-Felloak	14	0	1			1		4	3	clb	Club		5	5000	lgry			invclbu				res-ltng		60	60	res-fire		20	20	knock		1	1	fire-min		6	6	fire-max		8	8	dmg%		70	80																										0
-Knell Striker	15	0	1			1		7	5	scp	Scepter		5	5000	dred	dred						crush		25	25	res-fire		20	20	res-pois		20	20	mana		15	15	att		35	35	dmg%		70	80																										0
-Rusthandle	16	0	1			1		23	17	gsc	Grand Scepter		5	5000	lgld	lgld						pal		1	1	dmg-norm		3	7	red-mag		1	1	lifesteal		8	8	dmg%		50	60	dmg-undead		50	60	skill	111	1	3	skill	103	3	3																		0
-Stormeye	17	0	1			1		31	23	wsp	War Scepter		5	5000	cred	cred						dmg-ltng		1	6	dmg-cold	75	3	5	regen		10	10	dmg%		80	120	skill	110	3	5	skill	118	3	3	skill	121	1	1																						0
-Stoutnail	18	0	1			1		7	5	spc	Spiked Club		5	5000	dgry			invspcu				thorns		3	10	dmg%		100	100	vit		7	7	red-mag		2	2																																		0
-Crushflange	19	0	1			1		12	9	mac	Mace		5	5000	blac	blac						str		15	15	knock		1	1	light		2	2	res-fire		50	50	dmg%		50	60	crush		33	33																										0
-Bloodrise	20	0	1			1		20	15	mst	Morning Star		5	5000	lblu			invmstu				dmg%		120	120	att%		50	50	openwounds		25	25	light		2	2	swing1		10	10	skill	96	3	3	lifesteal		5	5																						0
-The Generals Tan Do Li Ga	21	0	1			1		28	21	fla	Flail		5	5000	dblu	dblu						dmg-min		1	1	dmg-max		20	20	slow		50	50	ac		25	25	manasteal		5	5	dmg%		50	60	swing2		20	20																						0
-Ironstone	22	0	1			1		36	27	whm	War Hammer		5	5000	cblu	cblu						att		100	150	dmg%		100	150	ltng-min		1	1	ltng-max		10	10	str		10	10	*enr		-5	-5																										0
-Bonesob	23	0	1			1		32	24	mau	Maul		5	5000	lred			invmauu				dmg%		200	300	crush		40	40	res-fire		30	30	res-cold		30	30	dmg-undead		50	50																														0
-Steeldriver	24	0	1			1		39	29	gma	Great Maul		5	5000	cgrn	cgrn		invgma				ease		-50	-50	swing3		40	40	regen-stam		25	25	dmg%		150	250																																		0
-Rixots Keen	25	0	1			1		3	2	ssd	Short Sword		5	5000	blac	blac						dmg-min		5	5	att%		20	20	light		2	2	crush		25	25	ac		25	25	dmg%		100	100																										0
-Blood Crescent	26	0	1			1		10	7	scm	Scimitar		5	5000	lblu			invscmu				res-all		15	15	dmg%		60	80	hp		15	15	light		4	4	openwounds		33	33	swing2		15	15	lifesteal		15	15																						0
-Krintizs Skewer	27	0	1			1		14	10	sbr	Saber		5	5000	cblu			inv9sbu				ignore-ac		1	1	str		10	10	dex		10	10	manasteal		7	7	dmg%		50	50	dmg-norm		3	7																										0
-Gleamscythe	28	0	1			1		18	13	flc	Falchion		5	5000	lred			invflcu				light		3	3	mana		30	30	ac		20	20	swing2		20	20	dmg%		60	100	dmg-cold	50	3	5																										0
-Azurewrath	29	0	0			1		18	13	crs	Crystal Sword		5	5000	lgry			invcrsu				deadly		50	50	mag%		10	10	dmg-cold	100	3	6	dmg%		100	100	dur		25	25	dmg-mag		5	10																										0
-Griswolds Edge	30	0	1			1		23	17	bsd	Broad Sword		5	5000	cred			invbsdu				fire-min		10	12	fire-max		15	25	att		100	100	swing1		10	10	knock		1	1	dmg%		80	120	str		12	12																						0
-Hellplague	31	0	1			1		30	22	lsd	Long Sword		5	5000	dred			invlsdu				manasteal		5	5	lifesteal		5	5	pois-min		48	48	pois-max		96	96	pois-len		150	150	dmg%		70	80	dmg-fire		25	75	fireskill		2	2																		0
-Culwens Point	32	0	1			1		39	29	wsd	War Sword		5	5000	whit	whit						allskills		1	1	res-pois-len		50	50	balance2		20	20	swing2		20	20	att		60	60	dmg%		70	80																										0
-Shadowfang	33	0	1			1		16	12	2hs	2-Handed Sword		5	5000	cgrn			inv2hsu				manasteal		9	9	res-cold		20	20	light		-2	-2	dmg-cold	150	10	30	dmg%		100	100	lifesteal		9	9																										0
-Soulflay	34	0	1			1		26	19	clm	Claymore		5	5000	dgrn	dgrn						manasteal		4	10	lifesteal		4	4	dmg%		70	100	res-all		5	5	swing2		10	10																														0
-Kinemils Awl	35	0	1			1		31	23	gis	Giant Sword		5	5000	dblu			invgisu				att		100	150	mana		20	20	fire-min		6	6	fire-max		20	40	dmg%		80	100	skill	102	6	6																										0
-Blacktongue	36	0	1			1		35	26	bsw	Bastard Sword		5	5000	lgrn			invbswu				dmg-pois	150	192	192	noheal		1	1	att		50	50	res-pois		50	50	dmg%		50	60	*hp		-10	-10																										0
-Ripsaw	37	0	1			1		35	26	flb	Flamberge		5	5000	cblu	cblu						openwounds		80	80	dmg-max		15	15	manasteal		6	6	dmg%		80	100																																		0
-The Patriarch	38	0	1			1		39	29	gsd	Great Sword		5	5000	cred			invgsdu				red-dmg		3	3	red-mag		3	3	stupidity		1	1	gold%		100	100	dmg%		100	120	str		10	10																										0
-Gull	39	0	1			1		6	4	dgr	Dagger		5	5000	lgry	lgry						dmg-min		1	1	dmg-max		15	15	mag%		100	100	mana		-5	-5							0	0																										0
-The Diggler	40	0	1			1		15	11	dir	Dirk		5	5000	dgry	dgry						dex		10	10	dmg%		50	50	swing3		30	30	res-cold		25	25	res-fire		25	25	ignore-ac		1	1																										0
-The Jade Tan Do	41	0	1			1		26	19	kri	Kris		5	5000	oran			invkrsu				att		100	150	nofreeze		1	1	dmg-pois	100	460	460	res-pois		95	95	res-pois-max		20	20																														0
-Irices Shard	42	0	1			1		34	25	bld	Blade		5	5000	dblu	dblu						cast3		50	50	mana		50	50	att		55	55	res-all		10	10																																		0
-The Dragon Chang	43	0	1			1		11	8	spr	Spear		5	5000	dpur	dpur						att		35	35	dmg-min		10	10	light		2	2	dmg-undead		100	100	dmg-fire		3	6																														0
-Razortine	44	0	1			1		16	12	tri	Trident		5	5000	oran			invtriu				slow		25	25	reduce-ac		50	50	str		15	15	dex		8	8	swing2		30	30	dmg%		30	50																										0
-Bloodthief	45	0	1			1		23	17	brn	Brandistock		5	5000	whit	whit						openwounds		35	35	str		10	10	lifesteal		8	12	hp		26	26	dmg%		50	70																														0
-Lance of Yaggai	46	0	1			1		30	22	spt	Spetum		5	5000	lred	lred						thorns		8	8	ltng-min		1	1	ltng-max		60	60	res-all		15	15	swing2		40	40																														0
-The Tannr Gorerod	47	0	1			1		36	27	pik	Pike		5	5000	lgry	lgry						fire-min		23	23	fire-max		54	54	res-fire-max		15	15	hp		30	30	att		60	60	light		3	3	res-fire		15	15	dmg%		80	100																		0
-Dimoaks Hew	48	0	1			1		11	8	bar	Bardiche		5	5000	blac	blac						dex		15	15	dmg%		100	100	swing2		20	20	ac		-8	-8																																		0
-Steelgoad	49	0	1			1		19	14	vou	Voulge		5	5000	cgrn	cgrn						howl		96	96	deadly		30	30	att		30	30	res-all		5	5	dmg%		60	80	dur		20	40																										0
-Soul Harvest	50	0	1			1		26	19	scy	Scythe		5	5000	dgry			invscyu				openwounds		30	30	att		45	45	res-all		20	20	dmg%		50	90	manasteal		10	10	enr		5	5																										0
-The Battlebranch	51	0	1			1		34	25	pax	Poleaxe		5	5000	lblu	lblu						swing3		30	30	dex		10	10	dmg%		50	70	att		50	100	lifesteal		7	7																														0
-Woestave	52	0	1			1		38	28	hal	Halberd		5	5000	dblu	dblu						slow		50	50	openwounds		50	50	stupidity		3	3	dmg-ac		-50	-50	freeze		1	1	light		-3	-3	noheal		1	1	dmg%		20	40																		0
-The Grim Reaper	53	0	1			1		39	29	wsc	War Scythe		5	5000	lpur	lpur						deadly		100	100	noheal		1	1	manasteal		5	5	dmg%		20	20	dmg-min		15	15	*hp		-20	-20																										0
-Bane Ash	54	0	1			1		7	5	sst	Short Staff		5	5000	lgrn	lgrn						fire-min		4	4	fire-max		6	6	res-fire		50	50	mana		30	30	swing2		20	20	dmg%		50	60	skill	36	5	5	skill	37	2	2																		0
-Serpent Lord	55	0	1			1		12	9	lst	Long Staff		5	5000	cgrn	cgrn						dmg-pois	75	40	40	res-pois		50	50	light		-1	-1	mana		10	10	dmg%		30	40	manasteal		100	100	reduce-ac		50	50																						0
-Lazarus Spire	56	0	1			1		24	18	cst	Gnarled Staff		5	5000	lgry			invcstu				res-ltng		75	75	red-dmg		5	5	enr		15	15	skill	53	1	1	skill	49	2	2	skill	42	3	3	regen-mana		43	43	dmg-ltng		1	28	sor		1	1														0
-The Salamander	57	0	1			1		28	21	bst	Battle Staff		5	5000	dred	dred						dmg-fire		15	32	res-fire		30	30	skill	51	1	1	skill	47	2	2	skill	37	3	3	fireskill		2	2																										0
-The Iron Jang Bong	58	0	1			1		38	28	wst	War Staff		5	5000	dyel	dyel						ac		30	30	cast3		20	20	dmg%		100	100	att%		50	50	skill	48	2	2	skill	46	2	2	skill	44	3	3	sor		2	2																		0
-Pluckeye	59	0	1			1		10	7	sbw	Short Bow		5	5000	cblu	cblu						att		28	28	dmg%		100	100	hp		10	10	light		2	2	manasteal		3	3	mana-kill		2	2																										0
-Witherstring	60	0	1			1		18	13	hbw	Hunter\92s Bow		5	5000	lred	lred						swing3		30	30	dmg-min		1	1	dmg-max		3	3	att		50	50	magicarrow		3	3	dmg%		40	50																										0
-Rimeraven	61	0	1			1		20	15	lbw	Long Bow		5	5000	dred	dred						att%		50	50	dex		3	3	explosivearrow		3	3	str		3	3	dmg%		60	70																														0
-Piercerib	62	0	1			1		27	20	cbw	Composite Bow		5	5000	cred			invcbwu				res-all		10	10	deadly		30	30	att		60	60	dmg-undead		100	100	dmg%		40	60	swing2		50	50																										0
-Pullspite	63	0	1			1		34	25	sbb	Short Battle Bow		5	5000	lgrn			invsbbu				dmg-ltng		1	30	str		8	8	att		28	28	pierce		25	25	res-ltng		25	25	dmg%		70	90																										0
-Wizendraw	64	0	1			1		35	26	lbb	Long Battle Bow		5	5000	dgrn	dgrn						magicarrow		5	5	mana		30	30	swing2		20	20	res-cold		26	26	att		50	100	dmg%		70	80	enr		15	15	pierce-cold		20	35																		0
-Hellclap	65	0	1			1		36	27	swb	Short War Bow		5	5000	cgrn			invswbu				swing1		10	10	fire-min		15	15	fire-max		30	50	att		50	75	res-fire		40	40	dex		12	12	dmg%		70	90	fireskill		1	1																		0
-Blastbark	66	0	1			1		38	28	lwb	Long War Bow		5	5000	lyel	lyel						dmg%		70	130	str		5	5	ama		1	1	manasteal		3	3	skill	16	2	2																														0
-Leadcrow	67	0	1			1		12	9	lxb	Light Crossbow		5	5000	dyel			invlxbu				dex		10	10	hp		10	10	dmg%		70	70	res-pois		30	30	deadly		25	25	att		40	40																										0
-Ichorsting	68	0	1			1		24	18	mxb	Crossbow		5	5000	lgld			invmxbu				dmg-pois	75	102	102	dex		20	20	pierce		50	50	att		50	50	dmg%		50	50	swing2		20	20																										0
-Hellcast	69	0	1			1		36	27	hxb	Heavy Crossbow		5	5000	dgld			invhxbu				explosivearrow		5	5	res-fire-max		15	15	res-fire		15	15	att		70	70	swing2		20	20	dmg%		70	80	dmg-fire		15	35																						0
-Doomspittle	70	0	1			1		38	28	rxb	Repeating Crossbow		5	5000	lpur			invrxbu				ama		1	1	pierce		35	35	swing3		30	30	hp		15	15	dmg%		60	100																														0
-War Bonnet	71	0	1			1		4	3	cap	Cap		5	5000	dpur			invcapu				hp		15	15	att		30	30	dmg%		30	30	mana		15	15	ac		14	14																														0
-Tarnhelm	72	0	1			1		20	15	skp	Skull Cap		5	5000	oran	oran						gold%		75	75	mag%		25	50	allskills		1	1																																						0
-Coif of Glory	73	0	1			1		19	14	hlm	Helm		5	5000	whit			invhlmu				light-thorns		7	7	stupidity		1	1	res-ltng		15	15	ac-miss		100	100	ac		10	10																														0
-Duskdeep	74	0	1			1		23	17	fhl	Full Helm		5	5000	lgry			invfhlu				light		-2	-2	res-all		15	15	red-dmg		7	7	dmg-max		8	8	ac		10	20	ac%		30	50																										0
-Wormskull	75	0	1			1		28	21	bhm	Bone Helm		5	5000	lgrn			invbhmu				nec		1	1	lifesteal		5	5	mana		10	10	res-pois		25	25	dmg-pois	200	102	102																														0
-Howltusk	76	0	1			1		34	25	ghm	Great Helm		5	5000	dgry	dgry						red-mag		2	2	thorns		3	3	ac%		80	80	dmg-to-mana		35	35	knock		1	1	howl		33	33																										0
-Undead Crown	77	0	1			1		39	29	crn	Crown		5	5000	blac	blac						lifesteal		5	5	ac		40	40	res-pois		50	50	half-freeze		1	1	ac%		30	60	dmg-undead		50	50	att-undead		50	100	skill	69	3	3																		0
-The Face of Horror	78	0	1			1		27	20	msk	Mask		5	5000	lblu	lblu						howl		64	64	str		20	20	res-all		10	10	dmg-undead		50	50	ac		25	25																														0
-Greyform	79	0	1			1		10	7	qui	Quilted Armor		5	5000	lgry	lgry						red-mag		3	3	res-cold		20	20	res-fire		20	20	dex		10	10	lifesteal		5	5	ac		20	20																										0
-Blinkbats Form	80	0	1			1		16	12	lea	Leather Armor		5	5000	dred	dred						ac-miss		50	50	move2		10	10	ac		25	25	fire-min		3	3	fire-max		6	6	balance2		40	40																										0
-The Centurion	81	0	1			1		19	14	hla	Hard Leather		5	5000	cred	cred						ac		30	30	att		50	50	red-dmg		2	2	hp		15	15	mana		15	15					regen		5	5	stamdrain		25	25																		0
-Twitchthroe	82	0	1			1		22	16	stu	Studded Leather		5	5000	lgrn	lgrn						swing2		20	20	dex		10	10	block		25	25	ac		25	25	str		10	10	balance2		20	20																										0
-Darkglow	83	0	1			1		19	14	rng	Ring Mail		5	5000	dgrn	dgrn						att		20	20	res-all-max		5	5	light		3	3	ac-hth		50	50	res-all		10	10	ac%		70	100																										0
-Hawkmail	84	0	1			1		20	15	scl	Scale Mail		5	5000	cgrn	cgrn						ac%		80	100	res-cold-max		15	15	res-cold		15	15	nofreeze		1	1	move2		10	10																														0
-Sparking Mail	85	0	1			1		23	17	chn	Chain Mail		5	5000	lyel	lyel						ac%		75	85	dmg-ltng		1	20	light-thorns		10	14	res-ltng		30	30																																		0
-Venomsward	86	0	1			1		27	20	brs	Breast Plate		5	5000	dyel	dyel						res-pois-max		15	15	res-pois-len		50	50	res-pois		90	90	light		2	2	ac%		60	100																														0
-Iceblink	87	0	1			1		30	22	spl	Splint Mail		5	5000	lgld	lgld						freeze		1	1	res-cold		30	30	light		4	4	red-mag		1	1	ac%		70	80																														0
-Boneflesh	88	0	1			1		35	26	plt	Plate Mail		5	5000	dgld	dgld						lifesteal		5	5	ac%		100	120	att		35	35	openwounds		25	25																																		0
-Rockfleece	89	0	1			1		38	28	fld	Field Plate		5	5000	dgry	dgry						ease		-10	-10	ac%		100	130	red-dmg%		10	10	red-dmg		5	5	str		5	5																														0
-Rattlecage	90	0	1			1		39	29	gth	Gothic Plate		5	5000	dpur	dpur						howl		52	52	att		45	45	crush		25	25	ac		200	200																																		0
-Goldskin	91	0	1			1		38	28	ful	Full Plate Mail		5	5000	oran			invfulu				ac%		120	150	res-all		35	35	thorns		10	10	light		2	2	gold%		100	100																														0
-Victors Silk	92	0	1			1		38	28	aar	AncientArmor		5	5000	dblu			invaaru				manasteal		5	5	allskills		1	1	light		2	2	ac%		100	120																																		0
-Heavenly Garb	93	0	1			1		39	29	ltp	Light Plate		5	5000	cblu	cblu						ac%		100	100	res-all		10	10	regen-mana		25	25	enr		15	15	dmg-undead		50	50	att-undead		100	100																										0
-Pelta Lunata	94	0	1			1		3	2	buc	Buckler		5	5000	whit			invbucu				ac		30	30	vit		10	10	str		2	2	enr		10	10	ac%		30	40	block		20	20	block2		40	40	dur		8	12																		0
-Umbral Disk	95	0	1			1		12	9	sml	Small Shield		5	5000	lgry			invsmlu				stupidity		1	1	dex		10	10	ac		30	30	hp		20	20	light		-2	-2	ac%		40	50	block		30	30	dur		10	15																		0
-Stormguild	96	0	1			1		18	13	lrg	Large Shield		5	5000	dgry			invlrgu				red-mag		1	1	res-ltng		25	25	ac		30	30	dmg-ltng		1	6	ac%		50	60	block		30	30	light-thorns		3	3	dur		10	15																		0
-Wall of the Eyeless	97	0	1			1		27	20	bsh	Bone Shield		5	5000	lgld			invbshu				mana-kill		5	5	manasteal		3	3	cast2		20	20	res-pois		20	20	ac%		30	40	ac		10	10																										0
-Swordback Hold	98	0	1			1		20	15	spk	Spiked Shield		5	5000	lred			invspku				thorns		5	5	block		20	20	openwounds		50	50	bloody		3	5	ac%		30	60	thorns		5	5	ac		10	10																						0
-Steelclash	99	0	1			1		23	17	kit	Kite Shield		5	5000	blac			invkitu				block		25	25	pal		1	1	red-dmg		3	3	light		3	3	ac%		60	100	block2		20	20	res-all		15	15	ac		20	20	dur		15	20														0
-Bverrit Keep	100	0	1			1		26	19	tow	Tower Shield		5	5000	lblu			invtowu				ac		30	30	res-fire		75	75	str		5	5	red-mag		5	5	ac%		80	120	block		10	10	dur		80	100																						0
-The Ward	101	0	1			1		35	26	gts	Gothic Shield		5	5000	dblu			invgtsu				ac		40	40	red-mag		2	2	str		10	10	block		10	10	ac%		100	100	res-all		30	50																										0
-The Hand of Broc	102	0	1			1		7	5	lgl	Gloves		5	5000	cblu	cblu						manasteal		3	3	lifesteal		3	3	res-pois		10	10	mana		20	20	ac		10	10	ac%		10	20																										0
-Bloodfist	103	0	1			1		12	9	vgl	Heavy Gloves		5	5000	oran	oran						dmg-min		5	5	hp		40	40	balance2		30	30	ac		10	10	ac%		10	20	swing2		10	10																										0
-Chance Guards	104	0	1			1		20	15	mgl	Bracers		5	5000	lred	lred						gold%		200	200	mag%		25	40	att		25	25	ac		15	15	light		2	2	ac%		20	30																										0
-Magefist	105	0	1			1		31	23	tgl	Light Gauntlets		5	5000	lgry	lgry						cast3		20	20	regen-mana		25	25	fireskill		1	1	dmg-fire		1	6	ac		10	10	ac%		20	30																										0
-Frostburn	106	0	1			1		39	29	hgl	Gauntlets		5	5000	dred	dred						ac		30	30	dmg%		5	5	mana%		40	40	dmg-cold	50	1	6	ac%		10	20																														0
-Hotspur	107	0	1			1		7	5	lbt	Leather Boots		5	5000	cred	cred						res-fire-max		15	15	hp		15	15	dmg-fire		3	6	ac		6	6	res-fire		45	45	ac%		10	20																										0
-Gorefoot	108	0	1			1		12	9	vbt	Heavy Boots		5	5000	dblu	dblu						bloody		3	5	move2		20	20	manasteal		2	2	thorns		2	2	ac		12	12	ac%		20	30	skill	132	2	2																						0
-Treads of Cthon	109	0	1			1		20	15	mbt	Chain Boots		5	5000	lgrn	lgrn						move2		30	30	ac-miss		50	50	stamdrain		50	50	hp		10	10	ac		12	12	ac%		30	40																										0
-Goblin Toe	110	0	1			1		30	22	tbt	Light Plate Boots		5	5000	dgry	dgry						crush		25	25	red-dmg		1	1	red-mag		1	1	ac		15	15	light		-1	-1	ac%		50	60																										0
-Tearhaunch	111	0	1			1		39	29	hbt	Plate Boots		5	5000	dgrn	dgrn						ac		35	35	str		5	5	dex		5	5	move2		20	20	res-all		10	10	ac%		60	80	skill	115	2	2																						0
-Lenyms Cord	112	0	1			1		10	7	lbl	Sash		5	5000	cgrn	cgrn						mana		15	15	regen-mana		30	30	res-all		5	5	light		1	1																																		0
-Snakecord	113	0	1			1		16	12	vbl	Light Belt		5	5000	blac	blac						dmg-pois	75	40	40	res-pois		25	25	ac		10	10	ac%		20	30	regen		5	5	res-pois-len		50	50																										0
-Nightsmoke	114	0	1			1		27	20	mbl	Belt		5	5000	lyel	lyel						res-all		10	10	dmg-to-mana		50	50	mana		20	20	red-dmg		2	2	ac		15	15	ac%		30	50																										0
-Goldwrap	115	0	1			1		36	27	tbl	Heavy Belt		5	5000	lblu	lblu						mag%		30	30	light		2	2	ac		25	25	swing2		10	10	ac%		40	60	gold%		50	80																										0
-Bladebuckle	116	0	1			1		39	29	hbl	Girdle		5	5000	dyel	dyel						thorns		8	8	ac		30	30	red-dmg		3	3	str		5	5	dex		10	10	ac%		80	100	balance2		30	30																						0
-Nokozan Relic	117	0	1			20		14	10	amu	Amulet		5	5000	lgld							dmg-fire		3	6	res-fire-max		10	10	res-fire		50	50	light		3	3	balance2		20	20																														0
-The Eye of Etlich	118	0	1			5		20	15	amu	Amulet		5	5000	dgld							ac-miss		10	40	light		1	5	allskills		1	1	lifesteal		3	7	cold-min		1	2	cold-max		3	5	cold-len		50	250																						0
-The Mahim-Oak Curio	119	0	1			10		34	25	amu	Amulet		5	5000	lpur							dex		10	10	str		10	10	enr		10	10	vit		10	10	ac		10	10	att%		10	10	res-all		10	10	ac%		10	10																		0
-Nagelring	120	0	1			15		10	7	rin	Ring		5	5000	dpur							red-mag		3	3	thorns		3	3	att		50	75	mag%		15	30																																		0
-Manald Heal	121	0	1			15		20	15	rin	Ring		5	5000	oran							manasteal		4	7	regen		5	8	hp		20	20	regen-mana		20	20																																		0
-The Stone of Jordan	122	0	1			1		39	29	rin	Ring		5	5000	whit							mana		20	20	mana%		25	25	ltng-min		25	25	allskills		1	1	ltng-max		50	50																													1	0
-Amulet of the Viper	123	0	1			1		0	0	vip	Amulet		5	5000	lgry							mana		10	10	res-pois		25	25	hp		10	10			0	0			0	0			0	0			0	0																						0
-Staff of Kings	124	0	1			1		0	0	msf	Staff		5	5000	dgry							res-all		10	10	swing3		50	50			0	0			0	0			0	0			0	0			0	0																						0
-Horadric Staff	125	0	1			1		0	0	hst	Staff		5	5000	blac							mana		10	10	res-pois		25	25	hp		10	10	res-all		10	10	swing3		50	50			0	0			0	0																						0
-Hell Forge Hammer	126	0	1			1		0	0	hfh	Hammer		5	5000	cred							fire-min		5	5	fire-max		20	20	res-fire		40	40	ac		35	35			0	0			0	0			0	0																						0
-KhalimFlail	127	0	1			1		0	0	qf1	Flail		5	5000	dblu							ltng-min		1	1	ltng-max		20	20	swing3		50	50	att		40	40			0	0			0	0			0	0																						0
-SuperKhalimFlail	128	0	1			1		0	0	qf2	Flail		5	5000	dblu							ltng-min		1	1	ltng-max		40	40	swing3		50	50	att		40	40	manasteal		6	6	lifesteal		6	6			0	0																						0
+The Gnasher	0	0	1			1	1	7	5	hax	Hand Axe		5	5000	dyel			invhaxu				str		8	8	openwounds		50	50	crush		20	20	dmg%		60	70																																		0
+Deathspade	1	0	1			1	1	12	9	axe	Axe		5	5000	dgld			invaxeu				stupidity		1	1	dmg-min		8	8	att%		15	15	mana-kill		4	4	dmg%		60	70																														0
+Bladebone	2	0	1			1	1	20	15	2ax	Double Axe		5	5000	lgry	lgry						dmg-undead		100	100	att-undead		40	40	swing2		20	20	ac		20	20	fire-min		8	8	fire-max		12	12	dmg%		30	50																						0
+Mindrend	3	0	1			1	1	28	21	mpi	Military Pick		5	5000	lgrn			invmpiu				stupidity		2	2	regen-mana		20	20	ltng-min		1	1	ltng-max		12	15	att		50	100	dmg%		60	100	openwounds		15	15																						0
+Rakescar	4	0	1			1	1	36	27	wax	War Axe		5	5000	dgry	dgry						pois-min		128	128	pois-max		128	128	pois-len		75	75	att		50	50	res-pois		50	50	dmg%		75	150	swing2		30	30																						0
+Fechmars Axe	5	0	1			1	1	11	8	lax	Large Axe		5	5000	lpur	lpur						dmg%		70	90	freeze		3	3	res-cold		50	50	light		2	2																																		0
+Goreshovel	6	0	1			1	1	19	14	bax	Broad Axe		5	5000	dpur	dpur						swing3		30	30	str		25	25	openwounds		60	60	dmg%		40	50	dmg-max		9	9																														0
+The Chieftan	7	0	1			1	1	26	19	btx	Battle Axe		5	5000	oran			invbtxu				dmg%		100	100	res-all		10	20	mana-kill		6	6	swing2		20	20	dmg-ltng		1	40																														0
+Brainhew	8	0	1			1	1	34	25	gax	Great Axe		5	5000	whit			invgaxu				dmg-min		14	14	mana		25	25	light		4	4	manasteal		10	13	dmg%		50	80	dmg-fire		15	35																										0
+The Humongous	9	0	1			1	1	39	29	gix	Giant Axe		5	5000	blac	blac						str		20	30	dmg-min		8	8	dmg-max		15	25	crush		33	33	ease		20	20	dmg%		80	120																										0
+Iros Torch	10	0	1			1	1	7	5	wnd	Wand		5	5000	cred			invwndu				nec		1	1	lifesteal		6	6	dmg-fire		5	9	light		3	3	enr		10	10	regen-mana		5	5																										0
+Maelstromwrath	11	0	1			1	1	19	14	ywn	Yew Wand		5	5000	dblu	dblu						ltng-min		1	1	ltng-max		9	9	res-ltng		40	40	mana		13	13	cast2		30	30	skill	74	1	3	skill	77	1	3	skill	66	1	3	skill	76	1	3														0
+Gravenspine	12	0	1			1	1	27	20	bwn	Bone Wand		5	5000	cgrn			invbwnu				str		10	10	dex		10	10	cold-min		4	4	cold-max		8	8	cold-len		75	75	manasteal		5	5	nec		2	2	mana		25	50																		0
+Umes Lament	13	0	1			1	1	38	28	gwn	Grim Wand		5	5000	lblu	lblu						nec		2	2	mana		40	40	cast2		20	20	howl		64	64	skill	77	3	3	skill	87	2	2																										0
+Felloak	14	0	1			1	1	4	3	clb	Club		5	5000	lgry			invclbu				res-ltng		60	60	res-fire		20	20	knock		1	1	fire-min		6	6	fire-max		8	8	dmg%		70	80																										0
+Knell Striker	15	0	1			1	1	7	5	scp	Scepter		5	5000	dred	dred						crush		25	25	res-fire		20	20	res-pois		20	20	mana		15	15	att		35	35	dmg%		70	80																										0
+Rusthandle	16	0	1			1	1	23	17	gsc	Grand Scepter		5	5000	lgld	lgld						pal		1	1	dmg-norm		3	7	red-mag		1	1	lifesteal		8	8	dmg%		50	60	dmg-undead		50	60	skill	111	1	3	skill	103	3	3																		0
+Stormeye	17	0	1			1	1	31	23	wsp	War Scepter		5	5000	cred	cred						dmg-ltng		1	6	dmg-cold	75	3	5	regen		10	10	dmg%		80	120	skill	110	3	5	skill	118	3	3	skill	121	1	1																						0
+Stoutnail	18	0	1			1	1	7	5	spc	Spiked Club		5	5000	dgry			invspcu				thorns		3	10	dmg%		100	100	vit		7	7	red-mag		2	2																																		0
+Crushflange	19	0	1			1	1	12	9	mac	Mace		5	5000	blac	blac						str		15	15	knock		1	1	light		2	2	res-fire		50	50	dmg%		50	60	crush		33	33																										0
+Bloodrise	20	0	1			1	1	20	15	mst	Morning Star		5	5000	lblu			invmstu				dmg%		120	120	att%		50	50	openwounds		25	25	light		2	2	swing1		10	10	skill	96	3	3	lifesteal		5	5																						0
+The Generals Tan Do Li Ga	21	0	1			1	1	28	21	fla	Flail		5	5000	dblu	dblu						dmg-min		1	1	dmg-max		20	20	slow		50	50	ac		25	25	manasteal		5	5	dmg%		50	60	swing2		20	20																						0
+Ironstone	22	0	1			1	1	36	27	whm	War Hammer		5	5000	cblu	cblu						att		100	150	dmg%		100	150	ltng-min		1	1	ltng-max		10	10	str		10	10	*enr		-5	-5																										0
+Bonesob	23	0	1			1	1	32	24	mau	Maul		5	5000	lred			invmauu				dmg%		200	300	crush		40	40	res-fire		30	30	res-cold		30	30	dmg-undead		50	50																														0
+Steeldriver	24	0	1			1	1	39	29	gma	Great Maul		5	5000	cgrn	cgrn		invgma				ease		-50	-50	swing3		40	40	regen-stam		25	25	dmg%		150	250																																		0
+Rixots Keen	25	0	1			1	1	3	2	ssd	Short Sword		5	5000	blac	blac						dmg-min		5	5	att%		20	20	light		2	2	crush		25	25	ac		25	25	dmg%		100	100																										0
+Blood Crescent	26	0	1			1	1	10	7	scm	Scimitar		5	5000	lblu			invscmu				res-all		15	15	dmg%		60	80	hp		15	15	light		4	4	openwounds		33	33	swing2		15	15	lifesteal		15	15																						0
+Krintizs Skewer	27	0	1			1	1	14	10	sbr	Saber		5	5000	cblu			inv9sbu				ignore-ac		1	1	str		10	10	dex		10	10	manasteal		7	7	dmg%		50	50	dmg-norm		3	7																										0
+Gleamscythe	28	0	1			1	1	18	13	flc	Falchion		5	5000	lred			invflcu				light		3	3	mana		30	30	ac		20	20	swing2		20	20	dmg%		60	100	dmg-cold	50	3	5																										0
+Azurewrath	29	0	0			1	1	18	13	crs	Crystal Sword		5	5000	lgry			invcrsu				deadly		50	50	mag%		10	10	dmg-cold	100	3	6	dmg%		100	100	dur		25	25	dmg-mag		5	10																										0
+Griswolds Edge	30	0	1			1	1	23	17	bsd	Broad Sword		5	5000	cred			invbsdu				fire-min		10	12	fire-max		15	25	att		100	100	swing1		10	10	knock		1	1	dmg%		80	120	str		12	12																						0
+Hellplague	31	0	1			1	1	30	22	lsd	Long Sword		5	5000	dred			invlsdu				manasteal		5	5	lifesteal		5	5	pois-min		48	48	pois-max		96	96	pois-len		150	150	dmg%		70	80	dmg-fire		25	75	fireskill		2	2																		0
+Culwens Point	32	0	1			1	1	39	29	wsd	War Sword		5	5000	whit	whit						allskills		1	1	res-pois-len		50	50	balance2		20	20	swing2		20	20	att		60	60	dmg%		70	80																										0
+Shadowfang	33	0	1			1	1	16	12	2hs	2-Handed Sword		5	5000	cgrn			inv2hsu				manasteal		9	9	res-cold		20	20	light		-2	-2	dmg-cold	150	10	30	dmg%		100	100	lifesteal		9	9																										0
+Soulflay	34	0	1			1	1	26	19	clm	Claymore		5	5000	dgrn	dgrn						manasteal		4	10	lifesteal		4	4	dmg%		70	100	res-all		5	5	swing2		10	10																														0
+Kinemils Awl	35	0	1			1	1	31	23	gis	Giant Sword		5	5000	dblu			invgisu				att		100	150	mana		20	20	fire-min		6	6	fire-max		20	40	dmg%		80	100	skill	102	6	6																										0
+Blacktongue	36	0	1			1	1	35	26	bsw	Bastard Sword		5	5000	lgrn			invbswu				dmg-pois	150	192	192	noheal		1	1	att		50	50	res-pois		50	50	dmg%		50	60	*hp		-10	-10																										0
+Ripsaw	37	0	1			1	1	35	26	flb	Flamberge		5	5000	cblu	cblu						openwounds		80	80	dmg-max		15	15	manasteal		6	6	dmg%		80	100																																		0
+The Patriarch	38	0	1			1	1	39	29	gsd	Great Sword		5	5000	cred			invgsdu				red-dmg		3	3	red-mag		3	3	stupidity		1	1	gold%		100	100	dmg%		100	120	str		10	10																										0
+Gull	39	0	1			1	1	6	4	dgr	Dagger		5	5000	lgry	lgry						dmg-min		1	1	dmg-max		15	15	mag%		100	100	mana		-5	-5							0	0																										0
+The Diggler	40	0	1			1	1	15	11	dir	Dirk		5	5000	dgry	dgry						dex		10	10	dmg%		50	50	swing3		30	30	res-cold		25	25	res-fire		25	25	ignore-ac		1	1																										0
+The Jade Tan Do	41	0	1			1	1	26	19	kri	Kris		5	5000	oran			invkrsu				att		100	150	nofreeze		1	1	dmg-pois	100	460	460	res-pois		95	95	res-pois-max		20	20																														0
+Irices Shard	42	0	1			1	1	34	25	bld	Blade		5	5000	dblu	dblu						cast3		50	50	mana		50	50	att		55	55	res-all		10	10																																		0
+The Dragon Chang	43	0	1			1	1	11	8	spr	Spear		5	5000	dpur	dpur						att		35	35	dmg-min		10	10	light		2	2	dmg-undead		100	100	dmg-fire		3	6																														0
+Razortine	44	0	1			1	1	16	12	tri	Trident		5	5000	oran			invtriu				slow		25	25	reduce-ac		50	50	str		15	15	dex		8	8	swing2		30	30	dmg%		30	50																										0
+Bloodthief	45	0	1			1	1	23	17	brn	Brandistock		5	5000	whit	whit						openwounds		35	35	str		10	10	lifesteal		8	12	hp		26	26	dmg%		50	70																														0
+Lance of Yaggai	46	0	1			1	1	30	22	spt	Spetum		5	5000	lred	lred						thorns		8	8	ltng-min		1	1	ltng-max		60	60	res-all		15	15	swing2		40	40																														0
+The Tannr Gorerod	47	0	1			1	1	36	27	pik	Pike		5	5000	lgry	lgry						fire-min		23	23	fire-max		54	54	res-fire-max		15	15	hp		30	30	att		60	60	light		3	3	res-fire		15	15	dmg%		80	100																		0
+Dimoaks Hew	48	0	1			1	1	11	8	bar	Bardiche		5	5000	blac	blac						dex		15	15	dmg%		100	100	swing2		20	20	ac		-8	-8																																		0
+Steelgoad	49	0	1			1	1	19	14	vou	Voulge		5	5000	cgrn	cgrn						howl		96	96	deadly		30	30	att		30	30	res-all		5	5	dmg%		60	80	dur		20	40																										0
+Soul Harvest	50	0	1			1	1	26	19	scy	Scythe		5	5000	dgry			invscyu				openwounds		30	30	att		45	45	res-all		20	20	dmg%		50	90	manasteal		10	10	enr		5	5																										0
+The Battlebranch	51	0	1			1	1	34	25	pax	Poleaxe		5	5000	lblu	lblu						swing3		30	30	dex		10	10	dmg%		50	70	att		50	100	lifesteal		7	7																														0
+Woestave	52	0	1			1	1	38	28	hal	Halberd		5	5000	dblu	dblu						slow		50	50	openwounds		50	50	stupidity		3	3	dmg-ac		-50	-50	freeze		1	1	light		-3	-3	noheal		1	1	dmg%		20	40																		0
+The Grim Reaper	53	0	1			1	1	39	29	wsc	War Scythe		5	5000	lpur	lpur						deadly		100	100	noheal		1	1	manasteal		5	5	dmg%		20	20	dmg-min		15	15	*hp		-20	-20																										0
+Bane Ash	54	0	1			1	1	7	5	sst	Short Staff		5	5000	lgrn	lgrn						fire-min		4	4	fire-max		6	6	res-fire		50	50	mana		30	30	swing2		20	20	dmg%		50	60	skill	36	5	5	skill	37	2	2																		0
+Serpent Lord	55	0	1			1	1	12	9	lst	Long Staff		5	5000	cgrn	cgrn						dmg-pois	75	40	40	res-pois		50	50	light		-1	-1	mana		10	10	dmg%		30	40	manasteal		100	100	reduce-ac		50	50																						0
+Lazarus Spire	56	0	1			1	1	24	18	cst	Gnarled Staff		5	5000	lgry			invcstu				res-ltng		75	75	red-dmg		5	5	enr		15	15	skill	53	1	1	skill	49	2	2	skill	42	3	3	regen-mana		43	43	dmg-ltng		1	28	sor		1	1														0
+The Salamander	57	0	1			1	1	28	21	bst	Battle Staff		5	5000	dred	dred						dmg-fire		15	32	res-fire		30	30	skill	51	1	1	skill	47	2	2	skill	37	3	3	fireskill		2	2																										0
+The Iron Jang Bong	58	0	1			1	1	38	28	wst	War Staff		5	5000	dyel	dyel						ac		30	30	cast3		20	20	dmg%		100	100	att%		50	50	skill	48	2	2	skill	46	2	2	skill	44	3	3	sor		2	2																		0
+Pluckeye	59	0	1			1	1	10	7	sbw	Short Bow		5	5000	cblu	cblu						att		28	28	dmg%		100	100	hp		10	10	light		2	2	manasteal		3	3	mana-kill		2	2																										0
+Witherstring	60	0	1			1	1	18	13	hbw	Hunter\92s Bow		5	5000	lred	lred						swing3		30	30	dmg-min		1	1	dmg-max		3	3	att		50	50	magicarrow		3	3	dmg%		40	50																										0
+Rimeraven	61	0	1			1	1	20	15	lbw	Long Bow		5	5000	dred	dred						att%		50	50	dex		3	3	explosivearrow		3	3	str		3	3	dmg%		60	70																														0
+Piercerib	62	0	1			1	1	27	20	cbw	Composite Bow		5	5000	cred			invcbwu				res-all		10	10	deadly		30	30	att		60	60	dmg-undead		100	100	dmg%		40	60	swing2		50	50																										0
+Pullspite	63	0	1			1	1	34	25	sbb	Short Battle Bow		5	5000	lgrn			invsbbu				dmg-ltng		1	30	str		8	8	att		28	28	pierce		25	25	res-ltng		25	25	dmg%		70	90																										0
+Wizendraw	64	0	1			1	1	35	26	lbb	Long Battle Bow		5	5000	dgrn	dgrn						magicarrow		5	5	mana		30	30	swing2		20	20	res-cold		26	26	att		50	100	dmg%		70	80	enr		15	15	pierce-cold		20	35																		0
+Hellclap	65	0	1			1	1	36	27	swb	Short War Bow		5	5000	cgrn			invswbu				swing1		10	10	fire-min		15	15	fire-max		30	50	att		50	75	res-fire		40	40	dex		12	12	dmg%		70	90	fireskill		1	1																		0
+Blastbark	66	0	1			1	1	38	28	lwb	Long War Bow		5	5000	lyel	lyel						dmg%		70	130	str		5	5	ama		1	1	manasteal		3	3	skill	16	2	2																														0
+Leadcrow	67	0	1			1	1	12	9	lxb	Light Crossbow		5	5000	dyel			invlxbu				dex		10	10	hp		10	10	dmg%		70	70	res-pois		30	30	deadly		25	25	att		40	40																										0
+Ichorsting	68	0	1			1	1	24	18	mxb	Crossbow		5	5000	lgld			invmxbu				dmg-pois	75	102	102	dex		20	20	pierce		50	50	att		50	50	dmg%		50	50	swing2		20	20																										0
+Hellcast	69	0	1			1	1	36	27	hxb	Heavy Crossbow		5	5000	dgld			invhxbu				explosivearrow		5	5	res-fire-max		15	15	res-fire		15	15	att		70	70	swing2		20	20	dmg%		70	80	dmg-fire		15	35																						0
+Doomspittle	70	0	1			1	1	38	28	rxb	Repeating Crossbow		5	5000	lpur			invrxbu				ama		1	1	pierce		35	35	swing3		30	30	hp		15	15	dmg%		60	100																														0
+War Bonnet	71	0	1			1	1	4	3	cap	Cap		5	5000	dpur			invcapu				hp		15	15	att		30	30	dmg%		30	30	mana		15	15	ac		14	14																														0
+Tarnhelm	72	0	1			1	1	20	15	skp	Skull Cap		5	5000	oran	oran						gold%		75	75	mag%		25	50	allskills		1	1																																						0
+Coif of Glory	73	0	1			1	1	19	14	hlm	Helm		5	5000	whit			invhlmu				light-thorns		7	7	stupidity		1	1	res-ltng		15	15	ac-miss		100	100	ac		10	10																														0
+Duskdeep	74	0	1			1	1	23	17	fhl	Full Helm		5	5000	lgry			invfhlu				light		-2	-2	res-all		15	15	red-dmg		7	7	dmg-max		8	8	ac		10	20	ac%		30	50																										0
+Wormskull	75	0	1			1	1	28	21	bhm	Bone Helm		5	5000	lgrn			invbhmu				nec		1	1	lifesteal		5	5	mana		10	10	res-pois		25	25	dmg-pois	200	102	102																														0
+Howltusk	76	0	1			1	1	34	25	ghm	Great Helm		5	5000	dgry	dgry						red-mag		2	2	thorns		3	3	ac%		80	80	dmg-to-mana		35	35	knock		1	1	howl		33	33																										0
+Undead Crown	77	0	1			1	1	39	29	crn	Crown		5	5000	blac	blac						lifesteal		5	5	ac		40	40	res-pois		50	50	half-freeze		1	1	ac%		30	60	dmg-undead		50	50	att-undead		50	100	skill	69	3	3																		0
+The Face of Horror	78	0	1			1	1	27	20	msk	Mask		5	5000	lblu	lblu						howl		64	64	str		20	20	res-all		10	10	dmg-undead		50	50	ac		25	25																														0
+Greyform	79	0	1			1	1	10	7	qui	Quilted Armor		5	5000	lgry	lgry						red-mag		3	3	res-cold		20	20	res-fire		20	20	dex		10	10	lifesteal		5	5	ac		20	20																										0
+Blinkbats Form	80	0	1			1	1	16	12	lea	Leather Armor		5	5000	dred	dred						ac-miss		50	50	move2		10	10	ac		25	25	fire-min		3	3	fire-max		6	6	balance2		40	40																										0
+The Centurion	81	0	1			1	1	19	14	hla	Hard Leather		5	5000	cred	cred						ac		30	30	att		50	50	red-dmg		2	2	hp		15	15	mana		15	15					regen		5	5	stamdrain		25	25																		0
+Twitchthroe	82	0	1			1	1	22	16	stu	Studded Leather		5	5000	lgrn	lgrn						swing2		20	20	dex		10	10	block		25	25	ac		25	25	str		10	10	balance2		20	20																										0
+Darkglow	83	0	1			1	1	19	14	rng	Ring Mail		5	5000	dgrn	dgrn						att		20	20	res-all-max		5	5	light		3	3	ac-hth		50	50	res-all		10	10	ac%		70	100																										0
+Hawkmail	84	0	1			1	1	20	15	scl	Scale Mail		5	5000	cgrn	cgrn						ac%		80	100	res-cold-max		15	15	res-cold		15	15	nofreeze		1	1	move2		10	10																														0
+Sparking Mail	85	0	1			1	1	23	17	chn	Chain Mail		5	5000	lyel	lyel						ac%		75	85	dmg-ltng		1	20	light-thorns		10	14	res-ltng		30	30																																		0
+Venomsward	86	0	1			1	1	27	20	brs	Breast Plate		5	5000	dyel	dyel						res-pois-max		15	15	res-pois-len		50	50	res-pois		90	90	light		2	2	ac%		60	100																														0
+Iceblink	87	0	1			1	1	30	22	spl	Splint Mail		5	5000	lgld	lgld						freeze		1	1	res-cold		30	30	light		4	4	red-mag		1	1	ac%		70	80																														0
+Boneflesh	88	0	1			1	1	35	26	plt	Plate Mail		5	5000	dgld	dgld						lifesteal		5	5	ac%		100	120	att		35	35	openwounds		25	25																																		0
+Rockfleece	89	0	1			1	1	38	28	fld	Field Plate		5	5000	dgry	dgry						ease		-10	-10	ac%		100	130	red-dmg%		10	10	red-dmg		5	5	str		5	5																														0
+Rattlecage	90	0	1			1	1	39	29	gth	Gothic Plate		5	5000	dpur	dpur						howl		52	52	att		45	45	crush		25	25	ac		200	200																																		0
+Goldskin	91	0	1			1	1	38	28	ful	Full Plate Mail		5	5000	oran			invfulu				ac%		120	150	res-all		35	35	thorns		10	10	light		2	2	gold%		100	100																														0
+Victors Silk	92	0	1			1	1	38	28	aar	AncientArmor		5	5000	dblu			invaaru				manasteal		5	5	allskills		1	1	light		2	2	ac%		100	120																																		0
+Heavenly Garb	93	0	1			1	1	39	29	ltp	Light Plate		5	5000	cblu	cblu						ac%		100	100	res-all		10	10	regen-mana		25	25	enr		15	15	dmg-undead		50	50	att-undead		100	100																										0
+Pelta Lunata	94	0	1			1	1	3	2	buc	Buckler		5	5000	whit			invbucu				ac		30	30	vit		10	10	str		2	2	enr		10	10	ac%		30	40	block		20	20	block2		40	40	dur		8	12																		0
+Umbral Disk	95	0	1			1	1	12	9	sml	Small Shield		5	5000	lgry			invsmlu				stupidity		1	1	dex		10	10	ac		30	30	hp		20	20	light		-2	-2	ac%		40	50	block		30	30	dur		10	15																		0
+Stormguild	96	0	1			1	1	18	13	lrg	Large Shield		5	5000	dgry			invlrgu				red-mag		1	1	res-ltng		25	25	ac		30	30	dmg-ltng		1	6	ac%		50	60	block		30	30	light-thorns		3	3	dur		10	15																		0
+Wall of the Eyeless	97	0	1			1	1	27	20	bsh	Bone Shield		5	5000	lgld			invbshu				mana-kill		5	5	manasteal		3	3	cast2		20	20	res-pois		20	20	ac%		30	40	ac		10	10																										0
+Swordback Hold	98	0	1			1	1	20	15	spk	Spiked Shield		5	5000	lred			invspku				thorns		5	5	block		20	20	openwounds		50	50	bloody		3	5	ac%		30	60	thorns		5	5	ac		10	10																						0
+Steelclash	99	0	1			1	1	23	17	kit	Kite Shield		5	5000	blac			invkitu				block		25	25	pal		1	1	red-dmg		3	3	light		3	3	ac%		60	100	block2		20	20	res-all		15	15	ac		20	20	dur		15	20														0
+Bverrit Keep	100	0	1			1	1	26	19	tow	Tower Shield		5	5000	lblu			invtowu				ac		30	30	res-fire		75	75	str		5	5	red-mag		5	5	ac%		80	120	block		10	10	dur		80	100																						0
+The Ward	101	0	1			1	1	35	26	gts	Gothic Shield		5	5000	dblu			invgtsu				ac		40	40	red-mag		2	2	str		10	10	block		10	10	ac%		100	100	res-all		30	50																										0
+The Hand of Broc	102	0	1			1	1	7	5	lgl	Gloves		5	5000	cblu	cblu						manasteal		3	3	lifesteal		3	3	res-pois		10	10	mana		20	20	ac		10	10	ac%		10	20																										0
+Bloodfist	103	0	1			1	1	12	9	vgl	Heavy Gloves		5	5000	oran	oran						dmg-min		5	5	hp		40	40	balance2		30	30	ac		10	10	ac%		10	20	swing2		10	10																										0
+Chance Guards	104	0	1			1	1	20	15	mgl	Bracers		5	5000	lred	lred						gold%		200	200	mag%		25	40	att		25	25	ac		15	15	light		2	2	ac%		20	30																										0
+Magefist	105	0	1			1	1	31	23	tgl	Light Gauntlets		5	5000	lgry	lgry						cast3		20	20	regen-mana		25	25	fireskill		1	1	dmg-fire		1	6	ac		10	10	ac%		20	30																										0
+Frostburn	106	0	1			1	1	39	29	hgl	Gauntlets		5	5000	dred	dred						ac		30	30	dmg%		5	5	mana%		40	40	dmg-cold	50	1	6	ac%		10	20																														0
+Hotspur	107	0	1			1	1	7	5	lbt	Leather Boots		5	5000	cred	cred						res-fire-max		15	15	hp		15	15	dmg-fire		3	6	ac		6	6	res-fire		45	45	ac%		10	20																										0
+Gorefoot	108	0	1			1	1	12	9	vbt	Heavy Boots		5	5000	dblu	dblu						bloody		3	5	move2		20	20	manasteal		2	2	thorns		2	2	ac		12	12	ac%		20	30	skill	132	2	2																						0
+Treads of Cthon	109	0	1			1	1	20	15	mbt	Chain Boots		5	5000	lgrn	lgrn						move2		30	30	ac-miss		50	50	stamdrain		50	50	hp		10	10	ac		12	12	ac%		30	40																										0
+Goblin Toe	110	0	1			1	1	30	22	tbt	Light Plate Boots		5	5000	dgry	dgry						crush		25	25	red-dmg		1	1	red-mag		1	1	ac		15	15	light		-1	-1	ac%		50	60																										0
+Tearhaunch	111	0	1			1	1	39	29	hbt	Plate Boots		5	5000	dgrn	dgrn						ac		35	35	str		5	5	dex		5	5	move2		20	20	res-all		10	10	ac%		60	80	skill	115	2	2																						0
+Lenyms Cord	112	0	1			1	1	10	7	lbl	Sash		5	5000	cgrn	cgrn						mana		15	15	regen-mana		30	30	res-all		5	5	light		1	1																																		0
+Snakecord	113	0	1			1	1	16	12	vbl	Light Belt		5	5000	blac	blac						dmg-pois	75	40	40	res-pois		25	25	ac		10	10	ac%		20	30	regen		5	5	res-pois-len		50	50																										0
+Nightsmoke	114	0	1			1	1	27	20	mbl	Belt		5	5000	lyel	lyel						res-all		10	10	dmg-to-mana		50	50	mana		20	20	red-dmg		2	2	ac		15	15	ac%		30	50																										0
+Goldwrap	115	0	1			1	1	36	27	tbl	Heavy Belt		5	5000	lblu	lblu						mag%		30	30	light		2	2	ac		25	25	swing2		10	10	ac%		40	60	gold%		50	80																										0
+Bladebuckle	116	0	1			1	1	39	29	hbl	Girdle		5	5000	dyel	dyel						thorns		8	8	ac		30	30	red-dmg		3	3	str		5	5	dex		10	10	ac%		80	100	balance2		30	30																						0
+Nokozan Relic	117	0	1			20	1	14	10	amu	Amulet		5	5000	lgld							dmg-fire		3	6	res-fire-max		10	10	res-fire		50	50	light		3	3	balance2		20	20																														0
+The Eye of Etlich	118	0	1			5	1	20	15	amu	Amulet		5	5000	dgld							ac-miss		10	40	light		1	5	allskills		1	1	lifesteal		3	7	cold-min		1	2	cold-max		3	5	cold-len		50	250																						0
+The Mahim-Oak Curio	119	0	1			10	1	34	25	amu	Amulet		5	5000	lpur							dex		10	10	str		10	10	enr		10	10	vit		10	10	ac		10	10	att%		10	10	res-all		10	10	ac%		10	10																		0
+Nagelring	120	0	1			15	1	10	7	rin	Ring		5	5000	dpur							red-mag		3	3	thorns		3	3	att		50	75	mag%		15	30																																		0
+Manald Heal	121	0	1			15	1	20	15	rin	Ring		5	5000	oran							manasteal		4	7	regen		5	8	hp		20	20	regen-mana		20	20																																		0
+The Stone of Jordan	122	0	1			1	1	39	29	rin	Ring		5	5000	whit							mana		20	20	mana%		25	25	ltng-min		25	25	allskills		1	1	ltng-max		50	50																													1	0
+Amulet of the Viper	123	0	1			1	1	0	0	vip	Amulet		5	5000	lgry							mana		10	10	res-pois		25	25	hp		10	10			0	0			0	0			0	0			0	0																						0
+Staff of Kings	124	0	1			1	1	0	0	msf	Staff		5	5000	dgry							res-all		10	10	swing3		50	50			0	0			0	0			0	0			0	0			0	0																						0
+Horadric Staff	125	0	1			1	1	0	0	hst	Staff		5	5000	blac							mana		10	10	res-pois		25	25	hp		10	10	res-all		10	10	swing3		50	50			0	0			0	0																						0
+Hell Forge Hammer	126	0	1			1	1	0	0	hfh	Hammer		5	5000	cred							fire-min		5	5	fire-max		20	20	res-fire		40	40	ac		35	35			0	0			0	0			0	0																						0
+KhalimFlail	127	0	1			1	1	0	0	qf1	Flail		5	5000	dblu							ltng-min		1	1	ltng-max		20	20	swing3		50	50	att		40	40			0	0			0	0			0	0																						0
+SuperKhalimFlail	128	0	1			1	1	0	0	qf2	Flail		5	5000	dblu							ltng-min		1	1	ltng-max		40	40	swing3		50	50	att		40	40	manasteal		6	6	lifesteal		6	6			0	0																						0
 Expansion																																																																							0
-Coldkill	129	100	1			1		44	36	9ha	Hatchet		5	5000	cblu	cblu		invhaxu				dmg-cold	50	40	40	res-cold		15	15	res-cold-max		15	15	swing3		30	30	hit-skill	45	10	10	gethit-skill	44	10	5	dmg%		150	190																						0
-Butcher's Pupil	130	100	1			1		47	39	9ax	Cleaver		5	5000	cblu	cblu		invaxeu				deadly		35	35	openwounds		25	25	dmg%		150	200	indestruct		1	1	swing3		30	30	dmg-norm		30	50																										0
-Islestrike	131	100	1			1		51	43	92a	Twin Axe		5	5000								dru		2	2	str		10	10	dex		10	10	vit		10	10	enr		10	10	ac-miss		50	50	crush		25	25	dmg%		170	190	skill	233	1	1	skill	248	1	1										0
-Pompe's Wrath	132	100	1			1		53	45	9mp	Crowbill		5	5000	cred	cred		invmpiu				hit-skill	244	4	8	slow		50	50	dmg-fire		35	150	knock		1	1	dmg%		140	170																														0
-Guardian Naga	133	100	1			1		56	48	9wa	Naga		5	5000								hit-skill	92	5	8	thorns		15	15	res-pois		30	30	dmg%		150	180	dmg-pois	250	256	256	dmg-max		20	20																										0
-Warlord's Trust	134	100	1			1		43	35	9la	Military Axe		5	5000	whit	whit						ac		75	75	regen		20	20	vit/lvl	4			res-all		10	10	rep-dur	25			dmg%		175	175																										0
-Spellsteel	135	100	1			1		47	39	9ba	Bearded Axe		5	5000	whit	whit						ease		-60	-60	mana		100	100	red-mag		12	15	cast1		10	10	dmg%		165	165	regen-mana		25	25	charged	54	20	1	charged	87	30	3	charged	101	100	10	charged	225	60	12										0
-Stormrider	136	100	1			1		49	41	9bt	Tabar		5	5000	lred	lred		inv9btu				hit-skill	53	5	10	hit-skill	38	10	0	dmg-ltng		1	200	dmg-norm		35	75	dmg%		100	100	dur		50	50	light-thorns		15	15	gethit-skill	38	15	5																		0
-Boneslayer Blade	137	100	1			1		50	42	9ga	Gothic Axe		5	5000				invgaxu				att-und/lvl	10			dmg-und/lvl	20			str		8	8	swing2		20	20	att%		35	35	dmg%		180	220	charged	101	200	20	gethit-skill	101	50	0																		0
-The Minataur	138	100	1			1		53	45	9gi	Ancient Axe		5	5000				inv9giu				stupidity		2	2	half-freeze		1	1	str		15	20	slow		50	50	crush		30	30	dmg-norm		20	30	dmg%		140	200																						0
-Suicide Branch	139	100	1			1		41	33	9wn	Burnt Wand		5	5000								thorns		25	25	cast2		50	50	res-all		10	10	mana%		10	10	hp		40	40	allskills		1	1																										0
-Carin Shard	140	100	1			1		43	35	9yw	Petrified Wand		5	5000	cblu	cblu						hp/lvl	10			cast2		10	10	mana/lvl	10			balance2		30	30	regen		5	5	nec		1	1	skilltab	8	2	2																						0
-Arm of King Leoric	141	100	1			1		44	36	9bw	Tomb Wand		5	5000				invbwnu				skilltab	8	2	2	gethit-skill	93	5	10	mana/lvl	10			gethit-skill	88	10	2	cast1		10	10	skilltab	7	2	2	skill	77	2	2	skill	80	2	2	skill	69	3	3	skill	70	3	3										0
+Coldkill	129	100	1			1	1	44	36	9ha	Hatchet		5	5000	cblu	cblu		invhaxu				dmg-cold	50	40	40	res-cold		15	15	res-cold-max		15	15	swing3		30	30	hit-skill	45	10	10	gethit-skill	44	10	5	dmg%		150	190																						0
+Butcher's Pupil	130	100	1			1	1	47	39	9ax	Cleaver		5	5000	cblu	cblu		invaxeu				deadly		35	35	openwounds		25	25	dmg%		150	200	indestruct		1	1	swing3		30	30	dmg-norm		30	50																										0
+Islestrike	131	100	1			1	1	51	43	92a	Twin Axe		5	5000								dru		2	2	str		10	10	dex		10	10	vit		10	10	enr		10	10	ac-miss		50	50	crush		25	25	dmg%		170	190	skill	233	1	1	skill	248	1	1										0
+Pompe's Wrath	132	100	1			1	1	53	45	9mp	Crowbill		5	5000	cred	cred		invmpiu				hit-skill	244	4	8	slow		50	50	dmg-fire		35	150	knock		1	1	dmg%		140	170																														0
+Guardian Naga	133	100	1			1	1	56	48	9wa	Naga		5	5000								hit-skill	92	5	8	thorns		15	15	res-pois		30	30	dmg%		150	180	dmg-pois	250	256	256	dmg-max		20	20																										0
+Warlord's Trust	134	100	1			1	1	43	35	9la	Military Axe		5	5000	whit	whit						ac		75	75	regen		20	20	vit/lvl	4			res-all		10	10	rep-dur	25			dmg%		175	175																										0
+Spellsteel	135	100	1			1	1	47	39	9ba	Bearded Axe		5	5000	whit	whit						ease		-60	-60	mana		100	100	red-mag		12	15	cast1		10	10	dmg%		165	165	regen-mana		25	25	charged	54	20	1	charged	87	30	3	charged	101	100	10	charged	225	60	12										0
+Stormrider	136	100	1			1	1	49	41	9bt	Tabar		5	5000	lred	lred		inv9btu				hit-skill	53	5	10	hit-skill	38	10	0	dmg-ltng		1	200	dmg-norm		35	75	dmg%		100	100	dur		50	50	light-thorns		15	15	gethit-skill	38	15	5																		0
+Boneslayer Blade	137	100	1			1	1	50	42	9ga	Gothic Axe		5	5000				invgaxu				att-und/lvl	10			dmg-und/lvl	20			str		8	8	swing2		20	20	att%		35	35	dmg%		180	220	charged	101	200	20	gethit-skill	101	50	0																		0
+The Minataur	138	100	1			1	1	53	45	9gi	Ancient Axe		5	5000				inv9giu				stupidity		2	2	half-freeze		1	1	str		15	20	slow		50	50	crush		30	30	dmg-norm		20	30	dmg%		140	200																						0
+Suicide Branch	139	100	1			1	1	41	33	9wn	Burnt Wand		5	5000								thorns		25	25	cast2		50	50	res-all		10	10	mana%		10	10	hp		40	40	allskills		1	1																										0
+Carin Shard	140	100	1			1	1	43	35	9yw	Petrified Wand		5	5000	cblu	cblu						hp/lvl	10			cast2		10	10	mana/lvl	10			balance2		30	30	regen		5	5	nec		1	1	skilltab	8	2	2																						0
+Arm of King Leoric	141	100	1			1	1	44	36	9bw	Tomb Wand		5	5000				invbwnu				skilltab	8	2	2	gethit-skill	93	5	10	mana/lvl	10			gethit-skill	88	10	2	cast1		10	10	skilltab	7	2	2	skill	77	2	2	skill	80	2	2	skill	69	3	3	skill	70	3	3										0
 Blackhand Key	142	100	1			1		49	41	9gw	Grave Wand		5	5000	blac	blac		inv9gwu				skilltab	6	1	1	dmg-to-mana		20	20	hp		50	50	light		-2	-2	cast3		30	30	res-fire		37	37	nec		2	2	charged	142	30	13																		0
-Dark Clan Crusher	143	100	1			1		42	34	9cl	Cudgel		5	5000	dgld	dgld		invclbu				dru		2	2	dmg-demon		200	200	att-demon		200	200	dmg%		195	195	att%		20	25	demon-heal		15	15																										0
-Zakarum's Hand	144	100	1			1		45	37	9sc	Rune Scepter		5	5000	lpur	lpur						manasteal		8	8	ignore-ac		1	1	regen-mana		10	10	regen-stam		15	15	hit-skill	59	6	5	dmg%		180	220	swing2		30	30	skill	114	2	2	skill	118	2	2														0
-The Fetid Sprinkler	145	100	1			1		46	38	9qs	Holy Water Sprinkler		5	5000								pal		2	2	hit-skill	87	5	1	hit-skill	81	10	1	dmg-pois	100	409	409	dmg%		160	190	att		150	200	dmg-norm		15	25																						0
-Hand of Blessed Light	146	100	1			1		50	42	9ws	Divine Scepter		5	5000	lyel							pal		2	2	dmg%		130	160	att%		100	100	ac		50	50	regen-mana		15	15	light		4	4	dmg-norm		20	45	skill	101	4	4	skill	121	2	2	hit-skill	121	5	4										0
-Fleshrender	147	100	1			1		46	38	9sp	Barbed Club		5	5000	blac			invspcu				openwounds		25	25	noheal		1	1	crush		20	20	deadly		20	20	dmg-norm		35	50	dmg%		130	200	dru		1	1	skilltab	16	2	2	dur		20	20														0
-Sureshrill Frost	148	100	1			1		47	39	9ma	Flanged Mace		5	5000								dmg-cold	125	63	112	nofreeze		1	1	dmg%		150	180	dmg-norm		5	10	freeze		3	3	charged	64	50	9																										0
-Moonfall	149	100	1			1		50	42	9mt	Jagged Star		5	5000				invmstu				hit-skill	56	5	6	dmg-fire		55	115	red-mag		9	12	dmg%		120	150	light		2	2	charged	56	60	11	dmg-norm		10	15																						0
-Baezil's Vortex	150	100	1			1		53	45	9fl	Knout		5	5000	dblu	dblu						hit-skill	48	5	8	dmg-ltng		1	150	mana		100	100	res-ltng		25	25	dmg%		160	200	swing2		20	20	charged	48	80	15																						0
-Earthshaker	151	100	1			1		51	43	9wh	Battle Hammer		5	5000								hit-skill	234	5	7	knock		1	1	swing3		30	30	dmg%		180	180	stupidity		1	1	skilltab	17	3	3	dur		50	50																						0
-Bloodtree Stump	152	100	1			1		56	48	9m9	War Club		5	5000	dred							crush		50	50	dmg%		180	220	res-all		20	20	str		25	25	skilltab	13	2	2	skill	129	3	3	dur		40	40																						0
-The Gavel of Pain	153	100	1			1		53	45	9gm	Martel de Fer		5	5000				inv9gmu				hit-skill	66	5	1	gethit-skill	76	5	1	thorns		26	26	indestruct		1	1	dmg-norm		12	30	dmg%		130	160	charged	66	3	8																						0
-Bloodletter	154	100	1			1		38	30	9ss	Gladius		5	5000	cred	cred						dmg-norm		12	45	att		90	90	lifesteal		8	8	stamdrain		10	10	swing2		20	20	dmg%		140	140	skill	127	2	4	skill	151	1	3	dur		30	30														0
-Coldsteel Eye	155	100	1			1		39	31	9sm	Cutlass		5	5000	dgry			invscmu				stupidity		1	1	slow		30	30	deadly		50	50	dur		50	50	dmg%		200	250	swing2		20	20	manasteal		6	6																						0
-Hexfire	156	100	1			1		41	33	9sb	Shamshir		5	5000				invsbru				charged	62	36	6	ignore-ac		1	1	res-fire		25	25	res-fire-max		10	10	dmg-norm		35	40	dmg%		140	160	fireskill		3	3																						0
-Blade of Ali Baba	157	100	1			1		43	35	9fc	Tulwar		5	5000	cred	cred						sock	3			gold%/lvl	20			mag%/lvl	8			mana		15	15	dmg%		60	120	dex		5	15																										0
-Ginther's Rift	158	100	1			1		45	37	9cr	Dimensional Blade		5	5000	cblu			inv9cru				red-mag		7	12	swing2		30	30	rep-dur	20			dur		40	40	dmg-mag		50	120	dmg%		100	150																										0
-Headstriker	159	100	1			1		47	39	9bs	Battle Sword		5	5000	bwht	bwht						noheal		1	1	str		15	15	deadly/lvl	12			dmg/lvl	8			dmg%		150	150																														0
-Plague Bearer	160	100	1			1		49	41	9ls	Rune Sword		5	5000				inv9lsu				hit-skill	92	5	4	dmg-pois	200	384	384	dmg-norm		10	45	dmg%		150	150	res-pois		45	45	skill	238	5	5																										0
-The Atlantian	161	100	1			1		50	42	9wd	Ancient Sword		5	5000	lblu	lblu						dur		100	100	ac		75	75	str		16	16	dex		12	12	vit		8	8	dmg%		200	250	pal		2	2	att%		50	50																		0
-Crainte Vomir	162	100	1			1		50	42	92h	Espadon		5	5000	lgld			inv2hsu				slow		35	35	dmg-ac		-70	-70	move2		20	20	red-dmg%		10	10	dmg%		160	200	swing3		50	50																										0
-Bing Sz Wang	163	100	1			1		51	43	9cm	Dacian Falx		5	5000								ease		-30	-30	dmg-cold	75	50	140	str		20	20	freeze		2	2	hit-skill	64	5	3	dmg%		130	160																										0
-The Vile Husk	164	100	1			1		52	44	9gs	Tusk Sword		5	5000	dgry	dgry		invgisu				hit-skill	66	6	1	dmg-und/lvl	60			res-pois		50	50	dmg-pois	150	426	426	dmg%		150	200	att-und/lvl	20																												0
-Cloudcrack	165	100	1			1		53	45	9b9	Gothic Sword		5	5000				invbswu				hit-skill	121	6	7	dmg-ltng		1	240	ac		30	30	light		2	2	res-ltng-max		10	10	dmg%		150	200	light-thorns		15	15	skilltab	10	2	2	skilltab	11	2	2														0
-Todesfaelle Flamme	166	100	1			1		54	46	9fb	Zweihander		5	5000				inv9fbu				dmg-fire		50	200	res-fire		40	40	abs-fire		10	10	att-skill	47	10	6	dmg%		120	160	charged	52	45	10	charged	51	20	10																						0
-Swordguard	167	100	1			1		55	48	9gd	Executioner Sword		5	5000	bwht	bwht		invgsdu				ease		-50	-50	ac/lvl	40			res-all		10	20	ac-miss		100	100	dmg-to-mana		30	30	dmg%		170	180	ac-hth		200	200	balance2		20	20	block		20	20														0
-Spineripper	168	100	1			1		40	32	9dg	Poignard		5	5000								ignore-ac		1	1	lifesteal		8	8	noheal		1	1	swing3		15	15	dex		10	10	dmg%		200	240	dmg-norm		15	27	nec		1	1																		0
+Dark Clan Crusher	143	100	1			1	1	42	34	9cl	Cudgel		5	5000	dgld	dgld		invclbu				dru		2	2	dmg-demon		200	200	att-demon		200	200	dmg%		195	195	att%		20	25	demon-heal		15	15																										0
+Zakarum's Hand	144	100	1			1	1	45	37	9sc	Rune Scepter		5	5000	lpur	lpur						manasteal		8	8	ignore-ac		1	1	regen-mana		10	10	regen-stam		15	15	hit-skill	59	6	5	dmg%		180	220	swing2		30	30	skill	114	2	2	skill	118	2	2														0
+The Fetid Sprinkler	145	100	1			1	1	46	38	9qs	Holy Water Sprinkler		5	5000								pal		2	2	hit-skill	87	5	1	hit-skill	81	10	1	dmg-pois	100	409	409	dmg%		160	190	att		150	200	dmg-norm		15	25																						0
+Hand of Blessed Light	146	100	1			1	1	50	42	9ws	Divine Scepter		5	5000	lyel							pal		2	2	dmg%		130	160	att%		100	100	ac		50	50	regen-mana		15	15	light		4	4	dmg-norm		20	45	skill	101	4	4	skill	121	2	2	hit-skill	121	5	4										0
+Fleshrender	147	100	1			1	1	46	38	9sp	Barbed Club		5	5000	blac			invspcu				openwounds		25	25	noheal		1	1	crush		20	20	deadly		20	20	dmg-norm		35	50	dmg%		130	200	dru		1	1	skilltab	16	2	2	dur		20	20														0
+Sureshrill Frost	148	100	1			1	1	47	39	9ma	Flanged Mace		5	5000								dmg-cold	125	63	112	nofreeze		1	1	dmg%		150	180	dmg-norm		5	10	freeze		3	3	charged	64	50	9																										0
+Moonfall	149	100	1			1	1	50	42	9mt	Jagged Star		5	5000				invmstu				hit-skill	56	5	6	dmg-fire		55	115	red-mag		9	12	dmg%		120	150	light		2	2	charged	56	60	11	dmg-norm		10	15																						0
+Baezil's Vortex	150	100	1			1	1	53	45	9fl	Knout		5	5000	dblu	dblu						hit-skill	48	5	8	dmg-ltng		1	150	mana		100	100	res-ltng		25	25	dmg%		160	200	swing2		20	20	charged	48	80	15																						0
+Earthshaker	151	100	1			1	1	51	43	9wh	Battle Hammer		5	5000								hit-skill	234	5	7	knock		1	1	swing3		30	30	dmg%		180	180	stupidity		1	1	skilltab	17	3	3	dur		50	50																						0
+Bloodtree Stump	152	100	1			1	1	56	48	9m9	War Club		5	5000	dred							crush		50	50	dmg%		180	220	res-all		20	20	str		25	25	skilltab	13	2	2	skill	129	3	3	dur		40	40																						0
+The Gavel of Pain	153	100	1			1	1	53	45	9gm	Martel de Fer		5	5000				inv9gmu				hit-skill	66	5	1	gethit-skill	76	5	1	thorns		26	26	indestruct		1	1	dmg-norm		12	30	dmg%		130	160	charged	66	3	8																						0
+Bloodletter	154	100	1			1	1	38	30	9ss	Gladius		5	5000	cred	cred						dmg-norm		12	45	att		90	90	lifesteal		8	8	stamdrain		10	10	swing2		20	20	dmg%		140	140	skill	127	2	4	skill	151	1	3	dur		30	30														0
+Coldsteel Eye	155	100	1			1	1	39	31	9sm	Cutlass		5	5000	dgry			invscmu				stupidity		1	1	slow		30	30	deadly		50	50	dur		50	50	dmg%		200	250	swing2		20	20	manasteal		6	6																						0
+Hexfire	156	100	1			1	1	41	33	9sb	Shamshir		5	5000				invsbru				charged	62	36	6	ignore-ac		1	1	res-fire		25	25	res-fire-max		10	10	dmg-norm		35	40	dmg%		140	160	fireskill		3	3																						0
+Blade of Ali Baba	157	100	1			1	1	43	35	9fc	Tulwar		5	5000	cred	cred						sock	3			gold%/lvl	20			mag%/lvl	8			mana		15	15	dmg%		60	120	dex		5	15																										0
+Ginther's Rift	158	100	1			1	1	45	37	9cr	Dimensional Blade		5	5000	cblu			inv9cru				red-mag		7	12	swing2		30	30	rep-dur	20			dur		40	40	dmg-mag		50	120	dmg%		100	150																										0
+Headstriker	159	100	1			1	1	47	39	9bs	Battle Sword		5	5000	bwht	bwht						noheal		1	1	str		15	15	deadly/lvl	12			dmg/lvl	8			dmg%		150	150																														0
+Plague Bearer	160	100	1			1	1	49	41	9ls	Rune Sword		5	5000				inv9lsu				hit-skill	92	5	4	dmg-pois	200	384	384	dmg-norm		10	45	dmg%		150	150	res-pois		45	45	skill	238	5	5																										0
+The Atlantian	161	100	1			1	1	50	42	9wd	Ancient Sword		5	5000	lblu	lblu						dur		100	100	ac		75	75	str		16	16	dex		12	12	vit		8	8	dmg%		200	250	pal		2	2	att%		50	50																		0
+Crainte Vomir	162	100	1			1	1	50	42	92h	Espadon		5	5000	lgld			inv2hsu				slow		35	35	dmg-ac		-70	-70	move2		20	20	red-dmg%		10	10	dmg%		160	200	swing3		50	50																										0
+Bing Sz Wang	163	100	1			1	1	51	43	9cm	Dacian Falx		5	5000								ease		-30	-30	dmg-cold	75	50	140	str		20	20	freeze		2	2	hit-skill	64	5	3	dmg%		130	160																										0
+The Vile Husk	164	100	1			1	1	52	44	9gs	Tusk Sword		5	5000	dgry	dgry		invgisu				hit-skill	66	6	1	dmg-und/lvl	60			res-pois		50	50	dmg-pois	150	426	426	dmg%		150	200	att-und/lvl	20																												0
+Cloudcrack	165	100	1			1	1	53	45	9b9	Gothic Sword		5	5000				invbswu				hit-skill	121	6	7	dmg-ltng		1	240	ac		30	30	light		2	2	res-ltng-max		10	10	dmg%		150	200	light-thorns		15	15	skilltab	10	2	2	skilltab	11	2	2														0
+Todesfaelle Flamme	166	100	1			1	1	54	46	9fb	Zweihander		5	5000				inv9fbu				dmg-fire		50	200	res-fire		40	40	abs-fire		10	10	att-skill	47	10	6	dmg%		120	160	charged	52	45	10	charged	51	20	10																						0
+Swordguard	167	100	1			1	1	55	48	9gd	Executioner Sword		5	5000	bwht	bwht		invgsdu				ease		-50	-50	ac/lvl	40			res-all		10	20	ac-miss		100	100	dmg-to-mana		30	30	dmg%		170	180	ac-hth		200	200	balance2		20	20	block		20	20														0
+Spineripper	168	100	1			1	1	40	32	9dg	Poignard		5	5000								ignore-ac		1	1	lifesteal		8	8	noheal		1	1	swing3		15	15	dex		10	10	dmg%		200	240	dmg-norm		15	27	nec		1	1																		0
 Heart Carver	169	100	1			1		44	36	9di	Rondel		5	5000								deadly		35	35	ignore-ac		1	1	dmg-norm		15	35	dmg%		190	240	skill	131	4	4	skill	142	4	4	skill	129	4	4																						0
-Blackbog's Sharp	170	100	1			1		46	38	9kr	Cinquedeas		5	5000				invkrsu				slow		50	50	ac		50	50	dmg-norm		15	45	swing3		30	30	dmg-pois	250	500	500	skill	73	5	5	skill	83	4	4	skill	92	4	4																		0
-Stormspike	171	100	1			1		49	41	9bl	Stilleto		5	5000	cblu	cblu		inv9blu				dmg-ltng		1	120	light-thorns		20	20	gethit-skill	38	25	3	dmg%		150	150	res-ltng/lvl	8																																0
-The Impaler	172	100	1			1		39	31	9sr	War Spear		5	5000	lred	lred						ignore-ac		1	1	att		150	150	swing2		20	20	openwounds		40	40	noheal		1	1	dmg%		140	170	skill	19	5	5	skill	14	3	3																		0
-Kelpie Snare	173	100	1			1		41	33	9tr	Fuscina		5	5000				invtriu				slow		75	75	res-fire		50	50	hp/lvl	10			dmg-norm		30	50	str		10	10	dmg%		140	180																										0
-Soulfeast Tine	174	100	1			1		43	35	9br	War Fork		5	5000	lyel	lyel		inv9bru				ease		-20	-20	lifesteal		7	7	manasteal		7	7	stamdrain		20	20	dmg%		150	190	att		150	250	dur		15	15																						0
-Hone Sundan	175	100	1			1		45	37	9st	Yari		5	5000								sock	3			dmg-norm		20	40	crush		45	45	rep-dur	10			dmg%		160	200																														0
-Spire of Honor	176	100	1			1		47	39	9p9	Lance		5	5000	lgry	lgry						att%		25	25	light		3	3	regen		20	20	balance2		20	20	dmg-norm		20	40	dmg-dem/lvl	12			dmg%		150	200	skilltab	9	3	3	ac%		25	25														0
-The Meat Scraper	177	100	1			1		49	41	9b7	Lochaber Axe		5	5000	dred	dred						dmg%		150	200	swing2		30	30	lifesteal		10	10	openwounds		50	50	mag%		25	25	skilltab	13	3	3																										0
-Blackleach Blade	178	100	1			1		50	42	9vo	Bill		5	5000	blac	blac						ease		-25	-25	hit-skill	72	5	5	light		-2	-2	lifesteal		8	8	dmg/lvl	10			dmg%		100	140																										0
-Athena's Wrath	179	100	1			1		50	42	9s8	Battle Scythe		5	5000				inv9s8u				dru		1	3	dex		15	15	swing2		30	30	hp/lvl	8			dmg/lvl	8			dmg%		150	180																										0
-Pierre Tombale Couant	180	100	1			1		51	43	9pa	Partizan		5	5000	lgld	lgld						deadly		55	55	bar		3	3	balance2		30	30	manasteal		6	6	dmg-norm		12	20	dmg%		160	220	att		100	200																						0
-Husoldal Evo	181	100	1			1		52	44	9h9	Bec-de-Corbin		5	5000								regen		20	20	att		200	250	noheal		1	1	dmg-norm		20	32	dmg%		160	200	swing2		20	20																										0
-Grim's Burning Dead	182	100	1			1		52	45	9wc	Grim Scythe		5	5000	cred	cred						dmg-fire		131	232	res-fire		45	45	dmg%		140	180	thorns		8	8	ease		-50	-50	nec		3	3	reduce-ac		50	50	ac%		20	20	att		200	250														0
-Razorswitch	183	100	1			1		36	28	8ss	Jo Stalf		5	5000	lpur							cast3		30	30	thorns		15	15	mana		175	175	hp		80	80	red-mag		15	15	res-all		50	50	allskills		1	1																						0
-Ribcracker	184	100	1			1		39	31	8ls	Quarterstaff		5	5000	lblu	lblu						dmg-norm		30	65	dmg%		200	300	crush		50	50	dex		15	15	ac		100	100	ac%		100	100	balance2		50	50	swing2		50	50	dur		100	100														0
-Chromatic Ire	185	100	1			1		43	35	8cs	Cedar Staff		5	5000				invcstu				sor		3	3	res-all		20	40	cast1		20	20	light-thorns		20	20	hp%		20	25	skill	61	1	1	skill	63	1	1	skill	65	1	1																		0
-Warpspear	186	100	1			1		47	39	8bs	Gothic Staff		5	5000	cblu	cblu						sor		3	3	ignore-ac		1	1	skill	54	3	3	skill	43	3	3	skill	58	3	3	ac-miss		250	250																										0
-Skullcollector	187	100	1			1		49	41	8ws	Rune Staff		5	5000	blac	blac		inv8wsu				mana%		20	20	mana-kill		20	20	allskills		2	2	mag%/lvl	8																																				0
-Skystrike	188	100	1			1		36	28	8sb	Edge Bow		5	5000								dmg-ltng		1	250	att		100	100	enr		10	10	swing3		30	30	dmg%		150	200	hit-skill	56	2	6	ama		1	1																						0
-Riphook	189	100	1			1		39	31	8hb	Razor Bow		5	5000	cred	cred						openwounds		30	30	dmg%		180	220	slow		30	30	mana		35	35	swing2		30	30	lifesteal		7	10																										0
-Kuko Shakaku	190	100	1			1		41	33	8lb	CedarBow		5	5000	lpur	lpur		inv8lbu				skill	27	3	3	explosivearrow		7	7	dmg%		150	180	pierce		50	50	dmg-fire		40	180	skilltab	0	3	3																										0
-Endlesshail	191	100	1			1		44	36	8cb	Double Bow		5	5000				invcbwu				res-cold		35	35	mana		40	40	ac-miss		50	50	skill	26	3	5	dmg%		180	220	dmg-cold	75	15	30																										0
-Whichwild String	192	100	1			1		47	39	8s8	Short Siege Bow		5	5000	lblu	lblu		inv8s8u				hit-skill	66	2	5	res-all		40	40	deadly/lvl	8			dmg%		150	170	magicarrow		20	20	sock	2																												0
-Cliffkiller	193	100	1			1		49	41	8l8	Long Siege Bow		5	5000	dgld							ama		2	2	dmg%		190	230	ac-miss		80	80	knock		1	1	hp		50	50	dmg-min		5	10	dmg-max		20	30																						0
-Magewrath	194	100	1			1		51	43	8sw	Rune Bow		5	5000	oran			invswbu				manasteal		15	15	red-mag		9	13	skill	22	3	3	att		200	250	dex		10	10	stupidity		1	1	dmg-norm		25	50	dmg%		120	150	ama		1	1														0
-Godstrike Arch	195	100	1			1		54	46	8lw	Gothic Bow		5	5000	lgry	lgry						dmg%		200	250	att%		100	150	dmg-undead		100	200	dmg-demon		100	200	hit-skill	121	5	7	swing2		50	50	regen		12	12																						0
-Langer Briser	196	100	1			1		40	32	8lx	Arbalest		5	5000				inv8lxu				knock		1	1	dmg%		170	200	mag%		30	60	hp		30	30	dmg-max		10	30	openwounds		33	33	dmg-ltng		1	212																						0
-Pus Spiter	197	100	1			1		44	36	8mx	Siege Crossbow		5	5000	cgrn	cgrn		inv8mxu				dmg-pois	200	192	192	hit-skill	91	4	1	nec		2	2	ease		-60	-60	gethit-skill	92	9	6	swing2		10	10	dmg%		150	220	att/lvl	10																				0
-Buriza-Do Kyanon	198	100	1			1		59	41	8hx	Balista		5	5000				invhxbu				pierce		100	100	dex		35	35	ac		75	150	dmg/lvl	20			swing2		80	80	dmg%		150	200	freeze		3	3	dmg-cold	200	32	196																		0
-Demon Machine	199	100	1			1		57	49	8rx	Chu-Ko-Nu		5	5000	blac	blac		invrxbu				ac		321	321	mana		36	36	pierce		66	66	explosivearrow		6	6	dmg-max		66	66	dmg%		123	123	att		632	632																						0
+Blackbog's Sharp	170	100	1			1	1	46	38	9kr	Cinquedeas		5	5000				invkrsu				slow		50	50	ac		50	50	dmg-norm		15	45	swing3		30	30	dmg-pois	250	500	500	skill	73	5	5	skill	83	4	4	skill	92	4	4																		0
+Stormspike	171	100	1			1	1	49	41	9bl	Stilleto		5	5000	cblu	cblu		inv9blu				dmg-ltng		1	120	light-thorns		20	20	gethit-skill	38	25	3	dmg%		150	150	res-ltng/lvl	8																																0
+The Impaler	172	100	1			1	1	39	31	9sr	War Spear		5	5000	lred	lred						ignore-ac		1	1	att		150	150	swing2		20	20	openwounds		40	40	noheal		1	1	dmg%		140	170	skill	19	5	5	skill	14	3	3																		0
+Kelpie Snare	173	100	1			1	1	41	33	9tr	Fuscina		5	5000				invtriu				slow		75	75	res-fire		50	50	hp/lvl	10			dmg-norm		30	50	str		10	10	dmg%		140	180																										0
+Soulfeast Tine	174	100	1			1	1	43	35	9br	War Fork		5	5000	lyel	lyel		inv9bru				ease		-20	-20	lifesteal		7	7	manasteal		7	7	stamdrain		20	20	dmg%		150	190	att		150	250	dur		15	15																						0
+Hone Sundan	175	100	1			1	1	45	37	9st	Yari		5	5000								sock	3			dmg-norm		20	40	crush		45	45	rep-dur	10			dmg%		160	200																														0
+Spire of Honor	176	100	1			1	1	47	39	9p9	Lance		5	5000	lgry	lgry						att%		25	25	light		3	3	regen		20	20	balance2		20	20	dmg-norm		20	40	dmg-dem/lvl	12			dmg%		150	200	skilltab	9	3	3	ac%		25	25														0
+The Meat Scraper	177	100	1			1	1	49	41	9b7	Lochaber Axe		5	5000	dred	dred						dmg%		150	200	swing2		30	30	lifesteal		10	10	openwounds		50	50	mag%		25	25	skilltab	13	3	3																										0
+Blackleach Blade	178	100	1			1	1	50	42	9vo	Bill		5	5000	blac	blac						ease		-25	-25	hit-skill	72	5	5	light		-2	-2	lifesteal		8	8	dmg/lvl	10			dmg%		100	140																										0
+Athena's Wrath	179	100	1			1	1	50	42	9s8	Battle Scythe		5	5000				inv9s8u				dru		1	3	dex		15	15	swing2		30	30	hp/lvl	8			dmg/lvl	8			dmg%		150	180																										0
+Pierre Tombale Couant	180	100	1			1	1	51	43	9pa	Partizan		5	5000	lgld	lgld						deadly		55	55	bar		3	3	balance2		30	30	manasteal		6	6	dmg-norm		12	20	dmg%		160	220	att		100	200																						0
+Husoldal Evo	181	100	1			1	1	52	44	9h9	Bec-de-Corbin		5	5000								regen		20	20	att		200	250	noheal		1	1	dmg-norm		20	32	dmg%		160	200	swing2		20	20																										0
+Grim's Burning Dead	182	100	1			1	1	52	45	9wc	Grim Scythe		5	5000	cred	cred						dmg-fire		131	232	res-fire		45	45	dmg%		140	180	thorns		8	8	ease		-50	-50	nec		3	3	reduce-ac		50	50	ac%		20	20	att		200	250														0
+Razorswitch	183	100	1			1	1	36	28	8ss	Jo Stalf		5	5000	lpur							cast3		30	30	thorns		15	15	mana		175	175	hp		80	80	red-mag		15	15	res-all		50	50	allskills		1	1																						0
+Ribcracker	184	100	1			1	1	39	31	8ls	Quarterstaff		5	5000	lblu	lblu						dmg-norm		30	65	dmg%		200	300	crush		50	50	dex		15	15	ac		100	100	ac%		100	100	balance2		50	50	swing2		50	50	dur		100	100														0
+Chromatic Ire	185	100	1			1	1	43	35	8cs	Cedar Staff		5	5000				invcstu				sor		3	3	res-all		20	40	cast1		20	20	light-thorns		20	20	hp%		20	25	skill	61	1	1	skill	63	1	1	skill	65	1	1																		0
+Warpspear	186	100	1			1	1	47	39	8bs	Gothic Staff		5	5000	cblu	cblu						sor		3	3	ignore-ac		1	1	skill	54	3	3	skill	43	3	3	skill	58	3	3	ac-miss		250	250																										0
+Skullcollector	187	100	1			1	1	49	41	8ws	Rune Staff		5	5000	blac	blac		inv8wsu				mana%		20	20	mana-kill		20	20	allskills		2	2	mag%/lvl	8																																				0
+Skystrike	188	100	1			1	1	36	28	8sb	Edge Bow		5	5000								dmg-ltng		1	250	att		100	100	enr		10	10	swing3		30	30	dmg%		150	200	hit-skill	56	2	6	ama		1	1																						0
+Riphook	189	100	1			1	1	39	31	8hb	Razor Bow		5	5000	cred	cred						openwounds		30	30	dmg%		180	220	slow		30	30	mana		35	35	swing2		30	30	lifesteal		7	10																										0
+Kuko Shakaku	190	100	1			1	1	41	33	8lb	CedarBow		5	5000	lpur	lpur		inv8lbu				skill	27	3	3	explosivearrow		7	7	dmg%		150	180	pierce		50	50	dmg-fire		40	180	skilltab	0	3	3																										0
+Endlesshail	191	100	1			1	1	44	36	8cb	Double Bow		5	5000				invcbwu				res-cold		35	35	mana		40	40	ac-miss		50	50	skill	26	3	5	dmg%		180	220	dmg-cold	75	15	30																										0
+Whichwild String	192	100	1			1	1	47	39	8s8	Short Siege Bow		5	5000	lblu	lblu		inv8s8u				hit-skill	66	2	5	res-all		40	40	deadly/lvl	8			dmg%		150	170	magicarrow		20	20	sock	2																												0
+Cliffkiller	193	100	1			1	1	49	41	8l8	Long Siege Bow		5	5000	dgld							ama		2	2	dmg%		190	230	ac-miss		80	80	knock		1	1	hp		50	50	dmg-min		5	10	dmg-max		20	30																						0
+Magewrath	194	100	1			1	1	51	43	8sw	Rune Bow		5	5000	oran			invswbu				manasteal		15	15	red-mag		9	13	skill	22	3	3	att		200	250	dex		10	10	stupidity		1	1	dmg-norm		25	50	dmg%		120	150	ama		1	1														0
+Godstrike Arch	195	100	1			1	1	54	46	8lw	Gothic Bow		5	5000	lgry	lgry						dmg%		200	250	att%		100	150	dmg-undead		100	200	dmg-demon		100	200	hit-skill	121	5	7	swing2		50	50	regen		12	12																						0
+Langer Briser	196	100	1			1	1	40	32	8lx	Arbalest		5	5000				inv8lxu				knock		1	1	dmg%		170	200	mag%		30	60	hp		30	30	dmg-max		10	30	openwounds		33	33	dmg-ltng		1	212																						0
+Pus Spiter	197	100	1			1	1	44	36	8mx	Siege Crossbow		5	5000	cgrn	cgrn		inv8mxu				dmg-pois	200	192	192	hit-skill	91	4	1	nec		2	2	ease		-60	-60	gethit-skill	92	9	6	swing2		10	10	dmg%		150	220	att/lvl	10																				0
+Buriza-Do Kyanon	198	100	1			1	1	59	41	8hx	Balista		5	5000				invhxbu				pierce		100	100	dex		35	35	ac		75	150	dmg/lvl	20			swing2		80	80	dmg%		150	200	freeze		3	3	dmg-cold	200	32	196																		0
+Demon Machine	199	100	1			1	1	57	49	8rx	Chu-Ko-Nu		5	5000	blac	blac		invrxbu				ac		321	321	mana		36	36	pierce		66	66	explosivearrow		6	6	dmg-max		66	66	dmg%		123	123	att		632	632																						0
 Armor																																																																							0
-Peasent Crown	201	100	1			1		36	28	xap	War Hat		3	5000	lgry							enr		20	20	vit		20	20	allskills		1	1	move2		15	15	regen		6	12	ac%		100	100																										0
-Rockstopper	202	100	1			1		39	31	xkp	Sallet		3	5000				invxkpu				res-ltng		20	40	red-dmg%		10	10	balance2		30	30	ac%		160	220	res-fire		20	50	res-cold		20	40	vit		15	15																						0
-Stealskull	203	100	1			1		43	35	xlm	Casque		3	5000				invhlmu				manasteal		5	5	lifesteal		5	5	balance2		10	10	swing2		10	10	ac%		200	240	mag%		30	50																										0
-Darksight Helm	204	100	1			1		46	38	xhl	Basinet		3	5000	blac	blac		invfhlu				light		-4	-4	ac/lvl	16			nofreeze		1	1	manasteal		5	5	gethit-skill	71	6	3	charged	264	30	5	res-fire		20	40																						0
-Valkiry Wing	205	100	1			1		52	44	xhm	Winged Helm		3	5000	lgld							ac%		150	200	move2		20	20	balance2		20	20	ama		1	2	mana-kill		2	4																														0
-Crown of Thieves	206	100	1			1		57	49	xrn	Grand Crown		3	5000	dgld	dgld		invxrnu				dex		25	25	lifesteal		9	12	hp		50	50	mana		35	35	res-fire		33	33	ac%		160	200	gold%		80	100																						0
-Blackhorn's Face	207	100	1			1		49	41	xsk	Death Mask		3	5000	blac	blac						light-thorns		25	25	slow		20	20	noheal		1	1	abs-ltng		20	20	res-ltng		15	15	ac%		180	220																										0
-Vampiregaze	208	100	1			1		49	41	xh9	Grim Helm		3	5000	cgrn	cgrn		invbhmu				manasteal		6	8	lifesteal		6	8	stamdrain		15	15	red-dmg%		15	20	red-mag		10	15	ac%		100	100	dmg-cold	100	6	22																						0
-The Spirit Shroud	209	100	1			1		36	28	xui	Ghost Armor		3	5000								nofreeze		1	1	allskills		1	1	red-mag		7	11	regen		10	10	ac%		150	150																														0
-Skin of the Vipermagi	210	100	1			1		37	29	xea	SerpentSkin Armor		3	5000	dblu	dblu						ac%		120	120	res-all		20	35	cast3		30	30	red-mag		9	13	allskills		1	1																														0
-Skin of the Flayerd One	211	100	1			1		39	31	xla	Demonhide Armor		3	5000	lred	lred						rep-dur	10			regen		15	25	dur		30	30	lifesteal		5	7	ac%		150	190	thorns		15	15																										0
-Ironpelt	212	100	1			1		41	33	xtu	Tresllised Armor		3	5000	dgry	dgry		invxtuu				dur		125	125	hp		25	25	red-mag		10	16	red-dmg		15	20	ac/lvl	24			ac%		50	100																										0
-Spiritforge	213	100	1			1		43	35	xng	Linked Mail		3	5000								light		4	4	hp/lvl	10			dmg-fire		20	65	res-fire		5	5	ac%		120	160	str		15	15	sock	2																								0
+Peasent Crown	201	100	1			1	1	36	28	xap	War Hat		3	5000	lgry							enr		20	20	vit		20	20	allskills		1	1	move2		15	15	regen		6	12	ac%		100	100																										0
+Rockstopper	202	100	1			1	1	39	31	xkp	Sallet		3	5000				invxkpu				res-ltng		20	40	red-dmg%		10	10	balance2		30	30	ac%		160	220	res-fire		20	50	res-cold		20	40	vit		15	15																						0
+Stealskull	203	100	1			1	1	43	35	xlm	Casque		3	5000				invhlmu				manasteal		5	5	lifesteal		5	5	balance2		10	10	swing2		10	10	ac%		200	240	mag%		30	50																										0
+Darksight Helm	204	100	1			1	1	46	38	xhl	Basinet		3	5000	blac	blac		invfhlu				light		-4	-4	ac/lvl	16			nofreeze		1	1	manasteal		5	5	gethit-skill	71	6	3	charged	264	30	5	res-fire		20	40																						0
+Valkiry Wing	205	100	1			1	1	52	44	xhm	Winged Helm		3	5000	lgld							ac%		150	200	move2		20	20	balance2		20	20	ama		1	2	mana-kill		2	4																														0
+Crown of Thieves	206	100	1			1	1	57	49	xrn	Grand Crown		3	5000	dgld	dgld		invxrnu				dex		25	25	lifesteal		9	12	hp		50	50	mana		35	35	res-fire		33	33	ac%		160	200	gold%		80	100																						0
+Blackhorn's Face	207	100	1			1	1	49	41	xsk	Death Mask		3	5000	blac	blac						light-thorns		25	25	slow		20	20	noheal		1	1	abs-ltng		20	20	res-ltng		15	15	ac%		180	220																										0
+Vampiregaze	208	100	1			1	1	49	41	xh9	Grim Helm		3	5000	cgrn	cgrn		invbhmu				manasteal		6	8	lifesteal		6	8	stamdrain		15	15	red-dmg%		15	20	red-mag		10	15	ac%		100	100	dmg-cold	100	6	22																						0
+The Spirit Shroud	209	100	1			1	1	36	28	xui	Ghost Armor		3	5000								nofreeze		1	1	allskills		1	1	red-mag		7	11	regen		10	10	ac%		150	150																														0
+Skin of the Vipermagi	210	100	1			1	1	37	29	xea	SerpentSkin Armor		3	5000	dblu	dblu						ac%		120	120	res-all		20	35	cast3		30	30	red-mag		9	13	allskills		1	1																														0
+Skin of the Flayerd One	211	100	1			1	1	39	31	xla	Demonhide Armor		3	5000	lred	lred						rep-dur	10			regen		15	25	dur		30	30	lifesteal		5	7	ac%		150	190	thorns		15	15																										0
+Ironpelt	212	100	1			1	1	41	33	xtu	Tresllised Armor		3	5000	dgry	dgry		invxtuu				dur		125	125	hp		25	25	red-mag		10	16	red-dmg		15	20	ac/lvl	24			ac%		50	100																										0
+Spiritforge	213	100	1			1	1	43	35	xng	Linked Mail		3	5000								light		4	4	hp/lvl	10			dmg-fire		20	65	res-fire		5	5	ac%		120	160	str		15	15	sock	2																								0
 Crow Caw	214	100	1			1		45	37	xcl	Tigulated Mail		3	5000								openwounds		35	35	ac%		150	180	dex		15	15	balance2		15	15	swing2		15	15	charged	221	3	5																										0
-Shaftstop	215	100	1			1		46	38	xhn	Mesh Armor		3	5000	dgry							ac-miss		250	250	red-dmg%		30	30	hp		60	60	ac%		180	220																																		0
-Duriel's Shell	216	100	1			1		49	41	xrs	Cuirass		3	5000	oran	oran						str		15	15	ac/lvl	10			hp/lvl	8			ac%		160	200	res-fire		20	20	res-ltng		20	20	res-pois		20	20	res-cold		50	50	nofreeze		1	1	dur		100	100										0
-Skullder's Ire	217	100	1			1		50	42	xpl	Russet Armor		3	5000								allskills		1	1	mag%/lvl	10			ac%		160	200	dur		60	60	red-mag		10	10	rep-dur	20																												0
-Guardian Angel	218	100	1			1		53	45	xlt	Templar Coat		3	5000	lgry	lgry						light		4	4	pal		1	1	ac%		180	200	block2		30	30	res-all-max		15	15	att-dem/lvl	5			block		20	20																						0
-Toothrow	219	100	1			1		56	48	xld	Sharktooth Armor		3	5000	whit	whit						thorns		20	40	ac		40	60	str		10	10	openwounds		40	40	res-fire		15	15	ac%		160	220	dur		15	15																						0
-Atma's Wail	220	100	1			1		59	51	xth	Embossed Plate		3	5000								dex		15	15	regen		10	10	mana%		15	15	balance2		30	30	ac/lvl	16			dur		50	50	ac%		120	160	mag%		20	20																		0
-Black Hades	221	100	1			1		61	53	xul	Chaos Armor		3	5000								light		-2	-2	att-demon		200	250	half-freeze		1	1	sock	3			ac%		140	200	dmg-demon		30	60																										0
-Corpsemourn	222	100	1			1		63	55	xar	Ornate Armor		3	5000	blac	blac		invxaru				str		8	8	vit		10	10	res-cold		35	35	gethit-skill	76	6	2	ac%		150	180	dmg-fire		12	36	charged	74	40	5																						0
-Que-Hegan's Wisdon	223	100	1			1		59	51	xtp	Mage Plate		3	5000								cast2		20	20	mana-kill		3	3	red-mag		6	10	enr		15	15	balance2		20	20	ac%		140	160	allskills		1	1																						0
-Visceratuant	224	100	1			1		36	28	xuc	Defender		3	5000	dred			invbucu				sor		1	1	block2		30	30	block		30	30	ac%		100	150	light-thorns		10	10																														0
-Mosers Blessed Circle	225	100	1			1		39	31	xml	Round Shield		3	5000				invxmlu				res-all		25	25	block		25	25	sock	2			ac%		180	220	block2		30	30																														0
-Stormchaser	226	100	1			1		43	35	xrg	Scutum		3	5000	cblu	cblu		invxrgu				dmg-ltng		1	60	block		20	20	half-freeze		1	1	res-ltng		50	50	att		150	150	ac%		160	220	block2		10	10	gethit-skill	59	4	6	gethit-skill	245	4	5														0
-Tiamat's Rebuke	227	100	1			1		46	38	xit	Dragon Shield		3	5000	lgry	lgry		invkitu				dmg-cold	150	27	53	dmg-fire		35	95	dmg-ltng		1	120	res-all		25	35	ac%		140	200	gethit-skill	44	5	9	gethit-skill	48	5	7	gethit-skill	62	3	6	dur		40	40														0
-Kerke's Sanctuary	228	100	1			1		52	44	xow	Pavise		3	5000	lgrn	lgrn		invtowu				red-dmg		11	16	red-mag		14	18	regen		15	15	ac%		180	240	dur		100	100	block		30	30	res-all		20	30																						0
-Radimant's Sphere	229	100	1			1		58	50	xts	Ancient Shield		3	5000				invgtsu				dmg-pois	100	204	204	gethit-skill	92	5	5	res-pois		75	75	ac%		160	200	block		20	20	block2		20	20	charged	83	40	6	dur		20	20																		0
-Lidless Wall	230	100	1			1		49	41	xsh	Grim Shield		3	5000	dgld	dgld		invxshu				light		1	1	allskills		1	1	cast2		20	20	mana-kill		3	5	ac%		80	130	enr		10	10	mana%		10	10																						0
-Lance Guard	231	100	1			1		43	35	xpk	Barbed Shield		3	5000				invxpku				hp		50	50	balance2		30	30	dmg-to-mana		15	15	thorns		47	47	ac%		70	120	deadly		20	20																										0
-Venom Grip	232	100	1			1		37	29	xlg	Demonhide Gloves		5	5000	dgrn							res-pois		30	30	res-pois-max		5	5	dmg-pois	100	153	153	crush		5	5	lifesteal		5	5	ac		15	25	ac%		130	160																						0
-Gravepalm	233	100	1			1		39	32	xvg	Sharkskin Gloves		5	5000								enr		10	10	str		10	10	dmg-undead		100	200	att-undead		100	200	ac%		140	180																														0
-Ghoulhide	234	100	1			1		44	36	xmg	Heavy Bracers		5	5000								att-und/lvl	16			dmg-und/lvl	16			manasteal		4	5	hp		20	20	ac%		150	190																														0
-Lavagout	235	100	1			1		50	42	xtg	Battle Guantlets		5	5000	lyel							res-fire		24	24	half-freeze		1	1	hit-skill	52	2	10	swing2		20	20	ac%		150	200	dmg-fire		13	46	dur		20	20																						0
-Hellmouth	236	100	1			1		55	47	xhg	War Gauntlets		5	5000								dmg-fire		15	72	abs-fire		15	15	ac%		150	200	dur		15	15	hit-skill	56	2	4	hit-skill	225	4	12																										0
-Infernostride	237	100	1			1		37	29	xlb	Demonhide Boots		5	5000								dmg-fire		12	33	move2		20	20	res-fire-max		10	10	res-fire		30	30	light		2	2	ac%		120	150	gold%		40	70	ac		15	15	gethit-skill	46	5	8														0
-Waterwalk	238	100	1			1		40	32	xvb	Sharkskin Boots		5	5000								ac-miss		100	100	move2		20	20	dex		15	15	ac%		180	210	hp		45	65					res-fire-max		5	5	regen-stam		50	50																		0
-Silkweave	239	100	1			1		44	36	xmb	Mesh Boots		5	5000								ac%		150	190	mana-kill		5	5	ac-miss		200	200	mana%		10	10	move2		30	30																														0
-Wartraveler	240	100	1			1		50	42	xtb	Battle Boots		5	5000								vit		10	10	str		10	10	mag%		30	50	dur		30	30	move2		25	25	ac%		150	190	dmg-norm		15	25	thorns		5	10	stamdrain		40	40														0
-Gorerider	241	100	1			1		55	47	xhb	War Boots		5	5000	dred							ease		-25	-25	deadly		15	15	move2		30	30	crush		15	15	openwounds		10	10	ac%		160	200	dur		10	10																						0
-String of Ears	242	100	1			1		37	29	zlb	Demonhide Sash		5	5000	lred							red-mag		10	15	red-dmg%		10	15	lifesteal		6	8	ac%		150	180	ac		15	15	dur		10	10																										0
-Razortail	243	100	1			1		39	32	zvb	Sharkskin Belt		5	5000								thorns/lvl	8			dex		15	15	pierce		33	33	ac		15	15	ac%		120	150	dmg-max		10	10																										0
-Gloomstrap	244	100	1			1		45	36	zmb	Mesh Belt		5	5000								light		-3	-3	mana%		15	15	manasteal		5	5	ac%		120	150	vit		15	15	regen-mana		15	15																										0
-Snowclash	245	100	1			1		49	42	ztb	Battle Belt		5	5000								gethit-skill	59	5	0	abs-cold		15	15	res-cold-max		15	15	dmg-cold	75	13	21	ac%		130	170	skill	59	2	2	skill	55	3	3	skill	60	2	2																		0
-Thudergod's Vigor	246	100	1			1		55	47	zhb	War Belt		5	5000								gethit-skill	121	5	7	dmg-ltng		1	50	res-ltng-max		10	10	abs-ltng		20	20	ac%		160	200	vit		20	20	str		20	20	skill	34	3	3	skill	35	3	3														0
+Shaftstop	215	100	1			1	1	46	38	xhn	Mesh Armor		3	5000	dgry							ac-miss		250	250	red-dmg%		30	30	hp		60	60	ac%		180	220																																		0
+Duriel's Shell	216	100	1			1	1	49	41	xrs	Cuirass		3	5000	oran	oran						str		15	15	ac/lvl	10			hp/lvl	8			ac%		160	200	res-fire		20	20	res-ltng		20	20	res-pois		20	20	res-cold		50	50	nofreeze		1	1	dur		100	100										0
+Skullder's Ire	217	100	1			1	1	50	42	xpl	Russet Armor		3	5000								allskills		1	1	mag%/lvl	10			ac%		160	200	dur		60	60	red-mag		10	10	rep-dur	20																												0
+Guardian Angel	218	100	1			1	1	53	45	xlt	Templar Coat		3	5000	lgry	lgry						light		4	4	pal		1	1	ac%		180	200	block2		30	30	res-all-max		15	15	att-dem/lvl	5			block		20	20																						0
+Toothrow	219	100	1			1	1	56	48	xld	Sharktooth Armor		3	5000	whit	whit						thorns		20	40	ac		40	60	str		10	10	openwounds		40	40	res-fire		15	15	ac%		160	220	dur		15	15																						0
+Atma's Wail	220	100	1			1	1	59	51	xth	Embossed Plate		3	5000								dex		15	15	regen		10	10	mana%		15	15	balance2		30	30	ac/lvl	16			dur		50	50	ac%		120	160	mag%		20	20																		0
+Black Hades	221	100	1			1	1	61	53	xul	Chaos Armor		3	5000								light		-2	-2	att-demon		200	250	half-freeze		1	1	sock	3			ac%		140	200	dmg-demon		30	60																										0
+Corpsemourn	222	100	1			1	1	63	55	xar	Ornate Armor		3	5000	blac	blac		invxaru				str		8	8	vit		10	10	res-cold		35	35	gethit-skill	76	6	2	ac%		150	180	dmg-fire		12	36	charged	74	40	5																						0
+Que-Hegan's Wisdon	223	100	1			1	1	59	51	xtp	Mage Plate		3	5000								cast2		20	20	mana-kill		3	3	red-mag		6	10	enr		15	15	balance2		20	20	ac%		140	160	allskills		1	1																						0
+Visceratuant	224	100	1			1	1	36	28	xuc	Defender		3	5000	dred			invbucu				sor		1	1	block2		30	30	block		30	30	ac%		100	150	light-thorns		10	10																														0
+Mosers Blessed Circle	225	100	1			1	1	39	31	xml	Round Shield		3	5000				invxmlu				res-all		25	25	block		25	25	sock	2			ac%		180	220	block2		30	30																														0
+Stormchaser	226	100	1			1	1	43	35	xrg	Scutum		3	5000	cblu	cblu		invxrgu				dmg-ltng		1	60	block		20	20	half-freeze		1	1	res-ltng		50	50	att		150	150	ac%		160	220	block2		10	10	gethit-skill	59	4	6	gethit-skill	245	4	5														0
+Tiamat's Rebuke	227	100	1			1	1	46	38	xit	Dragon Shield		3	5000	lgry	lgry		invkitu				dmg-cold	150	27	53	dmg-fire		35	95	dmg-ltng		1	120	res-all		25	35	ac%		140	200	gethit-skill	44	5	9	gethit-skill	48	5	7	gethit-skill	62	3	6	dur		40	40														0
+Kerke's Sanctuary	228	100	1			1	1	52	44	xow	Pavise		3	5000	lgrn	lgrn		invtowu				red-dmg		11	16	red-mag		14	18	regen		15	15	ac%		180	240	dur		100	100	block		30	30	res-all		20	30																						0
+Radimant's Sphere	229	100	1			1	1	58	50	xts	Ancient Shield		3	5000				invgtsu				dmg-pois	100	204	204	gethit-skill	92	5	5	res-pois		75	75	ac%		160	200	block		20	20	block2		20	20	charged	83	40	6	dur		20	20																		0
+Lidless Wall	230	100	1			1	1	49	41	xsh	Grim Shield		3	5000	dgld	dgld		invxshu				light		1	1	allskills		1	1	cast2		20	20	mana-kill		3	5	ac%		80	130	enr		10	10	mana%		10	10																						0
+Lance Guard	231	100	1			1	1	43	35	xpk	Barbed Shield		3	5000				invxpku				hp		50	50	balance2		30	30	dmg-to-mana		15	15	thorns		47	47	ac%		70	120	deadly		20	20																										0
+Venom Grip	232	100	1			1	1	37	29	xlg	Demonhide Gloves		5	5000	dgrn							res-pois		30	30	res-pois-max		5	5	dmg-pois	100	153	153	crush		5	5	lifesteal		5	5	ac		15	25	ac%		130	160																						0
+Gravepalm	233	100	1			1	1	39	32	xvg	Sharkskin Gloves		5	5000								enr		10	10	str		10	10	dmg-undead		100	200	att-undead		100	200	ac%		140	180																														0
+Ghoulhide	234	100	1			1	1	44	36	xmg	Heavy Bracers		5	5000								att-und/lvl	16			dmg-und/lvl	16			manasteal		4	5	hp		20	20	ac%		150	190																														0
+Lavagout	235	100	1			1	1	50	42	xtg	Battle Guantlets		5	5000	lyel							res-fire		24	24	half-freeze		1	1	hit-skill	52	2	10	swing2		20	20	ac%		150	200	dmg-fire		13	46	dur		20	20																						0
+Hellmouth	236	100	1			1	1	55	47	xhg	War Gauntlets		5	5000								dmg-fire		15	72	abs-fire		15	15	ac%		150	200	dur		15	15	hit-skill	56	2	4	hit-skill	225	4	12																										0
+Infernostride	237	100	1			1	1	37	29	xlb	Demonhide Boots		5	5000								dmg-fire		12	33	move2		20	20	res-fire-max		10	10	res-fire		30	30	light		2	2	ac%		120	150	gold%		40	70	ac		15	15	gethit-skill	46	5	8														0
+Waterwalk	238	100	1			1	1	40	32	xvb	Sharkskin Boots		5	5000								ac-miss		100	100	move2		20	20	dex		15	15	ac%		180	210	hp		45	65					res-fire-max		5	5	regen-stam		50	50																		0
+Silkweave	239	100	1			1	1	44	36	xmb	Mesh Boots		5	5000								ac%		150	190	mana-kill		5	5	ac-miss		200	200	mana%		10	10	move2		30	30																														0
+Wartraveler	240	100	1			1	1	50	42	xtb	Battle Boots		5	5000								vit		10	10	str		10	10	mag%		30	50	dur		30	30	move2		25	25	ac%		150	190	dmg-norm		15	25	thorns		5	10	stamdrain		40	40														0
+Gorerider	241	100	1			1	1	55	47	xhb	War Boots		5	5000	dred							ease		-25	-25	deadly		15	15	move2		30	30	crush		15	15	openwounds		10	10	ac%		160	200	dur		10	10																						0
+String of Ears	242	100	1			1	1	37	29	zlb	Demonhide Sash		5	5000	lred							red-mag		10	15	red-dmg%		10	15	lifesteal		6	8	ac%		150	180	ac		15	15	dur		10	10																										0
+Razortail	243	100	1			1	1	39	32	zvb	Sharkskin Belt		5	5000								thorns/lvl	8			dex		15	15	pierce		33	33	ac		15	15	ac%		120	150	dmg-max		10	10																										0
+Gloomstrap	244	100	1			1	1	45	36	zmb	Mesh Belt		5	5000								light		-3	-3	mana%		15	15	manasteal		5	5	ac%		120	150	vit		15	15	regen-mana		15	15																										0
+Snowclash	245	100	1			1	1	49	42	ztb	Battle Belt		5	5000								gethit-skill	59	5	0	abs-cold		15	15	res-cold-max		15	15	dmg-cold	75	13	21	ac%		130	170	skill	59	2	2	skill	55	3	3	skill	60	2	2																		0
+Thudergod's Vigor	246	100	1			1	1	55	47	zhb	War Belt		5	5000								gethit-skill	121	5	7	dmg-ltng		1	50	res-ltng-max		10	10	abs-ltng		20	20	ac%		160	200	vit		20	20	str		20	20	skill	34	3	3	skill	35	3	3														0
 Elite Uniques																																																																							0
-Harlequin Crest	248	100	1			1		69	62	uap	Shako		3	5000	cgrn	cgrn						allskills		2	2	hp/lvl	12			mana/lvl	12			mag%		50	50	red-dmg%		10	10	str		2	2	dex		2	2	vit		2	2	enr		2	2														0
-Veil of Steel	249	100	1			1		77	73	uhm	Spired Helm		3	5000	lgry	lgry						res-all		50	50	ac%		60	60	str		15	15	vit		15	15	light		-4	-4	dur		20	20	ac		140	140																						0
-The Gladiator's Bane	250	100	1			1		85	85	utu	Wire Fleece		3	5000	lgry	lgry						ac%		150	200	red-mag		15	20	red-dmg		15	20	thorns		20	20	res-pois-len		50	50	dur		103	103	balance2		30	30	ac		50	50	nofreeze		1	1														0
-Arkaine's Valor	251	100	1			1		85	85	upl	Balrog Skin		3	5000	lred	lred						ac%		150	180	balance2		30	30	allskills		1	2	red-dmg		10	15	vit/lvl	4																																0
-Blackoak Shield	252	100	1			1		67	61	uml	Luna		3	5000				invsmlu				dex/lvl	4			ac%		160	200	abs-cold/lvl	5			gethit-skill	72	4	5	dur		45	45	hp/lvl	10			block2		50	50	half-freeze		1	1																		0
-Stormshield	253	100	1			1		77	73	uit	Monarch		3	5000				invkitu				ac/lvl	30			red-dmg%		35	35	str		30	30	indestruct		1	1	block2		35	35	res-ltng		25	25	block		25	25	res-cold		60	60	light-thorns		10	10														0
-Hellslayer	254	100	1			1		71	66	7bt	Decapitator		5	5000	dred	dred		invbtxu				str/lvl	4			vit/lvl	4			dmg%/lvl	24			dmg-fire		150	250	hp		25	25	dmg%		100	100	att-skill	47	10	0																						0
-Messerschmidt's Reaver	255	100	1			1		75	70	7ga	Champion Axe		5	5000	blac	blac		invgaxu				dmg%/lvl	20			dmg%		200	200	str		15	15	dex		15	15	vit		15	15	enr		15	15	dmg-fire		20	240	dur		25	25	att%		100	100														0
-Baranar's Star	256	100	1			1		70	65	7mt	Devil Star		5	5000	lred	lred		invmstu				att%		200	200	dmg%		200	200	dex		15	15	str		15	15	swing2		50	50	dur		100	100	dmg-ltng		1	200	dmg-fire		1	200	dmg-cold		1	200														0
-Schaefer's Hammer	257	100	1			1		83	79	7wh	Legendary Mallet		5	5000	lblu	lblu						hit-skill	42	20	10	hp		50	50	att/lvl	16			res-ltng		75	75	swing2		20	20	dmg/lvl	16			indestruct		1	1	dmg%		100	130	light		1	1	dmg-ltng		50	200										0
-The Cranium Basher	258	100	1			1		85	87	7gm	Thunder Maul		5	5000	blac	blac						swing2		20	20	indestruct		1	1	str		25	25	res-all		25	25	crush		75	75	dmg-norm		20	20	dmg%		200	240	hit-skill	66	4	1																		0
-Lightsabre	259	100	1			5		66	58	7cr	Phase Blade		5	5000	lblu			invcrsu				light		7	7	att-skill	53	5	0	ignore-ac	1	1	1	abs-ltng%		25	25	swing2		20	20	dmg-mag		60	120	dmg-ltng		1	200	manasteal		5	7	dmg%		150	200	dmg-norm		10	30										0
-Doombringer	260	100	1			1		75	69	7b7	Champion Sword		5	5000	dred	dred		invbswu				hp%		20	20	dmg%		180	250	att%		40	40	indestruct		1	1	dmg-norm		30	100	hit-skill	72	8	3	lifesteal		5	7																						0
-The Grandfather	261	100	1			1		85	81	7gd	Colossus Blade		5	5000	lyel	lyel		invgsdu				str		20	20	dex		20	20	vit		20	20	enr		20	20	att%		50	50	hp		80	80	dmg/lvl	20			indestruct		1	1	dmg%		150	250														0
-Wizardspike	262	100	1			1		69	61	7dg	Bone Knife		5	5000	lgry	lgry						mana/lvl	16			regen-mana		15	15	mana%		15	15	res-all		75	75	indestruct		1	1	cast3		50	50																										0
-Constricting Ring	263	100	0			1		95	95	rin	Ring		5	5000	cblu	cblu						res-all		100	100	regen		-30	-30	mag%		100	100	res-all-max		15	15										0																								0
-Stormspire	264	100	1			1		78	70	7wc	Giant Thresher		5	5000	dblu	dblu						res-ltng		50	50	gethit-skill	53	5	5	dmg%		150	250	str		10	10	gethit-skill	38	2	0	swing2		30	30	indestruct		1	1	dmg-ltng		1	237	light-thorns		27	27														0
-Eaglehorn	265	100	1			1		77	69	6l7	Crusader Bow		5	5000	dgld	dgld						ignore-ac		1	1	att/lvl	12			dmg%/lvl	16			dmg%		200	200	ama		1	1	dex		25	25																										0
-Windforce	266	100	1			1		80	73	6lw	Hydra Bow		5	5000	dyel	dyel						dex		5	5	dmg/lvl	25			regen-stam		30	30	manasteal		6	8	knock		1	1	dmg%		250	250	swing2		20	20	str		10	10																		0
+Harlequin Crest	248	100	1			1	1	69	62	uap	Shako		3	5000	cgrn	cgrn						allskills		2	2	hp/lvl	12			mana/lvl	12			mag%		50	50	red-dmg%		10	10	str		2	2	dex		2	2	vit		2	2	enr		2	2														0
+Veil of Steel	249	100	1			1	1	77	73	uhm	Spired Helm		3	5000	lgry	lgry						res-all		50	50	ac%		60	60	str		15	15	vit		15	15	light		-4	-4	dur		20	20	ac		140	140																						0
+The Gladiator's Bane	250	100	1			1	1	85	85	utu	Wire Fleece		3	5000	lgry	lgry						ac%		150	200	red-mag		15	20	red-dmg		15	20	thorns		20	20	res-pois-len		50	50	dur		103	103	balance2		30	30	ac		50	50	nofreeze		1	1														0
+Arkaine's Valor	251	100	1			1	1	85	85	upl	Balrog Skin		3	5000	lred	lred						ac%		150	180	balance2		30	30	allskills		1	2	red-dmg		10	15	vit/lvl	4																																0
+Blackoak Shield	252	100	1			1	1	67	61	uml	Luna		3	5000				invsmlu				dex/lvl	4			ac%		160	200	abs-cold/lvl	5			gethit-skill	72	4	5	dur		45	45	hp/lvl	10			block2		50	50	half-freeze		1	1																		0
+Stormshield	253	100	1			1	1	77	73	uit	Monarch		3	5000				invkitu				ac/lvl	30			red-dmg%		35	35	str		30	30	indestruct		1	1	block2		35	35	res-ltng		25	25	block		25	25	res-cold		60	60	light-thorns		10	10														0
+Hellslayer	254	100	1			1	1	71	66	7bt	Decapitator		5	5000	dred	dred		invbtxu				str/lvl	4			vit/lvl	4			dmg%/lvl	24			dmg-fire		150	250	hp		25	25	dmg%		100	100	att-skill	47	10	0																						0
+Messerschmidt's Reaver	255	100	1			1	1	75	70	7ga	Champion Axe		5	5000	blac	blac		invgaxu				dmg%/lvl	20			dmg%		200	200	str		15	15	dex		15	15	vit		15	15	enr		15	15	dmg-fire		20	240	dur		25	25	att%		100	100														0
+Baranar's Star	256	100	1			1	1	70	65	7mt	Devil Star		5	5000	lred	lred		invmstu				att%		200	200	dmg%		200	200	dex		15	15	str		15	15	swing2		50	50	dur		100	100	dmg-ltng		1	200	dmg-fire		1	200	dmg-cold		1	200														0
+Schaefer's Hammer	257	100	1			1	1	83	79	7wh	Legendary Mallet		5	5000	lblu	lblu						hit-skill	42	20	10	hp		50	50	att/lvl	16			res-ltng		75	75	swing2		20	20	dmg/lvl	16			indestruct		1	1	dmg%		100	130	light		1	1	dmg-ltng		50	200										0
+The Cranium Basher	258	100	1			1	1	85	87	7gm	Thunder Maul		5	5000	blac	blac						swing2		20	20	indestruct		1	1	str		25	25	res-all		25	25	crush		75	75	dmg-norm		20	20	dmg%		200	240	hit-skill	66	4	1																		0
+Lightsabre	259	100	1			5	1	66	58	7cr	Phase Blade		5	5000	lblu			invcrsu				light		7	7	att-skill	53	5	0	ignore-ac	1	1	1	abs-ltng%		25	25	swing2		20	20	dmg-mag		60	120	dmg-ltng		1	200	manasteal		5	7	dmg%		150	200	dmg-norm		10	30										0
+Doombringer	260	100	1			1	1	75	69	7b7	Champion Sword		5	5000	dred	dred		invbswu				hp%		20	20	dmg%		180	250	att%		40	40	indestruct		1	1	dmg-norm		30	100	hit-skill	72	8	3	lifesteal		5	7																						0
+The Grandfather	261	100	1			1	1	85	81	7gd	Colossus Blade		5	5000	lyel	lyel		invgsdu				str		20	20	dex		20	20	vit		20	20	enr		20	20	att%		50	50	hp		80	80	dmg/lvl	20			indestruct		1	1	dmg%		150	250														0
+Wizardspike	262	100	1			1	1	69	61	7dg	Bone Knife		5	5000	lgry	lgry						mana/lvl	16			regen-mana		15	15	mana%		15	15	res-all		75	75	indestruct		1	1	cast3		50	50																										0
+Constricting Ring	263	100	0			1	1	95	95	rin	Ring		5	5000	cblu	cblu						res-all		100	100	regen		-30	-30	mag%		100	100	res-all-max		15	15										0																								0
+Stormspire	264	100	1			1	1	78	70	7wc	Giant Thresher		5	5000	dblu	dblu						res-ltng		50	50	gethit-skill	53	5	5	dmg%		150	250	str		10	10	gethit-skill	38	2	0	swing2		30	30	indestruct		1	1	dmg-ltng		1	237	light-thorns		27	27														0
+Eaglehorn	265	100	1			1	1	77	69	6l7	Crusader Bow		5	5000	dgld	dgld						ignore-ac		1	1	att/lvl	12			dmg%/lvl	16			dmg%		200	200	ama		1	1	dex		25	25																										0
+Windforce	266	100	1			1	1	80	73	6lw	Hydra Bow		5	5000	dyel	dyel						dex		5	5	dmg/lvl	25			regen-stam		30	30	manasteal		6	8	knock		1	1	dmg%		250	250	swing2		20	20	str		10	10																		0
 Rings																																																																							0
-Bul Katho's Wedding Band	268	100	1			1		66	58	rin	Ring		5	5000	dpur	dpur						hp/lvl	4			allskills		1	1	lifesteal		3	5																																						0
-The Cat's Eye	269	100	1			5		58	50	amu	Amulet		5	5000	oran	oran						move2		30	30	swing2		20	20	ac		100	100	ac-miss		100	100	dex		25	25																														0
-The Rising Sun	270	100	1			5		73	65	amu	Amulet		5	5000	lgld	lgld						abs-fire/lvl	6			light		4	4	gethit-skill	56	2	0	dmg-fire		24	48	fireskill		2	2	regen		10	10																										0
-Crescent Moon	271	100	1			5		58	50	amu	Amulet		5	5000	lblu	lblu						manasteal		11	15	red-mag		10	10	dmg-to-mana		10	10	light		-2	-2	mana		45	45	lifesteal		3	6																										0
-Mara's Kaleidoscope	272	100	1			5		80	67	amu	Amulet		5	5000	oran	oran						allskills		2	2	res-all		20	30	str		5	5	dex		5	5	vit		5	5	enr		5	5																										0
-Atma's Scarab	273	100	1			5		60	60	amu	Amulet		5	5000	cgrn	cgrn						dmg-pois	100	102	102	res-pois		75	75	light		3	3	thorns		5	5	hit-skill	66	5	2	att%		20	20	mag%		15	30	res-all		10	15																		0
-Dwarf Star	274	100	1			10		53	45	rin	Ring		5	5000	dgry	dgry						gold%		100	100					regen-stam		15	15	hp		40	40	red-mag		12	15	abs-fire%		15	15																										0
-Raven Frost	275	100	1			10		53	45	rin	Ring		5	5000	cblu	cblu						nofreeze		1	1	dmg-cold	100	15	45	abs-cold%		20	20	mana		40	40	dex		15	20	att		150	250																										0
-Highlord's Wrath	276	100	1			5		73	65	amu	Amulet		5	5000	bwht	bwht						res-ltng		35	35	dmg-ltng		1	30	swing2		20	20	allskills		1	1	deadly/lvl	3			light-thorns		15	15																										0
-Saracen's Chance	277	100	1			5		55	47	amu	Amulet		5	5000	dpur	dpur						res-all		15	25	gethit-skill	76	10	2	str		12	12	dex		12	12	enr		12	12	vit		12	12																										0
+Bul Katho's Wedding Band	268	100	1			1	1	66	58	rin	Ring		5	5000	dpur	dpur						hp/lvl	4			allskills		1	1	lifesteal		3	5																																						0
+The Cat's Eye	269	100	1			5	1	58	50	amu	Amulet		5	5000	oran	oran						move2		30	30	swing2		20	20	ac		100	100	ac-miss		100	100	dex		25	25																														0
+The Rising Sun	270	100	1			5	1	73	65	amu	Amulet		5	5000	lgld	lgld						abs-fire/lvl	6			light		4	4	gethit-skill	56	2	0	dmg-fire		24	48	fireskill		2	2	regen		10	10																										0
+Crescent Moon	271	100	1			5	1	58	50	amu	Amulet		5	5000	lblu	lblu						manasteal		11	15	red-mag		10	10	dmg-to-mana		10	10	light		-2	-2	mana		45	45	lifesteal		3	6																										0
+Mara's Kaleidoscope	272	100	1			5	1	80	67	amu	Amulet		5	5000	oran	oran						allskills		2	2	res-all		20	30	str		5	5	dex		5	5	vit		5	5	enr		5	5																										0
+Atma's Scarab	273	100	1			5	1	60	60	amu	Amulet		5	5000	cgrn	cgrn						dmg-pois	100	102	102	res-pois		75	75	light		3	3	thorns		5	5	hit-skill	66	5	2	att%		20	20	mag%		15	30	res-all		10	15																		0
+Dwarf Star	274	100	1			10	1	53	45	rin	Ring		5	5000	dgry	dgry						gold%		100	100					regen-stam		15	15	hp		40	40	red-mag		12	15	abs-fire%		15	15																										0
+Raven Frost	275	100	1			10	1	53	45	rin	Ring		5	5000	cblu	cblu						nofreeze		1	1	dmg-cold	100	15	45	abs-cold%		20	20	mana		40	40	dex		15	20	att		150	250																										0
+Highlord's Wrath	276	100	1			5	1	73	65	amu	Amulet		5	5000	bwht	bwht						res-ltng		35	35	dmg-ltng		1	30	swing2		20	20	allskills		1	1	deadly/lvl	3			light-thorns		15	15																										0
+Saracen's Chance	277	100	1			5	1	55	47	amu	Amulet		5	5000	dpur	dpur						res-all		15	25	gethit-skill	76	10	2	str		12	12	dex		12	12	enr		12	12	vit		12	12																										0
 Class Specific																																																																							0
-Arreat's Face	279	100	1			1		50	42	baa	Slayer Guard		5	5000								bar		2	2	skilltab	12	2	2	ac%		150	200	balance2		30	30	att%		20	20	str		20	20	dex		20	20	lifesteal		3	6	res-all		30	30														0
-Homunculus	280	100	1			1		50	42	nea	Heirophant Trophy		5	5000								nec		2	2	skilltab	6	2	2	ac%		150	200	block2		30	30	block		40	40	enr		20	20	regen-mana		33	33	mana-kill		5	5	res-all		40	40														0
-Titan's Revenge	281	100	1			1		50	42	ama	Ceremonial Javelin		5	5000								ama		2	2	skilltab	2	2	2	dmg%		150	200	move2		30	30	rep-quant	30			str		20	20	dex		20	20	lifesteal		5	9	dmg-norm		25	50	stack		60	60										0
-Lycander's Aim	282	100	1			1		50	42	am7	Ceremonial Bow		5	5000								ama		2	2	skilltab	0	2	2	dmg%		150	200	swing2		20	20	ac%		20	20	dex		20	20	enr		20	20	manasteal		5	8	dmg-norm		25	50														0
-Lycander's Flank	283	100	1			1		50	42	am9	Ceremonial Pike		5	5000								ama		2	2	skilltab	2	2	2	dmg%		150	200	swing2		30	30	ac%		20	20	str		20	20	vit		20	20	lifesteal		5	9	dmg-norm		25	50														0
-The Oculus	284	100	1			1		50	42	oba	Swirling Crystal		5	5000								sor		3	3	gethit-skill	54	25	1	res-all		20	20	cast2		30	30	ac%		20	20	vit		20	20	enr		20	20	mana-kill		5	5	mag%		50	50														0
-Herald of Zakarum	285	100	1			1		50	42	pa9	Aerin Shield		5	5000								pal		2	2	skilltab	9	2	2	ac%		150	200	block2		30	30	block		30	30	str		20	20	vit		20	20	att%		20	20	res-all		50	50														0
-Cutthroat1	286	100	1			1		50	42	9tw	Runic Talons		5	5000								ass		2	2	skilltab	20	1	1	dmg%		150	200	balance2		30	30	att%		20	20	str		20	20	dex		20	20	lifesteal		5	9	dmg-norm		25	50														0
-Jalal's Mane	287	100	1			1		50	42	dra	Dream Spirit		5	5000								dru		2	2	skilltab	16	2	2	ac%		150	200	balance2		30	30	att%		20	20	str		20	20	enr		20	20	mana-kill		5	5	res-all		30	30														0
-The Scalper	288	100	1			1		65	57	9ta	Francisca		5	5000								rep-quant	30			dmg%		150	200	att%		25	25	swing2		20	20	openwounds		33	33	lifesteal		4	6	mana-kill		4	4																						0
-Bloodmoon	289	100	1			1		69	61	7sb	elegant blade		5	5000	cred	cred		invsbru				dmg%		210	260	lifesteal		10	15	charged	BloodGolem	9	15	heal-kill		7	13	openwounds		50	50																														0
-Djinnslayer	290	100	1			1		73	65	7sm	ataghan		5	5000	dpur	dpur		invscmu				dmg%		190	240	dmg-fire		250	500	dmg-demon		100	150	att-demon		200	300	abs-ltng		3	7	manasteal		3	6	sock		1	2																						0
-Deathbit	291	100	1			1		52	44	9tk	battle dart		5	5000								deadly		40	40	dmg%		130	180	att		200	450	lifesteal		7	9	manasteal		4	6	rep-quant	25																												0
-Warshrike	292	100	1			1		83	75	7bk	winged knife		5	5000	bwht	bwht		invtk3				dmg%		200	250	pierce		50	50	swing2		30	30	deadly		50	50	rep-quant	30			hit-skill	Nova	25	9																										0
-Gutsiphon	293	100	1			1		79	71	6rx	demon crossbow		5	5000	lgrn	lgrn		invrxbu				dmg%		160	220	pierce		33	33	lifesteal		12	18	slow		25	25	openwounds		33	33																														0
-Razoredge	294	100	1			1		75	67	7ha	tomahawk		5	5000	lblu			invhaxu				dmg%		175	225	swing2		40	40	reduce-ac		33	33	deadly		50	50	openwounds		50	50																														0
-Gore Ripper	295	100				1							5	5000	dred	dred																																																							0
-Demonlimb	296	100	1			1		71	63	7sp	tyrant club		5	5000	dgrn	dgrn		invspcu				dmg%		180	230	dmg-fire		222	333	lifesteal		7	13	charged	Enchant	20	23	rep-dur	5			dmg-demon		123	123	res-fire		15	20																						0
-Steelshade	297	100	1			1		70	62	ulm	armet		5	5000	blac	blac		invhlmu				ac%		100	130	abs-fire		5	11	manasteal		4	8	regen		10	18																																		0
-Tomb Reaver	298	100	1			1		86	84	7pa	cryptic axe		5	5000	lyel	lyel						swing2		60	60	light		4	4	dmg%		200	280	dmg-undead		150	230	mag%		50	80	res-all		30	50	att-undead		250	350	reanimate	1	10	10	heal-kill		10	14	sock		1	3										0
-Deaths's Web	299	100	1			1		74	66	7gw	unearthed wand		5	5000	bwht	bwht						allskills		2	2	pierce-pois		40	50	heal-kill		7	12	mana-kill		7	12	skilltab	7	1	2																														0
-Nature's Peace	300	100	1			3		77	69	rin	ring		5	5000	dgrn	dgrn						noheal		1	1	rip		1	1	red-dmg		7	11	res-pois		20	30	charged	Oak Sage	27	5																														0
-Azurewrath	301	100	1			1		87	85	7cr	phase blade		5	5000	lgry			invcrs				dmg-mag		250	500	dmg%		230	270	aura	Sanctuary	10	13	dmg-cold	250	250	500	swing2		30	30	all-stats		5	10	light		3	3	allskills		1	1																		0
-Seraph's Hymn	302	100	1			3		73	65	amu	amulet		5	5000	bwht	bwht		invamu2				allskills		2	2	skilltab	11	1	2	dmg-demon		25	50	dmg-undead		25	50	att-demon		150	250	att-undead		150	250	light		2	2																						0
-Zakarum's Salvation	303	100				1							5	5000																																																									0
-Fleshripper	304	100	1			1		76	68	7kr	fanged knife		5	5000	dred	dred		invkrsu				dmg%		200	300	reduce-ac		50	50	noheal		1	1	crush		25	25	openwounds		50	50	deadly		33	33	slow		20	20																						0
-Odium	305	100				1							5	5000	blac																																																								0
-Horizon's Tornado	306	100	1			5		72	64	7fl	scourge		5	5000	dpur	dpur						dmg%		230	280	swing2		50	50	slow		20	20	hit-skill	Tornado	20	15	ease		-20	-20																														0
-Stone Crusher	307	100	1			4		76	68	7wh	legendary mallet		5	5000	whit							dmg%		280	320	str		20	30	crush		40	40	reduce-ac		25	25	dmg-ac		-100	-100	dmg		10	30																										0
-Jadetalon	308	100	1			1		74	66	7wb	wrist sword		5	5000	cgrn	cgrn						dmg%		190	240	manasteal		10	15	res-all		40	50	balance2		30	30	skilltab	19	1	2	skilltab	20	1	2																										0
-Shadowdancer	309	100	1			1		79	71	uhb	myrmidon greaves		5	5000	blac	blac						ac%		70	100	move2		30	30	balance2		30	30	dex		15	25	skilltab	19	1	2	ease		-20	-20																										0
-Cerebus	310	100	1			1		71	63	drb	blood spirit		5	5000	bwht	bwht						ac%		130	140	skilltab	16	2	4	lifesteal		7	10	att%		60	120	openwounds		33	33	skill	feral rage	1	2																										0
-Tyrael's Might	311	100	1			1		87	84	uar	sacred armor		5	5000	dblu	dblu		invaaru				ease		-100	-100	indestruct		1	1	ac%		120	150	rip		1	1	dmg-demon		50	100	nofreeze		1	1	move2		20	20	res-all		20	30	str		20	30	allskills		1	1	aura	might	1	1						0
-Souldrain	312	100	1			1		82	74	umg	vambraces		5	5000	dred	dred						ac%		90	120	manasteal		4	7	lifesteal		4	7	hit-skill	Weaken	8	3	dmg-ac		-50	-50																														0
-Runemaster	313	100	1			1		80	72	72a	ettin axe		5	5000	lblu	lblu						dmg%		220	270	sock		3	5	res-cold-max		5	5	nofreeze		1	1																																		0
-Deathcleaver	314	100	1			1		78	70	7wa	berserker axe		5	5000	dred							dmg%		230	280	deadly		66	66	reduce-ac		33	33	swing2		40	40	heal-kill		6	9																														0
-Executioner's Justice	315	100	1			1		83	75	7gi	glorious axe		5	5000	blac	blac						dmg%		240	290	crush		25	25	reduce-ac		33	33	kill-skill	Decrepify	50	6	swing2		30	30																														0
-Stoneraven	316	100	1			1		72	64	amd	matriarchal spear		5	5000	dgry							dmg%		230	280	dmg-mag		101	187	res-all		30	50	ac		400	600	skilltab	2	1	3																														0
-Leviathan	317	100	1			1		73	65	uld	kraken shell		5	5000	cgrn	cgrn						ac%		170	200	ac		100	150	red-dmg%		15	25	str		40	50	indestruct		1	1																														0
-Larzuk's Champion	318	100				1							5	5000	lgry		flphmr	invhfh																																																					0
-Wisp	319	100	1			1		84	76	rin	ring		5	5000	bwht	bwht						abs-ltng%		10	20	hit-skill	Lightning	10	16	mag%		10	20	charged	Oak Sage	15	2	charged	Heart of Wolverine	13	5	charged	Spirit of Barbs	11	7																										0
-Gargoyle's Bite	320	100	1			1		78	70	7ts	winged harpoon		5	5000	cgrn	cgrn						dmg%		180	230	rep-quant	30			dmg-pois	250	300	300	lifesteal		9	15	charged	Plague Javelin	60	11																														0
-Lacerator	321	100	1			1		76	68	7b8	winged axe		5	5000	blac	blac						dmg%		150	210	rep-quant	25			swing2		30	30	noheal		1	1	openwounds		33	33	howl		64	64	hit-skill	Amplify Damage	33	3																						0
-Mang Song's Lesson	322	100	1			1		86	82	6ws	archon staff		5	5000	dgld	dgld		inv8wsu				allskills		5	5	pierce-fire		7	15	pierce-ltng		7	15	pierce-cold		7	15	regen-mana		10	10	cast2		30	30																										0
-Viperfork	323	100	1			1		79	71	7br	war fork		5	5000	dgrn	dgrn						dmg%		190	240	dmg-pois	250	333	333	swing2		50	50	att		200	250	hit-skill	Poison Explosion	15	9	res-pois		30	50																										0
-Ethereal Edge	324	100	1			1		82	74	7ba	silver-edged axe		5	5000	whit	whit						dmg%		150	180	swing2		25	25	abs-fire		10	12	dmg-demon		150	200	demon-heal		5	10	att		270	350	ethereal		1	1	indestruct		1	1																		0
-Demonhorn's Edge	325	100	1			1		69	61	bad	destroyer helm		5	5000	dgry	dgry						ac%		120	160	swing2		10	10	lifesteal		3	6	thorns		55	77	skilltab	12	1	3	skilltab	13	1	3	skilltab	14	1	3																						0
-The Reaper's Toll	326	100	1			1		83	75	7s8	thresher		5	5000				invscy				dmg%		190	240	hit-skill	Decrepify	33	1	ignore-ac		1	1	lifesteal		11	15	ease		-25	-25	deadly		33	33	dmg-cold		4	44																						0
-Spiritkeeper	327	100	1			1		75	67	drd	earth spirit		5	5000								ac%		170	190	balance2		20	20	abs-ltng		9	14	res-fire		30	40	abs-cold%		15	25	res-pois-max		10	10	dru		1	2																						0
-Hellrack	328	100	1			1		84	76	6hx	colossus crossbow		5	5000	cred			invhxbu				dmg%		180	230	dmg-elem	33	63	324	swing2		20	20	att%		100	150	sock		2	2	charged	Immolation Arrow	150	18																										0
-Alma Negra	329	100	1			1		85	77	pac	sacred rondache		5	5000	blac	blac						ac%		180	210	block2		30	30	pal		1	2	block		20	20	red-mag		5	9	att%		40	75	dmg%		40	75																						0
-Darkforge Spawn	330	100	1			1		72	64	nef	bloodlord skull		5	5000	cred	cred						ac%		140	180	cast2		30	30	mana%		10	10	skilltab	6	1	3	skilltab	7	1	3	skilltab	8	1	3																										0
-Widowmaker	331	100	1			1		73	65	6sw	ward bow		5	5000	dred	dred		invswbu				dmg%		150	200	deadly		33	33	ignore-ac		1	1	magicarrow		11	11	oskill	Guided Arrow	3	5																														0
-Bloodraven's Charge	332	100	1			1		79	71	amb	matriarchal bow		5	5000	dgld	dgld		invswbu				dmg%		180	230	att%		200	300	explosivearrow		13	13	skilltab	0	2	4	charged	Revive	30	5																														0
-Ghostflame	333	100	1			1		70	62	7bl	legend spike		5	5000	cblu	cblu						dmg%		190	240	ignore-ac		1	1	dmg-mag		108	108	manasteal		10	15	ethereal		1	1	indestruct		1	1	light		2	2																						0
-Shadowkiller	334	100	1			1		85	78	7cs	battle cestus		5	5000				invaxfu				dmg%		170	220	reduce-ac		25	25	freeze		2	2	mana-kill		10	15	hit-skill	Frost Nova	33	8	ethereal		1	1	indestruct		1	1																						0
-Gimmershred	335	100	1			1		78	70	7ta	flying axe		5	5000	lgrn							dmg%		160	210	dmg-fire		218	483	dmg-cold	100	176	397	dmg-ltng		29	501	stack		60	60	swing2		30	30																										0
-Griffon's Eye	336	100	1			1		84	76	ci3	diadem		5	5000								ac		100	200	cast2		25	25	allskills		1	1	extra-ltng		10	15	pierce-ltng		15	20																														0
-Windhammer	337	100	1			1		76	68	7m7	ogre maul		5	5000	cblu	cblu		invmau				dmg%		180	230	crush		50	50	swing2		60	60	hit-skill	Twister	33	22																																		0
-Thunderstroke	338	100	1			1		77	69	amf	matriarchal javelin		5	5000	dblu	dblu						dmg%		150	200	dmg-ltng		1	511	hit-skill	Lightning	20	14	swing2		15	15	pierce-ltng		15	15	skill	Lightning Bolt	3	3	skilltab	2	2	4																						0
-Giantmaimer	339	100				1							5	5000	cred	cred																																																							0
-Demon's Arch	340	100	1			1		76	68	7s7	balrog spear		5	5000	cred	cred						dmg%		160	210	dmg-fire		232	323	lifesteal		6	12	rep-quant	30			swing2		30	30	dmg-ltng		23	333																										0
-Boneflame	341	100	1			1		80	72	nee	succubae skull		3	5000	dred	dred						ac%		120	150	move2		20	20	gethit-skill	Terror	15	3	nec		2	3	res-all		20	30																														0
-Steelpillar	342	100	1			1		77	69	7p7	war pike		3	5000								dmg%		210	260	swing2		25	25	reduce-ac		20	20	ac%		50	80	indestruct		1	1	crush		25	25																										0
-Nightwing's Veil	343	100	1			1		75	67	uhm	spired helm		3	5000	cblu	cblu						ac%		90	120	allskills		2	2	dex		10	20	abs-cold		5	9	half-freeze		1	1	extra-cold		8	15	ease		-50	-50																						0
-Crown of Ages	344	100	1			1		86	82	urn	corona		3	5000	dgld	dgld						balance2		30	30	res-all		20	30	allskills		1	1	ac		100	150	indestruct		1	1	red-dmg%		10	15	ac%		50	50	sock		1	2																		0
-Andariel's Visage	345	100	1			1		85	83	usk	demonhead		3	5000	dred	dred						ac%		100	150	res-pois		70	70	allskills		2	2	res-pois-max		10	10	swing2		20	20	str		25	30	gethit-skill	92	15	15	charged	278	20	3	lifesteal		8	10	res-fire		-30	-30										0
-Darkfear	346	100				1				ulm	armet		5	5000	blac			invhlmu																																																					0
-Dragonscale	347	100	1			1		84	80	pae	zakarum shield		3	5000	dgrn	dgrn						ac%		170	200	abs-fire%		10	20	res-fire-max		5	5	str		15	25	dmg-fire		211	371	oskill	Hydra	10	10	extra-fire		15	15																						0
-Steel Carapice	348	100	1			1		74	66	uul	shadow plate		3	5000	dgry	dgry						ac%		190	220	balance2		20	20	red-dmg		9	14	res-cold		40	60	regen-mana		10	15	rep-dur	5			gethit-skill	Iron Maiden	8	6																						0
-Medusa's Gaze	349	100	1			1		84	76	uow	aegis		3	5000	lred	lred		invtowu				ac%		150	180	slow		20	20	gethit-skill	Lower Resist	10	7	lifesteal		5	9	death-skill	Nova	100	44	res-cold		40	80																										0
-Ravenlore	350	100	1			1		82	74	dre	sky spirit		3	5000	dgld	dgld						ac%		120	150	res-all		15	25	skilltab	17	3	3	enr		20	30	pierce-fire		10	20	skill	Raven	7	7																										0
-Boneshade	351	100	1			1		84	79	7bw	lich wand		3	5000	dgry	dgry		invbwnu				nec		2	2	cast2		25	25	skill	Teeth	4	5	skill	Bone Armor	4	5	skill	Bone Spear	2	3	skill	Bone Spirit	1	2	skill	Bone Wall	2	3																						0
-Nethercrow	352	100				1							3	5000	cblu	cblu																																																							0
-Flamebellow	353	100	1			1		79	71	7gs	balrog blade		3	5000	cred	cred		invgisu				dmg%		170	240	dmg-fire		233	482	fireskill		3	3	abs-fire%		20	30	hit-skill	Firestorm	12	16	str		10	20	vit		5	10	oskill	Inferno	12	18																		0
-Fathom	354	100	1			1		81	73	obf	dimensional shard		3	5000	lblu							sor		3	3	extra-cold		15	30	cast2		20	20	res-fire		25	40	res-ltng		25	40																														0
-Wolfhowl	355	100	1			1		85	79	bac	fury visor		3	5000	cred	cred						ac%		120	150	skilltab	14	2	3	str		8	15	dex		8	15	vit		8	15	oskill	Wearwolf	3	6	charged	Summon Fenris	18	15	oskill	Shape Shifting	3	6	oskill	Feral Rage	3	6														0
-Spirit Ward	356	100	1			1		76	68	uts	ward		3	5000	dblu	dblu		invgtsu				ac%		130	180	abs-cold		6	11	res-all		30	40	block		20	30	block2		25	25	gethit-skill	Fade	5	8																										0
-Kira's Guardian	357	100	1			1		85	77	ci2	tiara		3	5000	blac	blac						ac		50	120	res-all		50	70	nofreeze		1	1	balance2		20	20																																		0
-Ormus' Robes	358	100	1			1		83	75	uui	dusk shroud		3	5000	blac	blac						ac		10	20	cast2		20	20	extra-fire		10	15	extra-cold		10	15	extra-ltng		10	15	regen-mana		10	15	skill-rand	3	36	60																						0
-Gheed's Fortune	359	100	1			1		70	62	cm3	charm	1	3	5000	lgld							mag%		20	40	gold%		80	160	cheap		10	15																																						0
-Stormlash	360	100	1			1		86	82	7fl	scourge		3	5000	dgry	dgry						dmg%		240	300	swing2		30	30	hit-skill	Static Field	15	10	hit-skill	Tornado	20	18	dmg-ltng		1	473	light-thorns		30	30	crush		33	33	abs-ltng		3	9																		0
-Halaberd's Reign	361	100	1			1		85	77	bae	conqueror crown		3	5000								ac%		140	170	skilltab	13	1	1	bar		2	2	balance2		20	20	regen		15	23	skill	Battle Orders	1	2	skill	Battle Command	1	2																						0
-Warriv's Warder	362	100				1							3	5000																																																									0
-Spike Thorn	363	100	1			1		78	70	upk	blade barrier		5	5000	dyel	dyel		invspku				ac%		120	150	thorns/lvl	11			dur		250	250	balance2		30	30	red-dmg%		15	20	sock		1	1																										0
-Dracul's Grasp	364	100	1			1		84	76	uvg	vampirebone gloves		5	5000	dred	dred						ac%		90	120	lifesteal		7	10	openwounds		25	25	hit-skill	Life Tap	5	10	heal-kill		5	10	str		10	15																										0
-Frostwind	365	100	1			1		78	70	7ls	cryptic sword		5	5000	cblu	cblu		invlsdu				dmg%		180	230	freeze		4	4	half-freeze		1	1	dmg-cold	150	237	486	swing2		25	25	abs-cold%		7	15	oskill	Arctic Blast	7	14																						0
-Templar's Might	366	100	1			8		82	74	uar	sacred armor		5	5000	cgrn	cgrn		invaaru				ac%		170	220	balance2		20	20	ac-miss		250	300					str		10	15	vit		10	15	skilltab	10	1	2																						0
-Eschuta's temper	367	100	1			1		80	72	obc	eldritch orb		5	5000	cred							sor		1	3	cast2		40	40	extra-fire		10	20	extra-ltng		10	20	enr		20	30																														0
-Firelizard's Talons	368	100	1			1		75	67	7lw	feral claws		5	5000								dmg%		200	270	swing2		15	15	skilltab	20	1	3	dmg-fire		236	480	res-fire		40	70	skill	Wake of Fire Sentry	1	2	skill	Inferno Sentry	1	2																						0
-Sandstorm Trek	369	100	1			1		72	64	uvb	scarabshell boots		5	5000								ac%		140	170	move2		20	20	balance2		20	20	stam/lvl	8			stamdrain		50	50	res-pois		40	70	rep-dur	5			str		10	15	vit		10	15														0
-Marrowwalk	370	100	1			1		74	66	umb	boneweave boots		5	5000	dgry							ac%		170	200	move2		20	20	charged	Bone Prison	13	33	charged	Life Tap	10	12	regen-stam		10	10	regen-mana		10	10	half-freeze		1	1	str		10	20	dex		17	17	skill	Skeleton Mastery	1	2										0
-Heaven's Light	371	100	1			1		69	61	7sc	mighty scepter		5	5000	cblu	cblu						dmg%		250	300	swing2		20	20	reduce-ac		33	33	light		3	3	demon-heal		15	20	crush		33	33	sock		1	3	pal		2	3																		0
-Merman's Speed	372	100																																																																					0
-Arachnid Mesh	373	100	1			1		87	80	ulc	spiderweb sash		5	5000	blac	blac						ac%		90	120	cast2		20	20	charged	Venom	11	3	allskills		1	1	slow		10	10	mana%		5	5																										0
-Nosferatu's Coil	374	100	1			1		68	51	uvc	vampirefang belt		5	5000								str		15	15	mana-kill		2	2	slow		10	10	lifesteal		5	7	swing2		10	10	light		-3	-3																										0
-Metalgrid	375	100	1			2		85	81	amu	amulet		5	5000								ac		300	350	res-all		25	35	att		400	450	charged	IronGolem	11	22	charged	Iron Maiden	20	12																														0
-Verdugo's Hearty Cord	376	100	1			1		71	63	umc	mithril coil		5	5000	blac	blac						ac%		90	140	vit		30	40					balance2		10	10	red-dmg%		10	15	regen		10	13																										0
-Sigurd's Staunch	377	100				1							5	5000																																																									0
-Carrion Wind	378	100	1			3		67	60	rin	ring		3	5000								ac-miss		100	160	lifesteal		6	9	res-pois		55	55	gethit-skill	Poison Nova	10	10	charged	Plague Poppy	15	21	hit-skill	Twister	8	13	dmg-to-mana		10	10	dex		10	15																		0
-Giantskull	379	100	1			1		73	65	uh9	bone visage		3	5000	lgry	lgry		invbhm				ac		250	320	str		25	35	crush		10	10	sock		1	2	knock		1	1																														0
-Ironward	380	100	1			1		68	60	7ws	caduceus		3	5000	blac	blac						dmg%		240	290	slow		25	25	att%		150	200	swing2		10	10	dmg-mag		80	240	red-dmg		4	7	dmg		40	85	skilltab	9	2	4	crush		33	33														0
-Annihilus	381	100	1			1		110	70	cm1	charm	1	3	5000			flpmss	invmss	item_gem	12	item_gem	allskills		1	1	all-stats		10	20	res-all		10	20	addxp		5	10																																		0
-Arioc's Needle	382	100	1			1		85	81	7sr	hyperion spear		3	5000								dmg%		180	230	dmg-pois	250	403	403	deadly		50	50	ignore-ac		1	1	allskills		2	4	swing2		30	30																										0
-Cranebeak	383	100	1			1		71	63	7mp	war spike		3	5000	dgry			invmpiu				dmg%		240	300	dmg-ltng		1	305	swing2		40	40	reduce-ac		25	25	mag%		20	50	charged	Raven	15	8																										0
-Nord's Tenderizer	384	100	1			1		76	68	7cl	truncheon		3	5000				invclbu				dmg%		270	330	freeze		2	4	swing2		25	25	charged	Blizzard	12	16	att%		150	180	abs-cold%		5	15	dmg-cold	125	205	455																						0
-Earthshifter	385	100	1			1		77	69	7gm	thunder maul		3	5000								dmg%		250	300	hit-skill	Eruption	25	14	crush		33	33	swing2		10	10	charged	Volcano	30	14	skilltab	17	7	7	cast2		10	10																						0
-Wraithflight	386	100	1			1		84	76	7gl	ghost glaive		3	5000	dblu	dblu						dmg%		150	190	rep-quant	40			lifesteal		9	13	mana-kill		15	15	ethereal		1	1																														0
+Arreat's Face	279	100	1			1	1	50	42	baa	Slayer Guard		5	5000								bar		2	2	skilltab	12	2	2	ac%		150	200	balance2		30	30	att%		20	20	str		20	20	dex		20	20	lifesteal		3	6	res-all		30	30														0
+Homunculus	280	100	1			1	1	50	42	nea	Heirophant Trophy		5	5000								nec		2	2	skilltab	6	2	2	ac%		150	200	block2		30	30	block		40	40	enr		20	20	regen-mana		33	33	mana-kill		5	5	res-all		40	40														0
+Titan's Revenge	281	100	1			1	1	50	42	ama	Ceremonial Javelin		5	5000								ama		2	2	skilltab	2	2	2	dmg%		150	200	move2		30	30	rep-quant	30			str		20	20	dex		20	20	lifesteal		5	9	dmg-norm		25	50	stack		60	60										0
+Lycander's Aim	282	100	1			1	1	50	42	am7	Ceremonial Bow		5	5000								ama		2	2	skilltab	0	2	2	dmg%		150	200	swing2		20	20	ac%		20	20	dex		20	20	enr		20	20	manasteal		5	8	dmg-norm		25	50														0
+Lycander's Flank	283	100	1			1	1	50	42	am9	Ceremonial Pike		5	5000								ama		2	2	skilltab	2	2	2	dmg%		150	200	swing2		30	30	ac%		20	20	str		20	20	vit		20	20	lifesteal		5	9	dmg-norm		25	50														0
+The Oculus	284	100	1			1	1	50	42	oba	Swirling Crystal		5	5000								sor		3	3	gethit-skill	54	25	1	res-all		20	20	cast2		30	30	ac%		20	20	vit		20	20	enr		20	20	mana-kill		5	5	mag%		50	50														0
+Herald of Zakarum	285	100	1			1	1	50	42	pa9	Aerin Shield		5	5000								pal		2	2	skilltab	9	2	2	ac%		150	200	block2		30	30	block		30	30	str		20	20	vit		20	20	att%		20	20	res-all		50	50														0
+Cutthroat1	286	100	1			1	1	50	42	9tw	Runic Talons		5	5000								ass		2	2	skilltab	20	1	1	dmg%		150	200	balance2		30	30	att%		20	20	str		20	20	dex		20	20	lifesteal		5	9	dmg-norm		25	50														0
+Jalal's Mane	287	100	1			1	1	50	42	dra	Dream Spirit		5	5000								dru		2	2	skilltab	16	2	2	ac%		150	200	balance2		30	30	att%		20	20	str		20	20	enr		20	20	mana-kill		5	5	res-all		30	30														0
+The Scalper	288	100	1			1	1	65	57	9ta	Francisca		5	5000								rep-quant	30			dmg%		150	200	att%		25	25	swing2		20	20	openwounds		33	33	lifesteal		4	6	mana-kill		4	4																						0
+Bloodmoon	289	100	1			1	1	69	61	7sb	elegant blade		5	5000	cred	cred		invsbru				dmg%		210	260	lifesteal		10	15	charged	BloodGolem	9	15	heal-kill		7	13	openwounds		50	50																														0
+Djinnslayer	290	100	1			1	1	73	65	7sm	ataghan		5	5000	dpur	dpur		invscmu				dmg%		190	240	dmg-fire		250	500	dmg-demon		100	150	att-demon		200	300	abs-ltng		3	7	manasteal		3	6	sock		1	2																						0
+Deathbit	291	100	1			1	1	52	44	9tk	battle dart		5	5000								deadly		40	40	dmg%		130	180	att		200	450	lifesteal		7	9	manasteal		4	6	rep-quant	25																												0
+Warshrike	292	100	1			1	1	83	75	7bk	winged knife		5	5000	bwht	bwht		invtk3				dmg%		200	250	pierce		50	50	swing2		30	30	deadly		50	50	rep-quant	30			hit-skill	Nova	25	9																										0
+Gutsiphon	293	100	1			1	1	79	71	6rx	demon crossbow		5	5000	lgrn	lgrn		invrxbu				dmg%		160	220	pierce		33	33	lifesteal		12	18	slow		25	25	openwounds		33	33																														0
+Razoredge	294	100	1			1	1	75	67	7ha	tomahawk		5	5000	lblu			invhaxu				dmg%		175	225	swing2		40	40	reduce-ac		33	33	deadly		50	50	openwounds		50	50																														0
+Gore Ripper	295	100				1	1						5	5000	dred	dred																																																							0
+Demonlimb	296	100	1			1	1	71	63	7sp	tyrant club		5	5000	dgrn	dgrn		invspcu				dmg%		180	230	dmg-fire		222	333	lifesteal		7	13	charged	Enchant	20	23	rep-dur	5			dmg-demon		123	123	res-fire		15	20																						0
+Steelshade	297	100	1			1	1	70	62	ulm	armet		5	5000	blac	blac		invhlmu				ac%		100	130	abs-fire		5	11	manasteal		4	8	regen		10	18																																		0
+Tomb Reaver	298	100	1			1	1	86	84	7pa	cryptic axe		5	5000	lyel	lyel						swing2		60	60	light		4	4	dmg%		200	280	dmg-undead		150	230	mag%		50	80	res-all		30	50	att-undead		250	350	reanimate	1	10	10	heal-kill		10	14	sock		1	3										0
+Deaths's Web	299	100	1			1	1	74	66	7gw	unearthed wand		5	5000	bwht	bwht						allskills		2	2	pierce-pois		40	50	heal-kill		7	12	mana-kill		7	12	skilltab	7	1	2																														0
+Nature's Peace	300	100	1			3	1	77	69	rin	ring		5	5000	dgrn	dgrn						noheal		1	1	rip		1	1	red-dmg		7	11	res-pois		20	30	charged	Oak Sage	27	5																														0
+Azurewrath	301	100	1			1	1	87	85	7cr	phase blade		5	5000	lgry			invcrs				dmg-mag		250	500	dmg%		230	270	aura	Sanctuary	10	13	dmg-cold	250	250	500	swing2		30	30	all-stats		5	10	light		3	3	allskills		1	1																		0
+Seraph's Hymn	302	100	1			3	1	73	65	amu	amulet		5	5000	bwht	bwht		invamu2				allskills		2	2	skilltab	11	1	2	dmg-demon		25	50	dmg-undead		25	50	att-demon		150	250	att-undead		150	250	light		2	2																						0
+Zakarum's Salvation	303	100				1	1						5	5000																																																									0
+Fleshripper	304	100	1			1	1	76	68	7kr	fanged knife		5	5000	dred	dred		invkrsu				dmg%		200	300	reduce-ac		50	50	noheal		1	1	crush		25	25	openwounds		50	50	deadly		33	33	slow		20	20																						0
+Odium	305	100				1	1						5	5000	blac																																																								0
+Horizon's Tornado	306	100	1			5	1	72	64	7fl	scourge		5	5000	dpur	dpur						dmg%		230	280	swing2		50	50	slow		20	20	hit-skill	Tornado	20	15	ease		-20	-20																														0
+Stone Crusher	307	100	1			4	1	76	68	7wh	legendary mallet		5	5000	whit							dmg%		280	320	str		20	30	crush		40	40	reduce-ac		25	25	dmg-ac		-100	-100	dmg		10	30																										0
+Jadetalon	308	100	1			1	1	74	66	7wb	wrist sword		5	5000	cgrn	cgrn						dmg%		190	240	manasteal		10	15	res-all		40	50	balance2		30	30	skilltab	19	1	2	skilltab	20	1	2																										0
+Shadowdancer	309	100	1			1	1	79	71	uhb	myrmidon greaves		5	5000	blac	blac						ac%		70	100	move2		30	30	balance2		30	30	dex		15	25	skilltab	19	1	2	ease		-20	-20																										0
+Cerebus	310	100	1			1	1	71	63	drb	blood spirit		5	5000	bwht	bwht						ac%		130	140	skilltab	16	2	4	lifesteal		7	10	att%		60	120	openwounds		33	33	skill	feral rage	1	2																										0
+Tyrael's Might	311	100	1			1	1	87	84	uar	sacred armor		5	5000	dblu	dblu		invaaru				ease		-100	-100	indestruct		1	1	ac%		120	150	rip		1	1	dmg-demon		50	100	nofreeze		1	1	move2		20	20	res-all		20	30	str		20	30	allskills		1	1	aura	might	1	1						0
+Souldrain	312	100	1			1	1	82	74	umg	vambraces		5	5000	dred	dred						ac%		90	120	manasteal		4	7	lifesteal		4	7	hit-skill	Weaken	8	3	dmg-ac		-50	-50																														0
+Runemaster	313	100	1			1	1	80	72	72a	ettin axe		5	5000	lblu	lblu						dmg%		220	270	sock		3	5	res-cold-max		5	5	nofreeze		1	1																																		0
+Deathcleaver	314	100	1			1	1	78	70	7wa	berserker axe		5	5000	dred							dmg%		230	280	deadly		66	66	reduce-ac		33	33	swing2		40	40	heal-kill		6	9																														0
+Executioner's Justice	315	100	1			1	1	83	75	7gi	glorious axe		5	5000	blac	blac						dmg%		240	290	crush		25	25	reduce-ac		33	33	kill-skill	Decrepify	50	6	swing2		30	30																														0
+Stoneraven	316	100	1			1	1	72	64	amd	matriarchal spear		5	5000	dgry							dmg%		230	280	dmg-mag		101	187	res-all		30	50	ac		400	600	skilltab	2	1	3																														0
+Leviathan	317	100	1			1	1	73	65	uld	kraken shell		5	5000	cgrn	cgrn						ac%		170	200	ac		100	150	red-dmg%		15	25	str		40	50	indestruct		1	1																														0
+Larzuk's Champion	318	100				1	1						5	5000	lgry		flphmr	invhfh																																																					0
+Wisp	319	100	1			1	1	84	76	rin	ring		5	5000	bwht	bwht						abs-ltng%		10	20	hit-skill	Lightning	10	16	mag%		10	20	charged	Oak Sage	15	2	charged	Heart of Wolverine	13	5	charged	Spirit of Barbs	11	7																										0
+Gargoyle's Bite	320	100	1			1	1	78	70	7ts	winged harpoon		5	5000	cgrn	cgrn						dmg%		180	230	rep-quant	30			dmg-pois	250	300	300	lifesteal		9	15	charged	Plague Javelin	60	11																														0
+Lacerator	321	100	1			1	1	76	68	7b8	winged axe		5	5000	blac	blac						dmg%		150	210	rep-quant	25			swing2		30	30	noheal		1	1	openwounds		33	33	howl		64	64	hit-skill	Amplify Damage	33	3																						0
+Mang Song's Lesson	322	100	1			1	1	86	82	6ws	archon staff		5	5000	dgld	dgld		inv8wsu				allskills		5	5	pierce-fire		7	15	pierce-ltng		7	15	pierce-cold		7	15	regen-mana		10	10	cast2		30	30																										0
+Viperfork	323	100	1			1	1	79	71	7br	war fork		5	5000	dgrn	dgrn						dmg%		190	240	dmg-pois	250	333	333	swing2		50	50	att		200	250	hit-skill	Poison Explosion	15	9	res-pois		30	50																										0
+Ethereal Edge	324	100	1			1	1	82	74	7ba	silver-edged axe		5	5000	whit	whit						dmg%		150	180	swing2		25	25	abs-fire		10	12	dmg-demon		150	200	demon-heal		5	10	att		270	350	ethereal		1	1	indestruct		1	1																		0
+Demonhorn's Edge	325	100	1			1	1	69	61	bad	destroyer helm		5	5000	dgry	dgry						ac%		120	160	swing2		10	10	lifesteal		3	6	thorns		55	77	skilltab	12	1	3	skilltab	13	1	3	skilltab	14	1	3																						0
+The Reaper's Toll	326	100	1			1	1	83	75	7s8	thresher		5	5000				invscy				dmg%		190	240	hit-skill	Decrepify	33	1	ignore-ac		1	1	lifesteal		11	15	ease		-25	-25	deadly		33	33	dmg-cold		4	44																						0
+Spiritkeeper	327	100	1			1	1	75	67	drd	earth spirit		5	5000								ac%		170	190	balance2		20	20	abs-ltng		9	14	res-fire		30	40	abs-cold%		15	25	res-pois-max		10	10	dru		1	2																						0
+Hellrack	328	100	1			1	1	84	76	6hx	colossus crossbow		5	5000	cred			invhxbu				dmg%		180	230	dmg-elem	33	63	324	swing2		20	20	att%		100	150	sock		2	2	charged	Immolation Arrow	150	18																										0
+Alma Negra	329	100	1			1	1	85	77	pac	sacred rondache		5	5000	blac	blac						ac%		180	210	block2		30	30	pal		1	2	block		20	20	red-mag		5	9	att%		40	75	dmg%		40	75																						0
+Darkforge Spawn	330	100	1			1	1	72	64	nef	bloodlord skull		5	5000	cred	cred						ac%		140	180	cast2		30	30	mana%		10	10	skilltab	6	1	3	skilltab	7	1	3	skilltab	8	1	3																										0
+Widowmaker	331	100	1			1	1	73	65	6sw	ward bow		5	5000	dred	dred		invswbu				dmg%		150	200	deadly		33	33	ignore-ac		1	1	magicarrow		11	11	oskill	Guided Arrow	3	5																														0
+Bloodraven's Charge	332	100	1			1	1	79	71	amb	matriarchal bow		5	5000	dgld	dgld		invswbu				dmg%		180	230	att%		200	300	explosivearrow		13	13	skilltab	0	2	4	charged	Revive	30	5																														0
+Ghostflame	333	100	1			1	1	70	62	7bl	legend spike		5	5000	cblu	cblu						dmg%		190	240	ignore-ac		1	1	dmg-mag		108	108	manasteal		10	15	ethereal		1	1	indestruct		1	1	light		2	2																						0
+Shadowkiller	334	100	1			1	1	85	78	7cs	battle cestus		5	5000				invaxfu				dmg%		170	220	reduce-ac		25	25	freeze		2	2	mana-kill		10	15	hit-skill	Frost Nova	33	8	ethereal		1	1	indestruct		1	1																						0
+Gimmershred	335	100	1			1	1	78	70	7ta	flying axe		5	5000	lgrn							dmg%		160	210	dmg-fire		218	483	dmg-cold	100	176	397	dmg-ltng		29	501	stack		60	60	swing2		30	30																										0
+Griffon's Eye	336	100	1			1	1	84	76	ci3	diadem		5	5000								ac		100	200	cast2		25	25	allskills		1	1	extra-ltng		10	15	pierce-ltng		15	20																														0
+Windhammer	337	100	1			1	1	76	68	7m7	ogre maul		5	5000	cblu	cblu		invmau				dmg%		180	230	crush		50	50	swing2		60	60	hit-skill	Twister	33	22																																		0
+Thunderstroke	338	100	1			1	1	77	69	amf	matriarchal javelin		5	5000	dblu	dblu						dmg%		150	200	dmg-ltng		1	511	hit-skill	Lightning	20	14	swing2		15	15	pierce-ltng		15	15	skill	Lightning Bolt	3	3	skilltab	2	2	4																						0
+Giantmaimer	339	100				1	1						5	5000	cred	cred																																																							0
+Demon's Arch	340	100	1			1	1	76	68	7s7	balrog spear		5	5000	cred	cred						dmg%		160	210	dmg-fire		232	323	lifesteal		6	12	rep-quant	30			swing2		30	30	dmg-ltng		23	333																										0
+Boneflame	341	100	1			1	1	80	72	nee	succubae skull		3	5000	dred	dred						ac%		120	150	move2		20	20	gethit-skill	Terror	15	3	nec		2	3	res-all		20	30																														0
+Steelpillar	342	100	1			1	1	77	69	7p7	war pike		3	5000								dmg%		210	260	swing2		25	25	reduce-ac		20	20	ac%		50	80	indestruct		1	1	crush		25	25																										0
+Nightwing's Veil	343	100	1			1	1	75	67	uhm	spired helm		3	5000	cblu	cblu						ac%		90	120	allskills		2	2	dex		10	20	abs-cold		5	9	half-freeze		1	1	extra-cold		8	15	ease		-50	-50																						0
+Crown of Ages	344	100	1			1	1	86	82	urn	corona		3	5000	dgld	dgld						balance2		30	30	res-all		20	30	allskills		1	1	ac		100	150	indestruct		1	1	red-dmg%		10	15	ac%		50	50	sock		1	2																		0
+Andariel's Visage	345	100	1			1	1	85	83	usk	demonhead		3	5000	dred	dred						ac%		100	150	res-pois		70	70	allskills		2	2	res-pois-max		10	10	swing2		20	20	str		25	30	gethit-skill	92	15	15	charged	278	20	3	lifesteal		8	10	res-fire		-30	-30										0
+Darkfear	346	100				1	1			ulm	armet		5	5000	blac			invhlmu																																																					0
+Dragonscale	347	100	1			1	1	84	80	pae	zakarum shield		3	5000	dgrn	dgrn						ac%		170	200	abs-fire%		10	20	res-fire-max		5	5	str		15	25	dmg-fire		211	371	oskill	Hydra	10	10	extra-fire		15	15																						0
+Steel Carapice	348	100	1			1	1	74	66	uul	shadow plate		3	5000	dgry	dgry						ac%		190	220	balance2		20	20	red-dmg		9	14	res-cold		40	60	regen-mana		10	15	rep-dur	5			gethit-skill	Iron Maiden	8	6																						0
+Medusa's Gaze	349	100	1			1	1	84	76	uow	aegis		3	5000	lred	lred		invtowu				ac%		150	180	slow		20	20	gethit-skill	Lower Resist	10	7	lifesteal		5	9	death-skill	Nova	100	44	res-cold		40	80																										0
+Ravenlore	350	100	1			1	1	82	74	dre	sky spirit		3	5000	dgld	dgld						ac%		120	150	res-all		15	25	skilltab	17	3	3	enr		20	30	pierce-fire		10	20	skill	Raven	7	7																										0
+Boneshade	351	100	1			1	1	84	79	7bw	lich wand		3	5000	dgry	dgry		invbwnu				nec		2	2	cast2		25	25	skill	Teeth	4	5	skill	Bone Armor	4	5	skill	Bone Spear	2	3	skill	Bone Spirit	1	2	skill	Bone Wall	2	3																						0
+Nethercrow	352	100				1	1						3	5000	cblu	cblu																																																							0
+Flamebellow	353	100	1			1	1	79	71	7gs	balrog blade		3	5000	cred	cred		invgisu				dmg%		170	240	dmg-fire		233	482	fireskill		3	3	abs-fire%		20	30	hit-skill	Firestorm	12	16	str		10	20	vit		5	10	oskill	Inferno	12	18																		0
+Fathom	354	100	1			1	1	81	73	obf	dimensional shard		3	5000	lblu							sor		3	3	extra-cold		15	30	cast2		20	20	res-fire		25	40	res-ltng		25	40																														0
+Wolfhowl	355	100	1			1	1	85	79	bac	fury visor		3	5000	cred	cred						ac%		120	150	skilltab	14	2	3	str		8	15	dex		8	15	vit		8	15	oskill	Wearwolf	3	6	charged	Summon Fenris	18	15	oskill	Shape Shifting	3	6	oskill	Feral Rage	3	6														0
+Spirit Ward	356	100	1			1	1	76	68	uts	ward		3	5000	dblu	dblu		invgtsu				ac%		130	180	abs-cold		6	11	res-all		30	40	block		20	30	block2		25	25	gethit-skill	Fade	5	8																										0
+Kira's Guardian	357	100	1			1	1	85	77	ci2	tiara		3	5000	blac	blac						ac		50	120	res-all		50	70	nofreeze		1	1	balance2		20	20																																		0
+Ormus' Robes	358	100	1			1	1	83	75	uui	dusk shroud		3	5000	blac	blac						ac		10	20	cast2		20	20	extra-fire		10	15	extra-cold		10	15	extra-ltng		10	15	regen-mana		10	15	skill-rand	3	36	60																						0
+Gheed's Fortune	359	100	1			1	1	70	62	cm3	charm	1	3	5000	lgld							mag%		20	40	gold%		80	160	cheap		10	15																																						0
+Stormlash	360	100	1			1	1	86	82	7fl	scourge		3	5000	dgry	dgry						dmg%		240	300	swing2		30	30	hit-skill	Static Field	15	10	hit-skill	Tornado	20	18	dmg-ltng		1	473	light-thorns		30	30	crush		33	33	abs-ltng		3	9																		0
+Halaberd's Reign	361	100	1			1	1	85	77	bae	conqueror crown		3	5000								ac%		140	170	skilltab	13	1	1	bar		2	2	balance2		20	20	regen		15	23	skill	Battle Orders	1	2	skill	Battle Command	1	2																						0
+Warriv's Warder	362	100				1	1						3	5000																																																									0
+Spike Thorn	363	100	1			1	1	78	70	upk	blade barrier		5	5000	dyel	dyel		invspku				ac%		120	150	thorns/lvl	11			dur		250	250	balance2		30	30	red-dmg%		15	20	sock		1	1																										0
+Dracul's Grasp	364	100	1			1	1	84	76	uvg	vampirebone gloves		5	5000	dred	dred						ac%		90	120	lifesteal		7	10	openwounds		25	25	hit-skill	Life Tap	5	10	heal-kill		5	10	str		10	15																										0
+Frostwind	365	100	1			1	1	78	70	7ls	cryptic sword		5	5000	cblu	cblu		invlsdu				dmg%		180	230	freeze		4	4	half-freeze		1	1	dmg-cold	150	237	486	swing2		25	25	abs-cold%		7	15	oskill	Arctic Blast	7	14																						0
+Templar's Might	366	100	1			8	1	82	74	uar	sacred armor		5	5000	cgrn	cgrn		invaaru				ac%		170	220	balance2		20	20	ac-miss		250	300					str		10	15	vit		10	15	skilltab	10	1	2																						0
+Eschuta's temper	367	100	1			1	1	80	72	obc	eldritch orb		5	5000	cred							sor		1	3	cast2		40	40	extra-fire		10	20	extra-ltng		10	20	enr		20	30																														0
+Firelizard's Talons	368	100	1			1	1	75	67	7lw	feral claws		5	5000								dmg%		200	270	swing2		15	15	skilltab	20	1	3	dmg-fire		236	480	res-fire		40	70	skill	Wake of Fire Sentry	1	2	skill	Inferno Sentry	1	2																						0
+Sandstorm Trek	369	100	1			1	1	72	64	uvb	scarabshell boots		5	5000								ac%		140	170	move2		20	20	balance2		20	20	stam/lvl	8			stamdrain		50	50	res-pois		40	70	rep-dur	5			str		10	15	vit		10	15														0
+Marrowwalk	370	100	1			1	1	74	66	umb	boneweave boots		5	5000	dgry							ac%		170	200	move2		20	20	charged	Bone Prison	13	33	charged	Life Tap	10	12	regen-stam		10	10	regen-mana		10	10	half-freeze		1	1	str		10	20	dex		17	17	skill	Skeleton Mastery	1	2										0
+Heaven's Light	371	100	1			1	1	69	61	7sc	mighty scepter		5	5000	cblu	cblu						dmg%		250	300	swing2		20	20	reduce-ac		33	33	light		3	3	demon-heal		15	20	crush		33	33	sock		1	3	pal		2	3																		0
+Merman's Speed	372	100					1																																																																0
+Arachnid Mesh	373	100	1			1	1	87	80	ulc	spiderweb sash		5	5000	blac	blac						ac%		90	120	cast2		20	20	charged	Venom	11	3	allskills		1	1	slow		10	10	mana%		5	5																										0
+Nosferatu's Coil	374	100	1			1	1	68	51	uvc	vampirefang belt		5	5000								str		15	15	mana-kill		2	2	slow		10	10	lifesteal		5	7	swing2		10	10	light		-3	-3																										0
+Metalgrid	375	100	1			2	1	85	81	amu	amulet		5	5000								ac		300	350	res-all		25	35	att		400	450	charged	IronGolem	11	22	charged	Iron Maiden	20	12																														0
+Verdugo's Hearty Cord	376	100	1			1	1	71	63	umc	mithril coil		5	5000	blac	blac						ac%		90	140	vit		30	40					balance2		10	10	red-dmg%		10	15	regen		10	13																										0
+Sigurd's Staunch	377	100				1	1						5	5000																																																									0
+Carrion Wind	378	100	1			3	1	67	60	rin	ring		3	5000								ac-miss		100	160	lifesteal		6	9	res-pois		55	55	gethit-skill	Poison Nova	10	10	charged	Plague Poppy	15	21	hit-skill	Twister	8	13	dmg-to-mana		10	10	dex		10	15																		0
+Giantskull	379	100	1			1	1	73	65	uh9	bone visage		3	5000	lgry	lgry		invbhm				ac		250	320	str		25	35	crush		10	10	sock		1	2	knock		1	1																														0
+Ironward	380	100	1			1	1	68	60	7ws	caduceus		3	5000	blac	blac						dmg%		240	290	slow		25	25	att%		150	200	swing2		10	10	dmg-mag		80	240	red-dmg		4	7	dmg		40	85	skilltab	9	2	4	crush		33	33														0
+Annihilus	381	100	1			1	1	110	70	cm1	charm	1	3	5000			flpmss	invmss	item_gem	12	item_gem	allskills		1	1	all-stats		10	20	res-all		10	20	addxp		5	10																																		0
+Arioc's Needle	382	100	1			1	1	85	81	7sr	hyperion spear		3	5000								dmg%		180	230	dmg-pois	250	403	403	deadly		50	50	ignore-ac		1	1	allskills		2	4	swing2		30	30																										0
+Cranebeak	383	100	1			1	1	71	63	7mp	war spike		3	5000	dgry			invmpiu				dmg%		240	300	dmg-ltng		1	305	swing2		40	40	reduce-ac		25	25	mag%		20	50	charged	Raven	15	8																										0
+Nord's Tenderizer	384	100	1			1	1	76	68	7cl	truncheon		3	5000				invclbu				dmg%		270	330	freeze		2	4	swing2		25	25	charged	Blizzard	12	16	att%		150	180	abs-cold%		5	15	dmg-cold	125	205	455																						0
+Earthshifter	385	100	1			1	1	77	69	7gm	thunder maul		3	5000								dmg%		250	300	hit-skill	Eruption	25	14	crush		33	33	swing2		10	10	charged	Volcano	30	14	skilltab	17	7	7	cast2		10	10																						0
+Wraithflight	386	100	1			1	1	84	76	7gl	ghost glaive		3	5000	dblu	dblu						dmg%		150	190	rep-quant	40			lifesteal		9	13	mana-kill		15	15	ethereal		1	1																														0
 Bonehew	387	100	1			1		72	64	7o7	ogre axe		3	5000	bwht	bwht						dmg%		270	320	swing2		30	30	charged	Corpse Explosion	30	14	hit-skill	Bone Spear	50	25	noheal		1	1	sock		2	4	extra_bonespears		1	1																						0
-Ondal's Wisdom	388	100	1			1		74	66	6cs	elder staff		3	5000				invcstu				cast2		45	45	enr		40	50	allskills		2	4	ac		450	550	addxp		5	5	red-mag		5	8																										0
-The Reedeemer	389	100	1			1		80	72	7sc	mighty scepter		3	5000								dmg%		250	300	dmg-demon		200	250	pal		2	2	ease		-60	-60	skill	Redemption	2	4	skill	Holy Bolt	2	4	light		3	3	reduce-ac		33	33	dmg		60	120														0
-Headhunter's Glory	390	100	1			1		83	75	ush	troll nest		3	5000				invbshu				ac		320	420	ac-miss		300	350	res-pois		30	40	sock		1	3	res-fire		20	30	heal-kill		5	7																										0
-Steelrend	391	100	1			1		78	70	uhg	ogre gauntlets		3	5000								ac		170	210	str		15	20	dmg%		30	60	crush		10	10																																		0
-Rainbow Facet	392	100	1			1		85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	death-skill	Chain Lightning	100	47																																		0
-Rainbow Facet	393	100	1			1		85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
-Rainbow Facet	394	100	1			1		85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
-Rainbow Facet	395	100	1			1		85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
-Rainbow Facet	396	100	1			1		85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	levelup-skill	Nova	100	41																																		0
-Rainbow Facet	397	100	1			1		85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
-Rainbow Facet	398	100	1			1		85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
-Rainbow Facet	399	100	1			1		85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Hellfire Torch	400	100	1			1		110	75	cm2	charm	1	3	5000			flptrch	invtrch	item_gem	12	item_gem	randclassskill		0	6	all-stats		10	20	res-all		10	20	light		8	8	hit-skill	197	5	10	charged	Hydra	10	30																										0
+Ondal's Wisdom	388	100	1			1	1	74	66	6cs	elder staff		3	5000				invcstu				cast2		45	45	enr		40	50	allskills		2	4	ac		450	550	addxp		5	5	red-mag		5	8																										0
+The Reedeemer	389	100	1			1	1	80	72	7sc	mighty scepter		3	5000								dmg%		250	300	dmg-demon		200	250	pal		2	2	ease		-60	-60	skill	Redemption	2	4	skill	Holy Bolt	2	4	light		3	3	reduce-ac		33	33	dmg		60	120														0
+Headhunter's Glory	390	100	1			1	1	83	75	ush	troll nest		3	5000				invbshu				ac		320	420	ac-miss		300	350	res-pois		30	40	sock		1	3	res-fire		20	30	heal-kill		5	7																										0
+Steelrend	391	100	1			1	1	78	70	uhg	ogre gauntlets		3	5000								ac		170	210	str		15	20	dmg%		30	60	crush		10	10																																		0
+Rainbow Facet	392	100	1			1	1	85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	death-skill	Chain Lightning	100	47																																		0
+Rainbow Facet	393	100	1			1	1	85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
+Rainbow Facet	394	100	1			1	1	85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
+Rainbow Facet	395	100	1			1	1	85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
+Rainbow Facet	396	100	1			1	1	85	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	levelup-skill	Nova	100	41																																		0
+Rainbow Facet	397	100	1			1	1	85	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
+Rainbow Facet	398	100	1			1	1	85	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
+Rainbow Facet	399	100	1			1	1	85	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
+Hellfire Torch	400	100	1			1	1	110	75	cm2	charm	1	3	5000			flptrch	invtrch	item_gem	12	item_gem	randclassskill		0	6	all-stats		10	20	res-all		10	20	light		8	8	hit-skill	197	5	10	charged	Hydra	10	30																										0
 Talonrage																																																																							0
-Auburnfire	401	100	1			1		18	18	hax	hand axe		5	5000	cred	cred						dmg-min		10	15	dmg-max		35	45	dmg-fire		35	50	dmg-ltng		25	50	res-ltng		15	25																														0
-Gangrene Reaper	402	100	1			3		1	6	hax	hand axe		5	5000	cgrn			invaxe19				dmg%		100	150	dmg-pois	100	55	55	noheal		1	1	rep-dur	15			str		10	10																														0
-Easebringer	403	100	1			1		22	22	axe	axe		5	5000				invaxe13				dmg-min		15	20	dmg-max		40	50	ease		-40	-40	swing2		25	25	lifesteal		6	6																														0
-Goreflood	404	100	1			3		1	10	axe	axe		5	5000	cred	cred						dmg%		120	170	bloody		1	1	wounds/lvl	24			skilltab	13	1	3	lifesteal		3	5	pierce-fire		5	10																										0
-Longsuffering	405	100	1			1		25	25	2ax	double axe		5	5000	dgrn			invaxe12				dmg-norm		20	50	cold-len	200			dmg-pois	100	200	200	slow		20	20	noheal		1	1	openwounds		44	44																										0
-Lungreaver	406	100	1			3		1	14	2ax	double axe		5	5000				invaxe11				dmg%		130	180	slow		10	10	lifesteal		5	7	move1		15	15	sock		1	2																														0
-Broken Earth	407	100	1			1		29	30	mpi	military pick		5	5000	lgry	lgry						dmg-min		15	20	dmg-max		30	60	hit-skill	234	6	3	dru		1	1	swing1		15	15	res-cold		33	33	res-pois		33	33																						0
-Occam's Razor	408	100	1			3	1	1	23	mpi	military pick		5	5000								dmg%		140	190	deadly		40	40	allskills		1	1	aura	99	5	7	oskill	sword mastery	3	6	res-fire		15	25																										0
-Shadazar's Answer	409	100	1			1		30	35	wax	war axe		5	5000	lblu	lblu						dmg-norm		20	70	allskills		1	1	knock		2	2	lifesteal		5	5	mana-kill		3	5	red-dmg		8	10	dur		40	40																						0
-Deathflake	410	100	1			3		1	30	wax	war axe		5	5000								dmg%		175	200	dmg-max		20	30	charged	raise skeleton	2	40	heal-kill		5	8	dmg-undead		200	200	aura	119	2	4																										0
-Bloody Scalp	411	100	1			1		55	44	9ha	hatchet		5	5000								dmg%		100	135	dmg/lvl	8			swing2		20	20	bloody		1	1	deadly		17	17	openwounds		77	77	att%		20	20																						0
-Pure Rancor	412	100	1			3		1	38	9ha	hatchet		5	5000	dgrn	dgrn		invhax				dmg%		175	200	bar		2	2	swing2		20	20	res-pois		25	25	dmg-pois	100	466	466	oskill	decrepify	1	3	dur		45	45																						0
-Slayer of Trents	413	100	1			3		1	45	9ax	cleaver		5	5000	dgrn			invaxe3				dmg%		170	200	dmg-norm		15	30	dmg-demon		100	100	reduce-ac		15	15	rep-dur	10			charged	130	15	10	res-pois		25	35																						0
-Edge of Forever	414	100	1			1		50	49	9ax	cleaver		5	5000				invaxe				dmg%		180	210	allskills		1	1	gethit-skill	53	7	12	rep-dur	15			dmg-norm		20	50	res-pois-len		35	35	sock		1	2																						0
-Cryohydra	415	100	1			1		55	56	92a	twin axe		5	5000	dblu			invaxe7				dmg%		150	200	dmg-max		30	50	dmg-cold	350	10	20	freeze		5	5	res-fire		55	55	res-cold		30	40	gethit-skill	39	75	20																						0
-Harvest of Souls	416	100	1			3		1	50	92a	twin axe		5	5000	blac			invaxe22				dmg%		190	230	swing3		30	30	oskill	bone spirit	4	7	aura	118	8	12	dmg-undead		175	175	lifesteal		5	8	noheal		1	1																						0
-Cornugon	417	100	1			3		1	53	9mp	crowbill		5	5000	oran	oran						dmg%		160	220	dmg-demon		250	250	manasteal		10	10	demon-heal		35	35	ac		35	50	red-dmg		10	15	red-mag		8	12	res-ltng		15	25																		0
-Groundshatter	418	100	1			1		55	60	9mp	crowbill		5	5000				invmpi				dmg%		200	240	hit-skill	234	12	7	fireskill		2	2	att		250	250	str		20	20	dmg-max		30	50	red-dmg		5	9	res-fire		35	40	res-cold		25	35														0
-Couatl	419	100	1			1		55	65	9wa	naga		5	5000	lgrn			invaxe5				dmg%		175	200	dmg-norm		10	50	swing3		50	50	move3		50	50	balance3		50	50	block3		50	50																										0
-Antics of the Jester	420	100	1			3		1	57	9wa	naga		5	5000	oran	oran		invwax				dmg%		225	260	howl		1	66	heal-kill		1	10	res-all		1	35	extra-cold		1	10	swing3		55	55	sock		1	2																						0
-Marilith	421	100	1			1			68	7ha	tomahawk		5	5000	dyel	dyel						dmg%		200	240	allskills		2	2	ignore-ac		1	1	aura	114	1	5	lifesteal		6	6	manasteal		6	6	dmg-to-mana		20	20																						0
-Death Slaad	422	100	1			1			71	7ax	small crescent		5	5000	blac	dgry		invaxe4				dmg%		350	450	dmg/lvl	8			swing3		60	60	rip		1	1																																		0
-Moon Blade	423	100	1			2		1	64	7ax	Small Crescent		5	5000								dmg%		190	280	block		15	25	block1		15	15	balance1		20	20	oskill	Life Tap	3	5	res-all		20	25																										0
-Beholder	424	100	1			1			75	72a	ettin axe		5	5000				invaxe6				dmg%		250	290	swing1		15	15	ac%		25	25	red-dmg%		15	15	res-mag		75	75	res-all		60	80																										0
-Elder Tojanida	425	100	1			1			80	7mp	war spike		5	5000				invaxe2				dmg%/lvl	33			addxp		3	5	dmg-min		50	75	res-ltng		30	40	res-cold		25	25	extra-fire		15	15	sock		1	1																						0
-Frostwyrm	426	100	1			1			84	7wa	berserker axe		5	5000	lblu	lblu		invaxe9				dmg%		150	200	sock		3	3	swing2		20	20	hit-skill	44	33	35	gethit-skill	45	8	19	abs-cold%		50	50	res-cold		25	25																						0
-Light Phasm	427	100	1			1		20	21	lax	large axe		5	5000	whit	whit						dmg-min		10	20	dmg-max		35	45	light		3	3	dmg-ltng		1	75	res-ltng		35	40	dmg-undead		150	150	dmg%		70	100																						0
-Gracehunter	428	100	1			3		1	8	lax	large axe		5	5000								dmg%		100	150	swing2		20	20	mag%		20	20	gold%		75	75	manasteal		6	6																														0
-Night Hag	429	100	1			1		24	23	bax	broad axe		5	5000	blac	blac						dmg-min		10	20	dmg-max		40	50	dmg-pois	75	133	133	lifesteal		7	7	stupidity		1	1	swing2		15	15	dmg%		70	100																						0
-Mirth Bringer	430	100	1			3		1	14	bax	broad axe		5	5000								dmg%		110	160	hit-skill	8	10	3	res-pois		20	25	res-cold		20	25	addxp		3	5																														0
-Tendriculos	431	100	1			1		27	27	btx	battle axe		5	5000								dmg-min		15	25	dmg-max		50	65	dur		40	40	att%		25	35	crush		15	25	reduce-ac		10	15	dmg%		70	100																						0
-Sandking	432	100	1			3		1	23	btx	battle axe		5	5000	lyel	lyel		invaxe1				dmg%		120	170	stupidity		2	2	dmg-fire		8	14	att		120	120	reduce-ac		10	15																														0
-Winter Wolf	433	100	1			1		30	33	gax	great axe		5	5000				invaxe16				dmg-min		20	30	dmg-max		55	75	dmg%		70	100	swing2		25	25	gethit-skill	50	6	4	charged	227	15	8	sock		1	2	dmg%		70	80																		0
-Nova Spine	434	100	1			3		1	28	gax	great axe		5	5000	cblu	cblu		invgax				dmg%		140	200	hit-skill	44	100	9	res-cold		25	30	res-cold-max		5	5	dmg-ltng		1	30	sock		1	2																										0
-Taskmaster's Curse	435	100	1			1		31	37	gix	giant axe		5	5000	dred	dred						dmg-min		30	40	dmg-max		60	80	hit-skill	81	4	2	manasteal		6	6	str		45	45	ease		35	35	dex		20	20	hp		30	50	dmg%		70	100														0
-Curseweaver	436	100	1			3	1	1	32	gix	giant axe		5	5000				invaxe10				dmg%		165	200	hit-skill	87	12	5	swing2		25	25	manasteal		5	7	bar		1	1	oskill	sword mastery	1	3																										0
-Sunblighter	437	100	1			1		55	45	9la	military axe		5	5000	dyel	dyel						dmg%		180	230	dmg-fire		100	300	res-all		25	25	deadly		44	44	extra-fire		15	15	stupidity		2	2	res-fire		40	50																						0
-Threat of Storms	438	100	1			3		1	40	9la	military axe		5	5000	dgry	dgry		invlax				dmg%		175	225	dmg-cold	200	25	40	dmg-ltng		1	150	dmg-fire		40	100	res-all		25	25	aura	118	5	10	swing1		15	15																						0
-Dwarven Honor	439	100	1			1		55	51	9ba	bearded axe		5	5000	dgry	dgry						dmg%		180	220	dmg-norm		25	50	red-dmg%		10	15	red-dmg		8	10	rep-dur	20			swing2		20	20	ac		100	150																						0
-Grandiose Dreams	440	100	1			3		1	44	9ba	bearded axe		5	5000								dmg%		180	230	mag%		40	40	dmg-max		40	60	allskills		1	1	crush		40	40	hp		60	60	move2		20	20																						0
-Ravid's Bite	441	100	1			3		1	47	9bt	tabar		5	5000								dmg%		200	250	hit-skill	238	12	2	swing3		30	30	all-stats		20	20	hp%		15	15	slow		10	20	sock		2	2	allskills		1	1																		0
-Spirit Naga	442	100	1			1		55	54	9bt	tabar		5	5000	lgrn	lgrn		invbtx				dmg%		190	240	rep-dur	18			ethereal		1	1	dmg-demon		150	150	res-fire		35	35	res-fire-max		10	10	bar		2	2	manasteal		8	8																		0
-Brittlequick	443	100	1			1		55	59	9ga	gothic axe		5	5000	whit			invaxe15				dur		-45	-45	rep-dur	5			swing3		50	50	dmg%		200	250	dmg-norm		20	40	reduce-ac		10	15	thorns		20	25	bar		1	1																		0
-Tonstrike	444	100	1			3		1	50	9ga	gothic axe		5	5000	oran			invaxe18				dmg%		200	250	swing3		30	30	str/lvl	4			deadly		25	25	hit-skill	229	4	9	dru		1	2	sock		2	2																						0
-Ogre's Breath	445	100	1			3		1	52	9gi	ancient axe		5	5000	lgry	lgry						dmg%		220	270	swing2		20	20	red-dmg%		10	15	gethit-skill	87	2	30	str		15	25	dex		-5	-5	regen		1	4	move1		10	10																		0
-Mythslayer	446	100	1			1		55	58	9gi	ancient axe		5	5000	dgld	dgld		invgix				dmg%		150	200	dmg%/lvl	12			all-stats		15	15	swing2		25	25	att%		30	30	allskills		1	1	charged	142	20	35	balance2		20	20																		0
-Woodland Beast	447	100	1			2		1	53	7la	feral axe		5	5000								dmg%		200	250	dru		2	3	skilltab	15	1	3	swing2		20	20	deadly/lvl	10			crush/lvl	4			res-all		15	25																						0
-Werewolf Slayer	448	100	1			1		1	65	7la	Feral Axe		5	5000	cblu	cblu						dmg%/lvl	16			dmg-min		25	35	dru		1	2	swing3		35	35	move3		40	40	lifesteal		5	8	sock		1	2	oskill	Wearwolf	8	20	oskill	Shape Shifting	8	20	dmg%		100	125										0
-Shapeshifter	449	100	1			1		1	69	7ba	silver-edged axe		5	5000				invaxe21				dmg%		200	250	swing3		40	40	skill	224	10	15	hp%		40	40	ethereal		1	1	indestruct		1	1																										0
-Dyer's Eve	450	100	1			1		1	73	7bt	decapitator		5	5000				invaxe20				dmg%		200	250	dmg-max		50	100	rip		1	1	lifesteal		12	12	bar		2	2	mag%		40	60	regen		12	15	sock		1	1																		0
-Hero's Welcome	451	100	1			1		1	79	7ga	champion axe		5	5000				invaxe14				dmg%		225	270	addxp		3	5	cheap		10	15	swing2		20	20	vit/lvl	5			red-dmg%		10	10	res-all		25	25	nofreeze		1	1																		0
-Nameless Horror	452	100	1			1		1	84	7gi	glorious axe		5	5000								dmg%		275	325	howl		155	155	gethit-skill	130	10	20	charged	88	77	15	res-pois		88	88	res-pois-len		50	75	res-pois-max		5	5	dmg-pois	300	1455	1455	allskills		2	2														0
-Epee of Speed	453	100	1			1		23	24	ssd	short sword		5	5000				invswrd15				dmg-norm		25	50	swing2		30	30	balance2		30	30	move2		20	20	charged	139	100	8	block		20	25																										0
-Deviljack	454	100	1			3		1	5	ssd	short sword		5	5000	lgry	lgry						dmg%		100	150	dmg-demon		100	100	addxp		3	5	cheap		10	10																																		0
-Anadek's Sword	455	100	1			1		24	26	scm	scimitar		5	5000								dmg-norm		25	50	swing1		15	15	dmg%		50	60	dmg-fire		25	40	res-cold		20	30	rep-dur	25																												0
-Briarblade	456	100	1			3		1	8	scm	scimitar		5	5000	dgrn	dgrn						dmg%		100	150	dmg-pois	250	100	100	openwounds		50	50	heal-kill		3	5	deadly		15	15																														0
-Sajorn Jinx	457	100	1			1		25	28	sbr	saber		5	5000				invswrd23				dmg-norm		25	55	hit-skill	76	4	3	hp		35	50	att		150	150	lifesteal		4	6	regen-mana		3	6																										0
-Chromablade	458	100	1			3		1	10	sbr	saber		5	5000	whit	whit						dmg%		100	150	ease		-100	-100	light		7	7	dmg-norm		5	5	gethit-skill	36	20	4																														0
-Qikadar's Laughter	459	100	1			1		26	30	flc	falshion		5	5000				invswrd25				dmg-min		20	25	dmg-max		50	65	howl		33	33	res-all		20	20	allskills		1	1	swing2		20	20																										0
-Fiendslayer	460	100	1			3		1	13	flc	falshion		5	5000	oran	oran						dmg%		120	170	dmg-demon		200	200	att-demon		200	200	demon-heal		5	8	swing2		20	20	res-all		20	20																										0
-Quartz Star	461	100	1			1		27	31	crs	crystal sword		5	5000								dmg-norm		30	65	manasteal		6	6	res-fire		25	25	block2		15	15	dex		20	20	mag%		35	35																										0
-Irksome Edge	462	100	1			3		1	17	crs	crystal sword		5	5000	oran	oran						dmg%		130	180	ease		25	25	hit-skill	42	8	7	manasteal		5	5	knock		1	1	howl		88	88																										0
-Azurewrath1	463	0	1			5		1	13	crs	Crystal Sword		5	5000	lgry	lgry						deadly		50	50	mag%		10	25	dmg-cold	100	3	6	dmg%		100	100	dur		25	75	dmg-mag		5	10																										0
-Omni-Slash	464	100	1			1		28	32	bsd	broadsword		5	5000				invswrd11				dmg%		100	140	dmg-norm		15	35	swing3		20	20	sock		2	2	deadly		20	20	thorns		20	20																										0
-Vanquisher	465	100	1			3		1	22	bsd	broadsword		5	5000	blac			invswrd7				dmg%		135	185	crush		25	25	lifesteal		5	7	swing2		15	15	hp		35	50	oskill	sacrifice	1	3																										0
-Honor Guard	466	100	1			1		29	34	lsd	long sword		5	5000	whit	whit						dmg-norm		40	70	block3		30	30	balance3		30	30	swing3		30	30	block		10	20	hp%		15	15	knock		1	1																						0
-Winterswipe	467	100	1			3		1	25	lsd	long sword		5	5000								dmg%		150	200	dmg-cold	600	10	20	freeze		1	1	swing2		25	25	aura	114	3	5	res-cold		75	75																										0
-Orc Slayer	468	100	1			3		1	31	wsd	war sword		5	5000	dgrn	dgrn						dmg%		100	150	dmg-norm		10	20	dmg-demon		100	100	demon-heal		20	20	att		100	100	openwounds		35	50	res-pois-max		15	15																						0
-Warrior Untamed	469	100	1			1		30	36	wsd	war sword		5	5000				invswrd16				dmg-norm		40	100	oskill	shout	1	1	oskill	battle orders	1	1	oskill	battle command	1	1	ease		50	50	swing2		40	40																										0
-Bridge of Pain	470	100	1			1		55	39	9ss	gladius		5	5000	blac	blac						dmg%		150	220	dmg-norm		20	40	deadly		15	15	crush		10	15	noheal		1	1	openwounds		33	33	sock		1	1																						0
-Cursebreaker	471	100	1			3		1	34	9ss	gladius		5	5000				invswrd5				dmg%		180	230	swing2		20	20	gethit-skill	66	8	3	aura	109	12	15	str		15	15	res-fire		20	40	hp		50	50																						0
-Darkkon	472	100	1			1		55	41	9sm	cutlass		5	5000	dgry	dgry						dmg%		150	190	dmg-norm		20	40	stupidity		3	3	light		-3	-3	dur		55	55	str		20	20	res-ltng		25	35																						0
-Deathfoe	473	100	1			3		1	36	9sm	cutlass		5	5000				invswrd10				dmg%		185	235	rip		1	1	addxp		5	5	dmg-undead		250	250	dmg-norm		15	30	dmg-cold	200	55	75	res-cold		35	35	half-freeze		1	1																		0
-Locathah	474	100	1			1		55	43	9sb	shamshir		5	5000	dyel			invswrd17				dmg%		150	180	dmg/lvl	8			swing3		40	40	block2		20	20	cast2		20	20	mana		50	60	allskills		1	1																						0
-Death of a Thousand Cuts	475	100	1			3		1	38	9sb	shamshir		5	5000	cred	cred		invsbr				dmg%		190	240	wounds/lvl	11			crush/lvl	4			swing3		30	30	oskill	277	6	6	lifesteal		6	9	pierce-ltng		8	12	res-ltng		35	35																		0
-Fleshbleeder	476	100	1			3		1	40	9fc	tulwar		5	5000				invswrd24				dmg%		160	200	dmg-norm		20	40	openwounds		100	100	lifesteal		6	8	heal-kill		6	8	regen		8	8	res-cold		30	35																						0
-Song of the Damned	477	100	1			1		55	45	9fc	tulwar		5	5000	lgry	lgry		invflc				dmg%		190	240	dmg/lvl	4			oskill	battle orders	1	1	oskill	revive	1	1	oskill	skeleton mastery	5	8	dmg-und/lvl	32			dex		25	25	swing2		25	25																		0
-Pseudodragon	478	100	1			1		55	47	9cr	dimensional blade		5	5000	cgrn	cgrn						dmg%		120	150	dmg-norm		30	60	charged	111	250	12	move2		20	20	vit		20	20	enr		20	20	res-all		20	30	red-dmg%		10	15																		0
-Serpent's Sharp	479	100	1			3		1	42	9cr	dimensional blade		5	5000	oran	oran		invcrs				dmg%		195	245	rep-dur	15			heal-kill		12	15	res-all		25	35	hp		75	75	dmg-pois	200	1677	1677	pierce-pois		25	25																						0
-Grimlock	480	100	1			1		55	49	9bs	battle sword		5	5000								dmg%		190	240	dmg-norm		30	50	swing3		40	40	mag%		40	50	hp		30	50	ignore-ac		1	1	sock		1	3																						0
-Dread of the Blade	481	100	1			3		1	44	9bs	battle sword		5	5000	dyel	dyel		invbsd				dmg%		200	250	dmg-max		40	60	swing2		30	30	allskills		1	1	howl		144	144	oskill	sword mastery	3	3	block3		40	40	manasteal		7	7																		0
-Troglodyte	482	100	1			1		55	52	9ls	rune sword		5	5000				invswrd3				dmg%		180	220	dmg-norm		20	40	reduce-ac		25	25	att%		25	25	lifesteal		6	8	manasteal		6	8	hit-skill	38	7	6																						0
-Bane of All Gods	483	100	1			3		1	47	9ls	rune sword		5	5000	dgrn	dgrn		invlsd				dmg%		215	250	dmg-norm		15	30	allskills		1	1	all-stats		10	20	addxp		3	5	dmg-demon		100	100	att%		25	25	sock		1	3																		0
-Sahuagin	484	100	1			1		55	54	9wd	amcient sword		5	5000				invswrd20				dmg%		200	220	dmg-max		40	60	dmg-pois	250	777	777	hit-skill	91	3	2	hit-skill	84	33	1	red-mag		10	15	abs-fire		10	15	abs-cold		7	10																		0
-Dark Descent	485	100	1			3		1	49	9wd	ancient sword		5	5000	blac	blac		invwsd				dmg%		220	265	swing2		20	20	res-pois		35	60	res-ltng		20	40	nofreeze		1	1	oskill	slow missiles	3	5	enr		15	15	cast2		20	20	regen		6	6														0
-Celestial Lion	486	100	1			1		1	60	7ss	falcata		5	5000	lgld	lgld						dmg%		200	300	dmg-elem	200	50	200	res-all		40	60	swing2		25	25	red-dmg%		10	10	addxp		2	3																										0
-Rabbit Slayer	487	100	1			2		1	49	7ss	Falcata		5	5000				invswrd14				dmg%		175	250	move2		25	25	all-stats		20	20	swing3		50	50	rep-dur	700			rip		1	1																										0
-Badger's Bite	488	100	1			1		1	64	7sm	ataghan		5	5000				invswrd22				dmg%		200	300	swing3		30	30	allskills		2	2	dmg-pois	25	800	800	noheal		1	1	skilltab	17	1	3	lifesteal		5	8																						0
-Wight's Touch	489	100	1			1		1	69	7sb	elegant blade		5	5000				invswrd21				dmg%		100	150	lifesteal		50	50	dmg-mag		300	500	hit-skill	72	25	8	nec		2	2	oskill	sword mastery	10	10	sock		1	1																						0
-Megladon's Bite	490	100	1			1		1	72	7fc	hydra edge		5	5000				invswrd18				dmg%		200	300	crush		33	33	deadly		33	33	regen-mana		25	25	reduce-ac		10	20	str/lvl	3			dex/lvl	3																								0
-Krakken	491	100	1			2		1	57	7fc	Hydra Edge		5	5000	dblu	dblu						dmg%		175	230	dmg-norm		20	40	dmg-cold	300	75	100	res-cold		45	55	res-fire		45	55	sock		2	2	heal-kill		3	12																						0
-Deathfriend	492	100	1			2		1	70	7bs	conquest sword		5	5000	blac			invswrd12				dmg%		200	300	rip		1	1	mag%		50	50	gold%		150	150	lifesteal		8	8	enr		15	15	vit		15	15																						0
-King's Bounty	493	100	1			1		1	79	7bs	Conquest Sword		5	5000				invswrd4				dmg%		200	300	gold%		100	100	mag%		75	75	swing2		25	25	manasteal		8	8	str		20	20	ease		-10	-100																						0
-Rhinoceros Strength	494	100	1			1		1	83	7ls	cryptic sword		5	5000								dmg%		250	350	dmg-norm		50	100	knock		6	6	move3		40	40	str/lvl	10			swing2		20	20																										0
-Owlbear's Attack	495	100	1			1		1	87	7wd	mythical sword		5	5000	oran	oran						dmg%		200	300	sock		1	3	dmg-to-mana		15	15	thorns		75	150	hit-skill	48	12	8	slow		20	20	allskills		2	3	ease		15	15																		0
-Call Of Heroes	496	100	1			2		1	80	7wd	Mythical Sword		5	5000				invswrd19				dmg%		200	300	block		25	25	dmg-elem	400	75	125	addxp		5	15	half-freeze		1	1	abs-mag%		20	20	regen-stam		300	300	cast2		25	25	oskill	Find Item	6	6														0
-Cloaker Beast	497	100	1			1		20	20	2hs	2-handed sword		5	5000				invswrd1				dmg-norm		35	70	swing1		15	15	oskill	cloak of shadows	2	4	stupidity		1	1	balance2		20	20	dex		15	15																										0
-Deathlust	498	100	1			3		1	12	2hs	2-handed sword		5	5000	blac	blac						dmg%		100	150	deadly		25	25	crush		15	15	swing2		20	20	skill	69	1	2																														0
-Blink Dog	499	100	1			1		23	25	clm	claymore		5	5000								dmg-min		30	40	dmg-max		60	80	gethit-skill	54	10	1	res-cold		35	45	skilltab	13	1	2	dur		35	35																										0
-Coaldark	500	100	1			3		1	20	clm	claymore		5	5000	lgry	dgry						dmg%		110	160	stupidity		3	3	skilltab	13	1	3	sock		3	3																																		0
-Ettercap	501	100	1			1		27	29	gis	giant sword		5	5000				invswrd6				dmg-min		35	45	dmg-max		70	90	move2		20	20	res-pois		40	50	att		75	75	heal-kill		8	10																										0
-Hellmessenger	502	100	1			3		1	24	gis	giant sword		5	5000	oran	oran		invgis				dmg%		125	175	dmg-demon		100	100	dmg-fire		10	25	res-fire		10	20	abs-fire		4	7	swing2		25	25																										0
-Yuan-Ti's Venom	503	100	1			1		30	34	bsw	bastard sword		5	5000	dyel	dyel						dmg%		100	120	dmg-norm		25	50	slow		50	50	bloody		1	1	noheal		1	1	res-all		15	20	red-dmg%		5	10																						0
-Oldfather	504	100	1			3		1	27	bsw	bastard sword		5	5000				invbsw				dmg%		125	175	dmg/lvl	9			all-stats		5	5	hp		25	25	rep-dur	2			dur%		20	20																										0
-Gharbad's Cry	505	100	1			1		32	36	flb	flamberge		5	5000	oran	oran						dmg%		70	100	dmg/lvl	8			dmg-min		25	35	hit-skill	81	11	6	charged	28	15	15	manasteal		6	8	regen		2	4																						0
-Warrior's Challenge	506	100	1			3		1	29	flb	flamberge		5	5000				invswrd2				dmg%		135	190	skill	137	5	5	skill	146	5	5	lifesteal		5	7	manasteal		5	5	swing2		20	20																										0
-Demolisher	507	100	1			1		33	38	gsd	great sword		5	5000								dmg-norm		60	120	crush		50	50	swing2		30	30	knock		1	1	allskills		1	1	sock		2	2																										0
-Arctic Edge	508	100	1			3		1	32	gsd	great sword		5	5000	cblu	cblu		invgsd				dmg%		165	200	dmg-cold	300	6	10	hit-skill	45	19	7	res-cold		65	65	pierce-cold		15	15																														0
-Celestial Tiger	509	100	1			1		55	48	92h	espadon		5	5000								dmg%		175	220	dmg-norm		25	50	res-all		20	30	addxp		2	4	block		25	35	block3		40	40	str		20	20																						0
-Sweet Agony	510	100	1			3		1	38	92h	espadon		5	5000	cred	cred		inv2hs				dmg%		190	240	regen		-2	-2	heal-kill		5	5	regen-mana		50	50	gethit-skill	42	7	7	att%		35	35	sock		2	2																						0
-Shirotachi	511	100	1			1		55	52	9cm	dacian falx		5	5000	lgld	lgld						dmg%		170	230	dmg-norm		25	50	lifesteal		7	7	openwounds		33	33	slow		15	25	vit		20	20	cast1		15	15																						0
-Sudden Epiphany	512	100	1			3		1	46	9cm	dacian falx		5	5000	oran	oran		invclm				dmg%		195	245	swing3		25	25	enr		25	25	lifesteal		6	8	manasteal		6	8	bar		2	2	skilltab	14	1	3																						0
-Thunderclap	513	100	1			1		55	56	9gs	tusk sword		5	5000				invswrd8				dmg%		160	200	swing2		20	20	dmg-ltng		75	150	pierce-ltng		10	15	oskill	thunder storm	3	5	oskill	lightning mastery	3	5	res-ltng		45	65	abs-ltng%		10	20																		0
-The Mangler	514	100	1			3		1	49	9gs	tusk sword		5	5000	dgld	dgld		invgis				dmg%		200	250	dmg%/lvl	8			deadly		25	40	crush		25	50	rep-dur	14			dur		50	50	openwounds		100	100																						0
-Na-Krul's Power	515	100	1			1		55	59	9b9	gothic sword		5	5000	lgry	lgry						dmg%		190	225	dmg-max		45	60	str/lvl	3			heal-kill		20	30	mana-kill		3	5	oskill	sword mastery	3	5	cast2		25	25	red-dmg%		10	15																		0
-No Quarter Given	516	100	1			3		1	51	9b9	gothic sword		5	5000	cgrn	cgrn		invbsw				dmg%		210	255	swing3		25	25	knock		3	3	oskill	stun	3	3	slow		20	20	move3		30	30	block3		30	30																						0
-Black Razor	517	100	1			1		55	61	9fb	zweihander		5	5000	blac	blac						dmg%		200	260	dmg-norm		25	50	deadly		44	44	openwounds		66	66	lifesteal		12	12	att%		30	30	bar		2	2																						0
-Demand for Justice	518	100	1			3		1	54	9fb	zweihander		5	5000	whit	whit		invflb				dmg%		215	260	allskills		1	1	addxp		6	10	demon-heal		5	12	kill-skill	Static Field	22	13	ac		75	75	charged	276	15	30	balance2		20	20																		0
-Thundercall	519	100	1			1		55	65	9gd	executioner sword		5	5000	dyel	dyel						dmg%		160	220	swing2		25	25	hit-skill	49	37	3	gethit-skill	53	4	11	res-ltng		35	70	res-fire		35	70	mag%		30	40	gold%		100	150	hp		50	50														0
-The Quick and the Dead	520	100	1			3		1	56	9gd	executioner sword		5	5000	cblu	cblu		invgsd				dmg%		220	260	swing3		50	50	sock		3	6	bar		1	1	oskill	sword mastery	1	3																														0
-Dragon's Breach	521	100	1			1		1	68	72h	legend sword		5	5000	dred	dred						dmg%		220	300	dmg-fire		200	300	dmg-cold	200	200	300	res-all		20	45	move2		20	20	balance2		20	20	allskills		2	2																						0
-Blade Of Mythos	522	100	1			2		1	54	72h	Legend Sword		5	5000								dmg%		200	300	red-dmg%		15	20	res-all		25	35	hp		50	50	swing2		25	25	att%		50	100	noheal		1	1																						0
-Blade of Conan	523	100	1			1		1	73	7cm	highland blade		5	5000	blac	blac						dmg%		200	300	dmg-max		100	200	res-mag		50	50	swing2		30	30	deadly		25	25	bar		2	2	gold%		100	100																						0
-Vorpal Blade	524	100	1			2		1	60	7cm	Highland Blade		5	5000	cblu							dmg%		225	275	crush		25	50	ignore-ac		1	1	deadly/lvl	13			heal-kill		15	25	oskill	whirlwind	1	20																										0
-Split Skull	525	100	1			1		1	77	7gs	balrog blade		5	5000				invgis				dmg%		200	300	dmg-undead		250	250	mana		75	75	att		300	300	addxp		2	2	vit/lvl	6			sock		1	1																						0
-Deadly Hunter	526	100	1			1		1	80	7b7	champion sword		5	5000								dmg%		200	300	deadly		75	75	swing2		25	25	manasteal		6	8	lifesteal		8	8	regen-mana		50	50	rep-dur	15																								0
-Nightscape	527	100	1			1		1	84	7fb	colossus sword		5	5000	blac	blac						dmg%		200	300	regen		5	7	ethereal		1	1	rep-dur	5			hp		40	50	mana%		10	10	bar		1	1	skilltab	14	3	3																		0
-Holy Avenger	528	100	1			2		1	75	7fb	Colossal Sword		5	5000	whit							dmg%		165	200	dmg%/lvl	10			aura	103	12	15	ac		200	500	swing2		20	20	rep-dur	500			death-skill	corpse explosion	100	60	kill-skill	corpse explosion	5	5																		0
-Grandmaster's Glory	529	100	1			1		1	87	7gd	colossus blade		5	5000								dmg%		200	300	dmg/lvl	16			oskill	sword mastery	15	20	gold%		300	300	mag%		60	100	allskills		1	2	balance3		20	20	swing3		40	40																		0
-Bramble Oak	530	100	1			1		24	24	clb	club		5	5000	dgrn	dgrn		invclb				dmg-min		10	15	dmg-max		40	50	block		10	15	swing1		15	15	allskills		1	1																														0
-Quickfeint	531	100	1			3		1	7	clb	club		5	5000				invmace21				dmg%		100	150	dmg-norm		3	6	swing2		20	20	ac		25	50	block		15	20	move1		15	15																										0
-Troll's Nail	532	100	1			1		28	30	spc	spiked club		5	5000	lgrn			invmace16				dmg-min		15	20	dmg-max		55	65	regen		6	9	regen-mana		60	60	dmg-pois	150	344	344	res-all		20	20	red-dmg		10	15																						0
-Oakheart	533	100	1			3		1	9	spc	spiked club		5	5000								dmg%		110	160	red-dmg%		8	12	red-dmg		3	6	red-mag		3	5	hp		20	30	regen		3	5																										0
-Dawn of Skeon	534	100	1			1		55	55	9cl	cudgel		5	5000	dyel							dmg-norm		40	120	dmg%		70	100	pal		1	1	dmg-fire		55	120	res-fire		65	65	dmg-undead		150	150	att%		35	35																						0
-Gladiator's Strike	535	100	1			3		1	40	9cl	cudgel		5	5000	oran	oran		invclb				dmg%		175	230	swing2		25	25	res-ltng		45	55	hit-skill	48	15	9	dmg-ltng		1	225	dru		2	2	noheal		1	1																						0
-Umbral's Bat	536	100	1			1		55	59	9sp	barbed club		5	5000				invmace20				dmg-norm		50	150	swing3		40	40	reduce-ac		15	15	noheal		66	66	pierce-fire		20	20	abs-fire		7	12	sock		2	2	rep-dur	25																				0
-Eater of Souls	537	100	1			3	1	1	46	9sp	barbed club		5	5000	dred			invmace23				dmg%		200	265	swing2		20	20	rip		1	1	oskill	sword mastery	3	5	lifesteal		5	9	dmg-norm		20	45	sock		1	1	block		15	25																		0
-Stirgi's Club	538	100	1			1		1	70	7cl	truncheon		5	5000	cred	cred		invclb				dmg%		290	350	knock		3	3	oskill	bash	1	1	allskills		1	1	ignore-ac		1	1	res-cold		40	40	res-ltng		40	40	hp		75	75																		0
-Blightsummoner	539	100	1			1		1	77	7sp	tyrant club		5	5000	dblu	dblu		invspc				dmg-min		60	90	dmg-max		180	235	swing2		20	20	lifesteal		12	12	manasteal		9	9	abs-ltng		15	25	res-ltng		35	35	res-pois		90	90	hit-skill	92	8	6														0
-Gnat Sting	540	100	1			1		35	35	whm	war hammer		5	5000	dgrn							dmg-min		20	40	dmg-max		75	100	swing2		20	20	stupidity		1	1	sock		2	4	slow		35	35	str		15	15																						0
-Stunhummer	541	100	1			3	1	1	32	whm	war hammer		5	5000				invmace11				dmg%		125	200	dmg/lvl	8			slow		50	50	swing2		20	20	pal		1	1	oskill	sword mastery	1	4	balance2		20	20																						0
-Hammer of Jholm	542	100	1			1		55	60	9wh	battle hammer		5	5000	oran	oran		invmace24				allskills		1	1	dmg/lvl	20			dmg-min		40	60	swing3		30	30	lifesteal		6	8	mana-kill		3	5	crush		25	25																						0
-Blasthammer	543	100	1			3		1	50	9wh	battle hammer		5	5000				invmace12				dmg%		200	255	swing3		30	30	allskills		1	1	skill	243	3	5	gethit-skill	84	12	7	ignore-ac		1	1	sock		1	2																						0
-Famorian's Club	544	100	1			1		31	39	mau	maul		5	5000	oran	oran		invmau				dmg-min		60	90	dmg-max		200	240	swing1		15	15	crush		50	50	hit-skill	243	5	7	sock		1	1																										0
-Spiritcrusher	545	100	1			3	1	1	25	mau	maul		5	5000								dmg%		150	200	dmg-norm		25	50	dmg-undead		250	250	rip		1	1	oskill	sword mastery	2	4	swing1		15	15																										0
-Konnan's Maul	546	100	1			1		40	46	gma	great maul		5	5000								dmg-norm		75	300	swing2		25	25	sock		5	5																																						0
-Vilifier	547	100	1			3		1	33	gma	great maul		5	5000	dgry	dgry						dmg%		175	200	oskill	find item	1	1	rep-dur	4			res-fire		25	25	res-ltng		25	25	mag%/lvl	8			sock		1	2																						0
-Hill Giant's Bludgeon	548	100	1			1		55	59	9m9	war club		5	5000	blac	blac						dmg%		80	100	dmg-min		120	150	dmg-max		300	350	hit-skill	139	9	5	dru		2	2	addxp		3	5	ease		25	25	str/lvl	4																				0
-Readiness for War	549	100	1			3	1	1	48	9m9	war club		5	5000				invmace7				dmg%		200	300	swing2		30	30	oskill	sword mastery	10	10	allskills		2	2	crush/lvl	6			addxp		3	5	move3		30	30																						0
-Doom Avatar	550	100	1			1		55	65	9gm	martel de fer		5	5000	blac			invmace25				dmg%		200	300	dmg-max		150	200	swing3		30	30	dex		25	25	allskills		1	1	charged	95	1	50	rep-dur	20																								0
-Burning Desire	551	100	1			3		1	55	9gm	martel de fer		5	5000	cred	cred						dmg%		225	300	gethit-skill	62	3	30	extra-fire		15	25	res-fire		35	50	res-fire-max		10	10	dmg-fire		100	200	dmg-to-mana		10	10	regen-mana		75	75																		0
-Astral Dreadnought	552	100	1			1		1	75	7m7	ogre maul		5	5000								dmg%		75	100	dmg-max		400	500	ethereal		1	1	indestruct		1	1	swing3		15	15	move1		15	15	red-dmg%		20	25	res-all		30	30																		0
-Hycandra	553	100	1			1		25	25	mac	mace		5	5000	oran	oran		invmac				dmg-norm		10	40	res-all		20	25	dex		15	15	balance3		40	40	block3		40	40																														0
-Lesson in Pain	554	100	1			3		1	13	mac	mace		5	5000								dmg%		100	150	aura	thorns	3	5	gethit-skill	66	20	3	dmg-norm		3	6	pal		1	1																														0
-Dawn's Mist	555	100	1			1		30	29	mst	morning star		5	5000				invmst				dmg-min		10	15	dmg-max		50	60	indestruct		1	1	indestruct		1	1	pal		1	1	sock		2	2																										0
-Endless Sleep	556	100	1			3		1	20	mst	morning star		5	5000	cblu	cblu		invmace1				dmg%		125	175	knock		3	3	stupidity		2	2	hit-skill	72	8	2	res-all		15	25	block		10	15																										0
-Lashfire	557	100	1			1		32	34	fla	flail		5	5000				invmace2				dmg-min		35	45	dmg-max		50	80	dmg-fire		50	60	res-fire		35	45	aura	102	5	7	abs-fire		10	15	swing2		30	30	dex		10	10																		0
-Quickening	558	100	1			3		1	29	fla	flail		5	5000	whit	whit						dmg%		150	200	dmg-min		30	40	swing2		25	25	ignore-ac		1	1	move2		20	20	cast2		20	20	balance2		20	20																						0
-Cat Tail	559	100	1			1		55	55	9ma	flanged mace		5	5000	dyel			invmace22				dmg-norm		50	125	stupidity		1	1	deadly		33	33	str		15	15	cast2		25	25	mana		60	60	regen-mana		75	75																						0
-Demise of the Weak	560	100	1			3		1	45	9ma	flanged mace		5	5000				invmace6				dmg%		180	230	regen		10	15	block		15	25	block2		20	20	balance3		50	50	att		225	225	addxp		2	5	charged	57	35	15																		0
-Comet's Tail	561	100	1			1		55	60	9mt	jagged star		5	5000	oran	oran		invmace8				dmg%		200	250	dmg-elem	150	1	200	res-all		50	50	heal-kill		7	10	addxp		3	5	ignore-ac		1	1	dmg-to-mana		10	15																						0
-Genoa's Trust	562	100	1			3		1	49	9mt	jagged star		5	5000	cred	cred		invmst				dmg%		190	240	res-all		25	50	pierce-ltng		25	25	extra-fire		15	15	freeze		3	3	mana		50	50	cheap		10	15																						0
-Efreeti's Eye	563	100	1			1		55	67	9fl	knout		5	5000								dmg%		200	250	dmg-norm		25	50	lifesteal		8	8	dmg-min		25	25	sock		3	3	allskills		2	2	swing2		20	20																						0
-Frantic Distress	564	100	1			3		1	53	9fl	knout		5	5000				invmace3				dmg%		200	250	howl		90	90	swing3		30	30	move3		40	40	dex		25	25	gethit-skill	58	5	10	sock		2	2	dmg-min		50	60																		0
-Star Dust	565	100	1			1		1	70	7ma	reinforced mace		5	5000				invmac				dmg%		250	300	hit-skill	154	12	7	all-stats		30	30	extra-fire		15	15	extra-ltng		15	15	extra-cold		15	15	cold-len	500																								0
-Fist of Lachdonnan	566	100	1			1		1	55	7ma	Reinforced Mace		5	5000	oran			invmace19				dmg%		200	275	enr		25	25	oskill	shiver armor	2	5	aura	115	3	5	allskills		1	1	dmg-demon		200	200	pierce-fire		10	20	dmg-fire		75	200																		0
-Soulgatherer	567	100	1			1		1	77	7mt	devil star		5	5000	blac			invmace18				dmg-norm		50	200	oskill	revive	1	1	oskill	skeleton mastery	1	1	dmg-undead		350	350	heal-kill		15	15	gethit-skill	74	10	10	enr		35	35	manasteal		8	8																		0
-Angelic Sympathy	568	100	1			1		25	24	scp	scepter		5	5000								dmg-min		5	10	dmg-max		25	40	regen		7	7	aura	99	3	5	red-dmg%		15	15	res-all		15	25																										0
-Ambercall	569	100	1			3		1	8	scp	scepter		5	5000	cred	cred						dmg%		100	150	fire-min		6	9	fire-max		15	20	oskill	shout	1	1	vit		10	10	dex		10	10																										0
-Avenger's Honor	570	100	1			1		28	35	gsc	grand scepter		5	5000	blac	blac						dmg-min		15	25	dmg-max		40	55	pal		1	1	lifesteal		6	6	skill-rand	3	96	125	addxp		3	5	sock		1	1																						0
-Angel's Grace	571	100	1			3		1	22	gsc	grand scepter		5	5000	whit	whit						dmg%		130	180	pal		1	1	dmg-undead		150	150	dmg-demon		200	200	swing2		20	20	balance2		15	15	red-dmg%		10	15																						0
-Crusader's Wrath	572	100	1			1		30	42	wsp	war scepter		5	5000				invmace13				dmg%		60	100	dmg-norm		30	60	crush		22	22	str		10	10	manasteal		6	6	skill	112	3	5	noheal		1	1																						0
-Dawnskein	573	100	1			3		1	29	wsp	war scepter		5	5000	lgld			invmace9				dmg%		150	200	dmg-norm		10	20	allskills		1	1	lifesteal		5	8	light		3	7	mana/lvl	8			hp/lvl	8																								0
-Runestar	574	100	1			1		55	51	9sc	rune scepter		5	5000								dmg-norm		50	125	skill-rand	3	96	125	skill-rand	4	96	125	res-mag		10	15	abs-mag%		30	30	res-all		20	20	allskills		1	1																						0
-Heavenly Wrath	575	100	1			3		1	39	9sc	rune scepter		5	5000	whit	whit						dmg%		190	240	skill-rand	3	96	125	skill-rand	2	96	125	skill-rand	2	96	125	dmg/lvl	8			res-fire		75	75	res-cold		35	50																						0
-Trianthalon's Sprinkler	576	100	1			1		55	58	9qs	holy water sprinkler		5	5000	cblu	cblu						dmg-norm		50	150	mag%		40	50	regen-mana		75	75	mana-kill		8	12	manasteal		8	8	heal-kill		20	20	vit		20	20	move2		20	20																		0
-Dragon Mephit	577	100	1			3		1	48	9qs	holy water sprinkler		5	5000	cgrn	cgrn						dmg%		200	250	dmg-fire		100	200	pierce-fire		15	15	swing2		25	25	cast1		15	15	mana		50	50	dex		10	10	mag%		35	35																		0
-Celestial Knight	578	100	1			1		55	62	9ws	divine scepter		5	5000	dgld			invmace17				dmg%		100	125	dmg-min		40	60	dmg-max		120	160	allskills		2	2	oskill	valkyrie	3	3	swing3		30	30	reduce-ac		20	20																						0
-Lord of Riddles	579	100	1			3		1	54	9ws	divine scepter		5	5000				invmace14				dmg%		225	260	dmg-max		25	35	heal-kill		5	8	regen		5	5	skill-rand	4	96	125	skill-rand	3	96	125	allskills		2	2	res-all		20	20																		0
-Celestial Judgment	580	100	1			1		1	81	7qs	seraph rod		5	5000								dmg%		250	325	dmg-ltng		10	500	dmg-fire		300	400	dmg-cold	150	100	200	freeze		3	3	hit-skill	55	9	2	gethit-skill	64	3	7	res-cold		80	80	res-fire		50	80														0
-Wrath Of Heaven	581	100	1			2		1	77	7qs	Seraph Rod		5	5000	whit							dmg%		200	300	swing2		20	20	extra-fire		20	20	oskill	Fire Wall	8	12	oskill	fire mastery	8	12	abs-fire		15	30	res-all		35	50	block		15	20																		0
-Wrath of the Seraphim	582	100	1			1		1	86	7ws	caduceus		5	5000				invmace15				dmg%		200	240	dmg/lvl	8			lifesteal		8	8	mana-kill		15	15	slow		90	90	stupidity		4	4	pal		3	3	swing3		40	40																		0
-Vampire's Fang	583	100	1			1		19	20	dgr	dagger		5	5000	whit	whit						dmg-norm		20	40	lifesteal		6	6	regen		6	6	regen-mana		50	50	res-cold		45	45																														0
-Darkflayer	584	100	1			3		1	6	dgr	dagger		5	5000								dmg-norm		7	15	swing1		15	15	allskills		1	1	res-all		10	15	noheal		1	1																														0
-Gornnagal's Dirk	585	100	1			1		23	25	dir	dirk		5	5000	cgrn	cgrn						dmg-norm		25	45	ignore-ac		1	1	res-pois		20	30	dex		15	15	pierce-cold		10	10	gold%		30	50																										0
-Prisoner's Anguish	586	100	1			3		1	14	dir	dirk		5	5000								dmg%		150	200	dmg-max		6	10	deadly		50	50	lifesteal		4	7	skill	66	1	3	skill	72	1	3	skill	73	1	3																						0
-Dragon Talon	587	100	1			1		25	29	kri	kris		5	5000	lyel	lyel						dmg-norm		30	55	crush		15	20	manasteal		5	5	cast2		20	20	swing2		25	25	oskill	poison dagger	1	5	sock		1	1																						0
-Zenkiller	588	100	1			3		1	22	kri	kris		5	5000								dmg%		175	200	slow		20	20	oskill	sacrifice	1	3	sock		2	2	res-fire		20	25	extra-pois		15	15																										0
-Moonsea Razor	589	100	1			1		35	35	bld	blade		5	5000	cblu	cblu						dmg-norm		35	70	dmg-cold	100	25	50	deadly		20	30	str		25	25	res-all		20	30	charged	42	22	7	mana		40	40																						0
-Deathprick	590	100	1			3		1	29	bld	blade		5	5000				invdagr3				dmg-norm		15	30	dmg-pois	100	145	145	deadly		15	25	crush		15	25	block		10	15	block1		15	15	move1		15	15																						0
-Cyan Bloodbane	591	100	1			1		55	47	9dg	piognard		5	5000	cred	cred						dmg-norm		25	50	dmg/lvl	8			heal-kill		15	15	mana-kill		15	15	allskills		1	1	charged	82	17	15	ac%		10	10																						0
-Chimera's Claw	592	100	1			3		1	37	9dg	piognard		5	5000	blac	blac		invdgr				dmg%		170	220	block		20	25	res-fire		25	30	deadly		25	25	dex		15	15	hit-skill	49	5	9	lifesteal		4	7																						0
-Rattlesnake Bite	593	100	1			1		55	49	9di	rondel		5	5000								dmg-norm		25	50	dmg/lvl	10			stupidity		2	2	slow		35	35	dmg-pois	100	466	466	swing3		40	40	res-cold		-25	-25	sock		2	2																		0
-Sweetwhisper	594	100	1			3		1	42	9di	rondel		5	5000	dyel	dyel		invdir				sor		1	1	dmg%		175	225	heal-kill		5	7	addxp		5	5	cheap		15	15	charged	32	10	10	mag%		25	25																						0
-Halfling's Blade	595	100	1			1		55	53	9kr	cinquedeas		5	5000								dmg-norm		25	50	dmg/lvl	12			mag%		35	50	gold%		100	100	cast2		20	20	manasteal		6	9	red-dmg%		5	5	dex/lvl	3																				0
-Basalisk's Touch	596	100	1			3		1	46	9kr	cinquedeas		5	5000	lgld	lgld		invkrs				dmg%		180	230	slow		25	25	dmg-pois	75	657	657	oskill	dim vision	5	7	ac		100	100	ignore-ac		1	1	dmg/lvl	6																								0
-Thieve's Lockpicker	597	100	1			1		55	56	9bl	stilleto		5	5000				invdagr1				cast2		30	30	mana		50	100	allskills		1	1	move2		25	25	block2		20	20	block		15	25	res-pois-len		90	90	rep-dur	5																				0
-Falcon Talon	598	100	1			3		1	48	9bl	stilleto		5	5000	lyel	lyel		invbld				dmg%		190	240	swing3		30	30	move2		30	30	charged	teleport	250	1	oskill	raven	6	6	deadly/lvl	12			hp		40	70	res-cold		25	50																		0
-Lich Dagger	599	100	1			1		1	70	7dg	bone knife		5	5000				invdagr2				dmg%		200	245	lifesteal		12	12	extra-fire		15	15	extra-cold		15	20	extra-ltng		10	15	dmg-norm		20	40	cast2		25	25	regen-mana		100	100																		0
-Elven Mystral	600	100	1			1		1	74	7di	mithral point		5	5000	cgrn	cgrn		invdir				dmg-norm		50	100	dmg/lvl	6			allskills		2	2	mag%		25	25	sock		2	2																														0
-Fall Of Myth Drannor	601	100	1			2		1	62	7di	Mithral Point		5	5000								dmg-min		20	40	dmg-max		75	100	regen		-15	-15	mag%		35	35	block		50	75	block3		50	50	cast3		35	35	mana%		25	25																		0
-Chaos Wail	602	100	1			1		1	80	7kr	fanged knife		5	5000	oran	oran		invkrs				dmg%		200	300	nec		1	1	oskill	grim ward	5	5	howl		155	155	swing2		25	25	skilltab	6	1	1	skill-rand	3	66	95																						0
-Dagger of Kara'Tir	603	100	1			1		1	85	7bl	legend spike		5	5000				invbld				oskill	find item	10	10	mag%		200	300	sock		3	3	dmg-min		40	60	dmg-max		100	150	swing2		25	25																										0
-Sleepthorn	604	100	1			1		20	18	spr	spear		5	5000	lgrn	lgrn						dmg-norm		35	70	stupidity		3	3	slow		80	80	res-pois		30	50	swing1		115	15	dur		60	60																										0
-Zealot's Branch	605	100	1			3		1	9	spr	spear		5	5000								dmg%		100	150	swing1		20	20	skill	106	3	3	res-pois		15	15	vit		10	10	str		10	10																										0
-Mako's Pierce	606	100	1			1		26	23	tri	trident		5	5000	dgry	dgry						dmg-norm		40	80	openwounds		25	50	demon-heal		15	15	lifesteal		15	15	thorns		15	20	att		100	100	str		10	10	dur		60	60																		0
-Deceiver's Device	607	100	1			3		1	15	tri	trident		5	5000								dmg%		110	165	move2		25	25	cheap		15	15	res-ltng		35	35	lifesteal		5	5	att		225	225																										0
-Spear of Hydragoon	608	100	1			1		27	25	brn	brandistock		5	5000								dmg-norm		45	90	swing2		20	20	dur		60	60	skill	143	8	8	str		10	10	dex		10	10																										0
-Fangtree	609	100	1			3		1	17	brn	brandistock		5	5000	dgry	dgry						dmg%		130	180	bloody		1	1	deadly/lvl	16			gethit-skill	81	25	3	sock		2	3																														0
-Dragon Turtle	610	100	1			1		29	32	spt	spetum		5	5000	blac	blac						dmg-norm		50	100	dur		60	60	res-all		20	30	red-dmg%		15	15	bar		1	1	mag%		30	50	swing2		30	30																						0
-Ruemonger	611	100	1			3	1	1	26	spt	spetum		5	5000								dmg%		150	200	dmg-norm		10	20	stupidity		1	1	oskill	sword mastery	2	2	allskills		1	1	extra-ltng		15	15	pierce-ltng		20	20																						0
-Footman's Picket	612	100	1			1		30	38	pik	pike		5	5000	dgld	dgld						dmg-norm		60	120	ethereal		1	1	rep-dur	25			lifesteal		7	7	manasteal		5	7	swing1		20	20	allskills		1	1	balance2		20	20																		0
-Woodclaw	613	100	1			3		1	30	pik	pike		5	5000								dmg%		180	200	dmg-norm		10	40	addxp		3	8	swing2		30	30	sock		1	6																														0
-Old Wolf	614	100	1			1		55	41	9sr	war spear		5	5000				invspea1				dmg%		120	160	dmg-norm		50	100	dur		60	60	addxp		3	3	oskill	wearwolf	5	5	oskill	shape shifting	3	5	swing3		40	40	lifesteal		5	5	oskill	fury	3	5														0
-Mandrake	615	100	1			3		1	35	9sr	war spear		5	5000	blac	blac		invspr				dmg%		180	230	heal-kill		8	8	lifesteal		6	8	hp		65	65	swing2		20	20	addxp		3	5	hit-skill	49	9	5																						0
-Flametongue	616	100	1			1		55	46	9tr	fuscina		5	5000	cred	cred						dmg%		120	160	dmg-norm		50	100	oskill	inferno	5	5	extra-fire		15	20	pierce-fire		15	20	dmg-fire		200	300	res-fire		65	65	dur		60	60																		0
-Frostband	617	100	1			3		1	39	9tr	fuscina		5	5000	cblu	cblu		invtri				dmg%		185	235	hit-skill	44	4	17	dmg-cold	175	200	250	allskills		1	1	str		15	15	enr		25	25	res-cold		25	25	res-fire		30	50																		0
-Dragoon's Shank	618	100	1			1		55	49	9br	war fork		5	5000								dmg%		125	175	dmg-norm		60	120	skill	143	10	15	swing2		20	20	sock		3	5	bar		2	2	dur		60	60																						0
-Fear and Loathing	619	100	1			3		1	44	9br	war fork		5	5000	dgld	dgld		invbrn				dmg%		190	240	dmg-norm		40	80	gethit-skill	77	6	4	hit-skill	86	10	3	swing3		30	30	manasteal		5	8	move2		20	20																						0
-Dragon Soul	620	100	1			1		55	54	9st	yari		5	5000	lred	lred						dmg%		125	175	dmg-norm		70	140	lifesteal		15	15	hp%		20	25	move3		40	40	balance2		25	25	res-all		20	40	dur		60	60																		0
-Dreams of Empire	621	100	1			3		1	47	9st	yari		5	5000	oran	oran		invspt				dmg%		205	255	crush		25	25	balance3		40	40	addxp		10	10	hp%		5	15	oskill	valkyrie	1	3	mag%		40	50	gold%/lvl	24																				0
-Imperial Dragonlance	622	100	1			1		55	57	9p9	lance		5	5000	whit	whit						dmg%		150	200	dmg-norm		80	160	swing3		60	60	sock		2	2	allskills		3	3	rep-dur	20			all-stats		10	10																						0
-Jouster's Boast	623	100	1			3	1	1	50	9p9	lance		5	5000				invpik				dmg%		215	260	bar		2	2	swing3		25	25	lifesteal		12	12	oskill	sword mastery	3	3	indestruct		1	1	dmg/lvl	16																								0
-Ice Mephit	624	100	1			1		1	60	7sr	hyperion spear		5	5000	dyel	dyel						dmg%		200	270	dur		60	60	dmg-cold		300	400	freeze		3	3	oskill	whirlwind	1	1	res-cold		50	50	res-fire		50	50																						0
-Kuo-Toa's Spear	625	100	1			1		1	69	7tr	stygian pike		5	5000	dgrn	dgrn						dmg%		200	280	dur		60	60	swing2		25	25	dmg-pois	400	8875	8875	howl		150	150																														0
-Breath Of Fire	626	100	1			2		1	58	7tr	Stygian Pike		5	5000	dred	dred						dmg%		200	250	swing3		30	30	oskill	inferno	40	40	res-fire		75	75	pierce-fire		30	30	abs-fire%		25	25																										0
-Imperial Passion	627	100	1			1		1	74	7br	mancatcher		5	5000								dmg%		250	300	swing3		30	30	addxp		20	20	cheap		5	5	dmg/lvl	24			rep-dur	50																												0
-Spirit of Lachdonan	628	100	1			1		1	79	7st	ghost spear		5	5000								dmg%		175	200	ethereal		1	1	fade		1	1	str/lvl	8			indestruct		1	1	dmg%/lvl	16			ease		-25	-25																						0
-Spirit Light	629	100	1			2		1	72	7st	Ghost Spear		5	5000	cblu	cblu						ethereal		1	1	indestruct		1	1	dmg%		200	300	ease		25	25	light		7	7	swing3		50	50	lifesteal		12	15	gethit-skill	60	50	12																		0
-Prancing Pike	630	100	1			1		1	86	7p7	war pike		5	5000	oran	oran						dmg%		150	200	swing3		60	60	balance3		40	40	allskills		3	3	dur		60	60	sock		1	1	heal-kill		35	50																						0
-Hylocan Axe	631	100	1			1		19	20	bar	bardiche		5	5000	lred	lred						dmg-min		20	30	dmg-max		50	70	dmg%		50	70	swing2		35	35	manasteal		4	6	dmg-cold	100	25	50																										0
-Knave's Ascendence	632	100	1			3		1	10	bar	bardiche		5	5000								dmg%		100	150	ac		25	50	str		15	15	dex		10	10	vit		10	10	hp		35	35																										0
+Auburnfire	401	100	1			1	1	18	18	hax	hand axe		5	5000	cred	cred						dmg-min		10	15	dmg-max		35	45	dmg-fire		35	50	dmg-ltng		25	50	res-ltng		15	25																														0
+Gangrene Reaper	402	100	1			3	1	4	6	hax	hand axe		5	5000	cgrn			invaxe19				dmg%		100	150	dmg-pois	100	55	55	noheal		1	1	rep-dur	15			str		10	10																														0
+Easebringer	403	100	1			1	1	22	22	axe	axe		5	5000				invaxe13				dmg-min		15	20	dmg-max		40	50	ease		-40	-40	swing2		25	25	lifesteal		6	6																														0
+Goreflood	404	100	1			3	1	9	10	axe	axe		5	5000	cred	cred						dmg%		120	170	bloody		1	1	wounds/lvl	24			skilltab	13	1	3	lifesteal		3	5	pierce-fire		5	10																										0
+Longsuffering	405	100	1			1	1	25	25	2ax	double axe		5	5000	dgrn			invaxe12				dmg-norm		20	50	cold-len	200			dmg-pois	100	200	200	slow		20	20	noheal		1	1	openwounds		44	44																										0
+Lungreaver	406	100	1			3	1	14	14	2ax	double axe		5	5000				invaxe11				dmg%		130	180	slow		10	10	lifesteal		5	7	move1		15	15	sock		1	2																														0
+Broken Earth	407	100	1			1	1	29	30	mpi	military pick		5	5000	lgry	lgry						dmg-min		15	20	dmg-max		30	60	hit-skill	234	6	3	dru		1	1	swing1		15	15	res-cold		33	33	res-pois		33	33																						0
+Occam's Razor	408	100	1			3	1	20	23	mpi	military pick		5	5000								dmg%		140	190	deadly		40	40	allskills		1	1	aura	99	5	7	oskill	sword mastery	3	6	res-fire		15	25																										0
+Shadazar's Answer	409	100	1			1	1	30	35	wax	war axe		5	5000	lblu	lblu						dmg-norm		20	70	allskills		1	1	knock		2	2	lifesteal		5	5	mana-kill		3	5	red-dmg		8	10	dur		40	40																						0
+Deathflake	410	100	1			3	1	26	30	wax	war axe		5	5000								dmg%		175	200	dmg-max		20	30	charged	raise skeleton	2	40	heal-kill		5	8	dmg-undead		200	200	aura	119	2	4																										0
+Bloody Scalp	411	100	1			1	1	55	44	9ha	hatchet		5	5000								dmg%		100	135	dmg/lvl	8			swing2		20	20	bloody		1	1	deadly		17	17	openwounds		77	77	att%		20	20																						0
+Pure Rancor	412	100	1			3	1	34	38	9ha	hatchet		5	5000	dgrn	dgrn		invhax				dmg%		175	200	bar		2	2	swing2		20	20	res-pois		25	25	dmg-pois	100	466	466	oskill	decrepify	1	3	dur		45	45																						0
+Slayer of Trents	413	100	1			3	1	44	45	9ax	cleaver		5	5000	dgrn			invaxe3				dmg%		170	200	dmg-norm		15	30	dmg-demon		100	100	reduce-ac		15	15	rep-dur	10			charged	130	15	10	res-pois		25	35																						0
+Edge of Forever	414	100	1			1	1	50	49	9ax	cleaver		5	5000				invaxe				dmg%		180	210	allskills		1	1	gethit-skill	53	7	12	rep-dur	15			dmg-norm		20	50	res-pois-len		35	35	sock		1	2																						0
+Cryohydra	415	100	1			1	1	55	56	92a	twin axe		5	5000	dblu			invaxe7				dmg%		150	200	dmg-max		30	50	dmg-cold	350	10	20	freeze		5	5	res-fire		55	55	res-cold		30	40	gethit-skill	39	75	20																						0
+Harvest of Souls	416	100	1			3	1	48	50	92a	twin axe		5	5000	blac			invaxe22				dmg%		190	230	swing3		30	30	oskill	bone spirit	4	7	aura	118	8	12	dmg-undead		175	175	lifesteal		5	8	noheal		1	1																						0
+Cornugon	417	100	1			3	1	50	53	9mp	crowbill		5	5000	oran	oran						dmg%		160	220	dmg-demon		250	250	manasteal		10	10	demon-heal		35	35	ac		35	50	red-dmg		10	15	red-mag		8	12	res-ltng		15	25																		0
+Groundshatter	418	100	1			1	1	55	60	9mp	crowbill		5	5000				invmpi				dmg%		200	240	hit-skill	234	12	7	fireskill		2	2	att		250	250	str		20	20	dmg-max		30	50	red-dmg		5	9	res-fire		35	40	res-cold		25	35														0
+Couatl	419	100	1			1	1	55	65	9wa	naga		5	5000	lgrn			invaxe5				dmg%		175	200	dmg-norm		10	50	swing3		50	50	move3		50	50	balance3		50	50	block3		50	50																										0
+Antics of the Jester	420	100	1			3	1	56	57	9wa	naga		5	5000	oran	oran		invwax				dmg%		225	260	howl		1	66	heal-kill		1	10	res-all		1	35	extra-cold		1	10	swing3		55	55	sock		1	2																						0
+Marilith	421	100	1			1	1	64	68	7ha	tomahawk		5	5000	dyel	dyel						dmg%		200	240	allskills		2	2	ignore-ac		1	1	aura	114	1	5	lifesteal		6	6	manasteal		6	6	dmg-to-mana		20	20																						0
+Death Slaad	422	100	1			1	1	69	71	7ax	small crescent		5	5000	blac	dgry		invaxe4				dmg%		350	450	dmg/lvl	8			swing3		60	60	rip		1	1																																		0
+Moon Blade	423	100	1			2	1	60	64	7ax	Small Crescent		5	5000								dmg%		190	280	block		15	25	block1		15	15	balance1		20	20	oskill	Life Tap	3	5	res-all		20	25																										0
+Beholder	424	100	1			1	1	72	75	72a	ettin axe		5	5000				invaxe6				dmg%		250	290	swing1		15	15	ac%		25	25	red-dmg%		15	15	res-mag		75	75	res-all		60	80																										0
+Elder Tojanida	425	100	1			1	1	75	80	7mp	war spike		5	5000				invaxe2				dmg%/lvl	33			addxp		3	5	dmg-min		50	75	res-ltng		30	40	res-cold		25	25	extra-fire		15	15	sock		1	1																						0
+Frostwyrm	426	100	1			1	1	80	84	7wa	berserker axe		5	5000	lblu	lblu		invaxe9				dmg%		150	200	sock		3	3	swing2		20	20	hit-skill	44	33	35	gethit-skill	45	8	19	abs-cold%		50	50	res-cold		25	25																						0
+Light Phasm	427	100	1			1	1	20	21	lax	large axe		5	5000	whit	whit						dmg-min		10	20	dmg-max		35	45	light		3	3	dmg-ltng		1	75	res-ltng		35	40	dmg-undead		150	150	dmg%		70	100																						0
+Gracehunter	428	100	1			3	1	6	8	lax	large axe		5	5000								dmg%		100	150	swing2		20	20	mag%		20	20	gold%		75	75	manasteal		6	6																														0
+Night Hag	429	100	1			1	1	24	23	bax	broad axe		5	5000	blac	blac						dmg-min		10	20	dmg-max		40	50	dmg-pois	75	133	133	lifesteal		7	7	stupidity		1	1	swing2		15	15	dmg%		70	100																						0
+Mirth Bringer	430	100	1			3	1	12	14	bax	broad axe		5	5000								dmg%		110	160	hit-skill	8	10	3	res-pois		20	25	res-cold		20	25	addxp		3	5																														0
+Tendriculos	431	100	1			1	1	27	27	btx	battle axe		5	5000								dmg-min		15	25	dmg-max		50	65	dur		40	40	att%		25	35	crush		15	25	reduce-ac		10	15	dmg%		70	100																						0
+Sandking	432	100	1			3	1	21	23	btx	battle axe		5	5000	lyel	lyel		invaxe1				dmg%		120	170	stupidity		2	2	dmg-fire		8	14	att		120	120	reduce-ac		10	15																														0
+Winter Wolf	433	100	1			1	1	30	33	gax	great axe		5	5000				invaxe16				dmg-min		20	30	dmg-max		55	75	dmg%		70	100	swing2		25	25	gethit-skill	50	6	4	charged	227	15	8	sock		1	2	dmg%		70	80																		0
+Nova Spine	434	100	1			3	1	26	28	gax	great axe		5	5000	cblu	cblu		invgax				dmg%		140	200	hit-skill	44	100	9	res-cold		25	30	res-cold-max		5	5	dmg-ltng		1	30	sock		1	2																										0
+Taskmaster's Curse	435	100	1			1	1	31	37	gix	giant axe		5	5000	dred	dred						dmg-min		30	40	dmg-max		60	80	hit-skill	81	4	2	manasteal		6	6	str		45	45	ease		35	35	dex		20	20	hp		30	50	dmg%		70	100														0
+Curseweaver	436	100	1			3	1	30	32	gix	giant axe		5	5000				invaxe10				dmg%		165	200	hit-skill	87	12	5	swing2		25	25	manasteal		5	7	bar		1	1	oskill	sword mastery	1	3																										0
+Sunblighter	437	100	1			1	1	55	45	9la	military axe		5	5000	dyel	dyel						dmg%		180	230	dmg-fire		100	300	res-all		25	25	deadly		44	44	extra-fire		15	15	stupidity		2	2	res-fire		40	50																						0
+Threat of Storms	438	100	1			3	1	38	40	9la	military axe		5	5000	dgry	dgry		invlax				dmg%		175	225	dmg-cold	200	25	40	dmg-ltng		1	150	dmg-fire		40	100	res-all		25	25	aura	118	5	10	swing1		15	15																						0
+Dwarven Honor	439	100	1			1	1	55	51	9ba	bearded axe		5	5000	dgry	dgry						dmg%		180	220	dmg-norm		25	50	red-dmg%		10	15	red-dmg		8	10	rep-dur	20			swing2		20	20	ac		100	150																						0
+Grandiose Dreams	440	100	1			3	1	40	44	9ba	bearded axe		5	5000								dmg%		180	230	mag%		40	40	dmg-max		40	60	allskills		1	1	crush		40	40	hp		60	60	move2		20	20																						0
+Ravid's Bite	441	100	1			3	1	45	47	9bt	tabar		5	5000								dmg%		200	250	hit-skill	238	12	2	swing3		30	30	all-stats		20	20	hp%		15	15	slow		10	20	sock		2	2	allskills		1	1																		0
+Spirit Naga	442	100	1			1	1	55	54	9bt	tabar		5	5000	lgrn	lgrn		invbtx				dmg%		190	240	rep-dur	18			ethereal		1	1	dmg-demon		150	150	res-fire		35	35	res-fire-max		10	10	bar		2	2	manasteal		8	8																		0
+Brittlequick	443	100	1			1	1	55	59	9ga	gothic axe		5	5000	whit			invaxe15				dur		-45	-45	rep-dur	5			swing3		50	50	dmg%		200	250	dmg-norm		20	40	reduce-ac		10	15	thorns		20	25	bar		1	1																		0
+Tonstrike	444	100	1			3	1	48	50	9ga	gothic axe		5	5000	oran			invaxe18				dmg%		200	250	swing3		30	30	str/lvl	4			deadly		25	25	hit-skill	229	4	9	dru		1	2	sock		2	2																						0
+Ogre's Breath	445	100	1			3	1	50	52	9gi	ancient axe		5	5000	lgry	lgry						dmg%		220	270	swing2		20	20	red-dmg%		10	15	gethit-skill	87	2	30	str		15	25	dex		-5	-5	regen		1	4	move1		10	10																		0
+Mythslayer	446	100	1			1	1	55	58	9gi	ancient axe		5	5000	dgld	dgld		invgix				dmg%		150	200	dmg%/lvl	12			all-stats		15	15	swing2		25	25	att%		30	30	allskills		1	1	charged	142	20	35	balance2		20	20																		0
+Woodland Beast	447	100	1			2	1	51	53	7la	feral axe		5	5000								dmg%		200	250	dru		2	3	skilltab	15	1	3	swing2		20	20	deadly/lvl	10			crush/lvl	4			res-all		15	25																						0
+Werewolf Slayer	448	100	1			1	1	65	65	7la	Feral Axe		5	5000	cblu	cblu						dmg%/lvl	16			dmg-min		25	35	dru		1	2	swing3		35	35	move3		40	40	lifesteal		5	8	sock		1	2	oskill	Wearwolf	8	20	oskill	Shape Shifting	8	20	dmg%		100	125										0
+Shapeshifter	449	100	1			1	1	68	69	7ba	silver-edged axe		5	5000				invaxe21				dmg%		200	250	swing3		40	40	skill	224	10	15	hp%		40	40	ethereal		1	1	indestruct		1	1																										0
+Dyer's Eve	450	100	1			1	1	71	73	7bt	decapitator		5	5000				invaxe20				dmg%		200	250	dmg-max		50	100	rip		1	1	lifesteal		12	12	bar		2	2	mag%		40	60	regen		12	15	sock		1	1																		0
+Hero's Welcome	451	100	1			1	1	75	79	7ga	champion axe		5	5000				invaxe14				dmg%		225	270	addxp		3	5	cheap		10	15	swing2		20	20	vit/lvl	5			red-dmg%		10	10	res-all		25	25	nofreeze		1	1																		0
+Nameless Horror	452	100	1			1	1	80	84	7gi	glorious axe		5	5000								dmg%		275	325	howl		155	155	gethit-skill	130	10	20	charged	88	77	15	res-pois		88	88	res-pois-len		50	75	res-pois-max		5	5	dmg-pois	300	1455	1455	allskills		2	2														0
+Epee of Speed	453	100	1			1	1	23	24	ssd	short sword		5	5000				invswrd15				dmg-norm		25	50	swing2		30	30	balance2		30	30	move2		20	20	charged	139	100	8	block		20	25																										0
+Deviljack	454	100	1			3	1	1	5	ssd	short sword		5	5000	lgry	lgry						dmg%		100	150	dmg-demon		100	100	addxp		3	5	cheap		10	10																																		0
+Anadek's Sword	455	100	1			1	1	24	26	scm	scimitar		5	5000								dmg-norm		25	50	swing1		15	15	dmg%		50	60	dmg-fire		25	40	res-cold		20	30	rep-dur	25																												0
+Briarblade	456	100	1			3	1	1	8	scm	scimitar		5	5000	dgrn	dgrn						dmg%		100	150	dmg-pois	250	100	100	openwounds		50	50	heal-kill		3	5	deadly		15	15																														0
+Sajorn Jinx	457	100	1			1	1	25	28	sbr	saber		5	5000				invswrd23				dmg-norm		25	55	hit-skill	76	4	3	hp		35	50	att		150	150	lifesteal		4	6	regen-mana		3	6																										0
+Chromablade	458	100	1			3	1	4	10	sbr	saber		5	5000	whit	whit						dmg%		100	150	ease		-100	-100	light		7	7	dmg-norm		5	5	gethit-skill	36	20	4																														0
+Qikadar's Laughter	459	100	1			1	1	26	30	flc	falshion		5	5000				invswrd25				dmg-min		20	25	dmg-max		50	65	howl		33	33	res-all		20	20	allskills		1	1	swing2		20	20																										0
+Fiendslayer	460	100	1			3	1	4	13	flc	falshion		5	5000	oran	oran						dmg%		120	170	dmg-demon		200	200	att-demon		200	200	demon-heal		5	8	swing2		20	20	res-all		20	20																										0
+Quartz Star	461	100	1			1	1	27	31	crs	crystal sword		5	5000								dmg-norm		30	65	manasteal		6	6	res-fire		25	25	block2		15	15	dex		20	20	mag%		35	35																										0
+Irksome Edge	462	100	1			3	1	8	17	crs	crystal sword		5	5000	oran	oran						dmg%		130	180	ease		25	25	hit-skill	42	8	7	manasteal		5	5	knock		1	1	howl		88	88																										0
+Azurewrath1	463	0	1			5	1	6	13	crs	Crystal Sword		5	5000	lgry	lgry						deadly		50	50	mag%		10	25	dmg-cold	100	3	6	dmg%		100	100	dur		25	75	dmg-mag		5	10																										0
+Omni-Slash	464	100	1			1	1	28	32	bsd	broadsword		5	5000				invswrd11				dmg%		100	140	dmg-norm		15	35	swing3		20	20	sock		2	2	deadly		20	20	thorns		20	20																										0
+Vanquisher	465	100	1			3	1	10	22	bsd	broadsword		5	5000	blac			invswrd7				dmg%		135	185	crush		25	25	lifesteal		5	7	swing2		15	15	hp		35	50	oskill	sacrifice	1	3																										0
+Honor Guard	466	100	1			1	1	29	34	lsd	long sword		5	5000	whit	whit						dmg-norm		40	70	block3		30	30	balance3		30	30	swing3		30	30	block		10	20	hp%		15	15	knock		1	1																						0
+Winterswipe	467	100	1			3	1	16	25	lsd	long sword		5	5000								dmg%		150	200	dmg-cold	600	10	20	freeze		1	1	swing2		25	25	aura	114	3	5	res-cold		75	75																										0
+Orc Slayer	468	100	1			3	1	24	31	wsd	war sword		5	5000	dgrn	dgrn						dmg%		100	150	dmg-norm		10	20	dmg-demon		100	100	demon-heal		20	20	att		100	100	openwounds		35	50	res-pois-max		15	15																						0
+Warrior Untamed	469	100	1			1	1	30	36	wsd	war sword		5	5000				invswrd16				dmg-norm		40	100	oskill	shout	1	1	oskill	battle orders	1	1	oskill	battle command	1	1	ease		50	50	swing2		40	40																										0
+Bridge of Pain	470	100	1			1	1	55	39	9ss	gladius		5	5000	blac	blac						dmg%		150	220	dmg-norm		20	40	deadly		15	15	crush		10	15	noheal		1	1	openwounds		33	33	sock		1	1																						0
+Cursebreaker	471	100	1			3	1	26	34	9ss	gladius		5	5000				invswrd5				dmg%		180	230	swing2		20	20	gethit-skill	66	8	3	aura	109	12	15	str		15	15	res-fire		20	40	hp		50	50																						0
+Darkkon	472	100	1			1	1	55	41	9sm	cutlass		5	5000	dgry	dgry						dmg%		150	190	dmg-norm		20	40	stupidity		3	3	light		-3	-3	dur		55	55	str		20	20	res-ltng		25	35																						0
+Deathfoe	473	100	1			3	1	28	36	9sm	cutlass		5	5000				invswrd10				dmg%		185	235	rip		1	1	addxp		5	5	dmg-undead		250	250	dmg-norm		15	30	dmg-cold	200	55	75	res-cold		35	35	half-freeze		1	1																		0
+Locathah	474	100	1			1	1	55	43	9sb	shamshir		5	5000	dyel			invswrd17				dmg%		150	180	dmg/lvl	8			swing3		40	40	block2		20	20	cast2		20	20	mana		50	60	allskills		1	1																						0
+Death of a Thousand Cuts	475	100	1			3	1	30	38	9sb	shamshir		5	5000	cred	cred		invsbr				dmg%		190	240	wounds/lvl	11			crush/lvl	4			swing3		30	30	oskill	277	6	6	lifesteal		6	9	pierce-ltng		8	12	res-ltng		35	35																		0
+Fleshbleeder	476	100	1			3	1	32	40	9fc	tulwar		5	5000				invswrd24				dmg%		160	200	dmg-norm		20	40	openwounds		100	100	lifesteal		6	8	heal-kill		6	8	regen		8	8	res-cold		30	35																						0
+Song of the Damned	477	100	1			1	1	55	45	9fc	tulwar		5	5000	lgry	lgry		invflc				dmg%		190	240	dmg/lvl	4			oskill	battle orders	1	1	oskill	revive	1	1	oskill	skeleton mastery	5	8	dmg-und/lvl	32			dex		25	25	swing2		25	25																		0
+Pseudodragon	478	100	1			1	1	55	47	9cr	dimensional blade		5	5000	cgrn	cgrn						dmg%		120	150	dmg-norm		30	60	charged	111	250	12	move2		20	20	vit		20	20	enr		20	20	res-all		20	30	red-dmg%		10	15																		0
+Serpent's Sharp	479	100	1			3	1	38	42	9cr	dimensional blade		5	5000	oran	oran		invcrs				dmg%		195	245	rep-dur	15			heal-kill		12	15	res-all		25	35	hp		75	75	dmg-pois	200	1677	1677	pierce-pois		25	25																						0
+Grimlock	480	100	1			1	1	55	49	9bs	battle sword		5	5000								dmg%		190	240	dmg-norm		30	50	swing3		40	40	mag%		40	50	hp		30	50	ignore-ac		1	1	sock		1	3																						0
+Dread of the Blade	481	100	1			3	1	40	44	9bs	battle sword		5	5000	dyel	dyel		invbsd				dmg%		200	250	dmg-max		40	60	swing2		30	30	allskills		1	1	howl		144	144	oskill	sword mastery	3	3	block3		40	40	manasteal		7	7																		0
+Troglodyte	482	100	1			1	1	55	52	9ls	rune sword		5	5000				invswrd3				dmg%		180	220	dmg-norm		20	40	reduce-ac		25	25	att%		25	25	lifesteal		6	8	manasteal		6	8	hit-skill	38	7	6																						0
+Bane of All Gods	483	100	1			3	1	42	47	9ls	rune sword		5	5000	dgrn	dgrn		invlsd				dmg%		215	250	dmg-norm		15	30	allskills		1	1	all-stats		10	20	addxp		3	5	dmg-demon		100	100	att%		25	25	sock		1	3																		0
+Sahuagin	484	100	1			1	1	55	54	9wd	amcient sword		5	5000				invswrd20				dmg%		200	220	dmg-max		40	60	dmg-pois	250	777	777	hit-skill	91	3	2	hit-skill	84	33	1	red-mag		10	15	abs-fire		10	15	abs-cold		7	10																		0
+Dark Descent	485	100	1			3	1	46	49	9wd	ancient sword		5	5000	blac	blac		invwsd				dmg%		220	265	swing2		20	20	res-pois		35	60	res-ltng		20	40	nofreeze		1	1	oskill	slow missiles	3	5	enr		15	15	cast2		20	20	regen		6	6														0
+Celestial Lion	486	100	1			1	1	55	60	7ss	falcata		5	5000	lgld	lgld						dmg%		200	300	dmg-elem	200	50	200	res-all		40	60	swing2		25	25	red-dmg%		10	10	addxp		2	3																										0
+Rabbit Slayer	487	100	1			2	1	45	49	7ss	Falcata		5	5000				invswrd14				dmg%		175	250	move2		25	25	all-stats		20	20	swing3		50	50	rep-dur	700			rip		1	1																										0
+Badger's Bite	488	100	1			1	1	60	64	7sm	ataghan		5	5000				invswrd22				dmg%		200	300	swing3		30	30	allskills		2	2	dmg-pois	25	800	800	noheal		1	1	skilltab	17	1	3	lifesteal		5	8																						0
+Wight's Touch	489	100	1			1	1	65	69	7sb	elegant blade		5	5000				invswrd21				dmg%		100	150	lifesteal		50	50	dmg-mag		300	500	hit-skill	72	25	8	nec		2	2	oskill	sword mastery	10	10	sock		1	1																						0
+Megladon's Bite	490	100	1			1	1	70	72	7fc	hydra edge		5	5000				invswrd18				dmg%		200	300	crush		33	33	deadly		33	33	regen-mana		25	25	reduce-ac		10	20	str/lvl	3			dex/lvl	3																								0
+Krakken	491	100	1			2	1	54	57	7fc	Hydra Edge		5	5000	dblu	dblu						dmg%		175	230	dmg-norm		20	40	dmg-cold	300	75	100	res-cold		45	55	res-fire		45	55	sock		2	2	heal-kill		3	12																						0
+Deathfriend	492	100	1			2	1	66	70	7bs	conquest sword		5	5000	blac			invswrd12				dmg%		200	300	rip		1	1	mag%		50	50	gold%		150	150	lifesteal		8	8	enr		15	15	vit		15	15																						0
+King's Bounty	493	100	1			1	1	74	79	7bs	Conquest Sword		5	5000				invswrd4				dmg%		200	300	gold%		100	100	mag%		75	75	swing2		25	25	manasteal		8	8	str		20	20	ease		-10	-100																						0
+Rhinoceros Strength	494	100	1			1	1	80	83	7ls	cryptic sword		5	5000								dmg%		250	350	dmg-norm		50	100	knock		6	6	move3		40	40	str/lvl	10			swing2		20	20																										0
+Owlbear's Attack	495	100	1			1	1	83	87	7wd	mythical sword		5	5000	oran	oran						dmg%		200	300	sock		1	3	dmg-to-mana		15	15	thorns		75	150	hit-skill	48	12	8	slow		20	20	allskills		2	3	ease		15	15																		0
+Call Of Heroes	496	100	1			2	1	76	80	7wd	Mythical Sword		5	5000				invswrd19				dmg%		200	300	block		25	25	dmg-elem	400	75	125	addxp		5	15	half-freeze		1	1	abs-mag%		20	20	regen-stam		300	300	cast2		25	25	oskill	Find Item	6	6														0
+Cloaker Beast	497	100	1			1	1	20	20	2hs	2-handed sword		5	5000				invswrd1				dmg-norm		35	70	swing1		15	15	oskill	cloak of shadows	2	4	stupidity		1	1	balance2		20	20	dex		15	15																										0
+Deathlust	498	100	1			3	1	6	12	2hs	2-handed sword		5	5000	blac	blac						dmg%		100	150	deadly		25	25	crush		15	15	swing2		20	20	skill	69	1	2																														0
+Blink Dog	499	100	1			1	1	23	25	clm	claymore		5	5000								dmg-min		30	40	dmg-max		60	80	gethit-skill	54	10	1	res-cold		35	45	skilltab	13	1	2	dur		35	35																										0
+Coaldark	500	100	1			3	1	12	20	clm	claymore		5	5000	lgry	dgry						dmg%		110	160	stupidity		3	3	skilltab	13	1	3	sock		3	3																																		0
+Ettercap	501	100	1			1	1	27	29	gis	giant sword		5	5000				invswrd6				dmg-min		35	45	dmg-max		70	90	move2		20	20	res-pois		40	50	att		75	75	heal-kill		8	10																										0
+Hellmessenger	502	100	1			3	1	18	24	gis	giant sword		5	5000	oran	oran		invgis				dmg%		125	175	dmg-demon		100	100	dmg-fire		10	25	res-fire		10	20	abs-fire		4	7	swing2		25	25																										0
+Yuan-Ti's Venom	503	100	1			1	1	30	34	bsw	bastard sword		5	5000	dyel	dyel						dmg%		100	120	dmg-norm		25	50	slow		50	50	bloody		1	1	noheal		1	1	res-all		15	20	red-dmg%		5	10																						0
+Oldfather	504	100	1			3	1	21	27	bsw	bastard sword		5	5000				invbsw				dmg%		125	175	dmg/lvl	9			all-stats		5	5	hp		25	25	rep-dur	2			dur%		20	20																										0
+Gharbad's Cry	505	100	1			1	1	32	36	flb	flamberge		5	5000	oran	oran						dmg%		70	100	dmg/lvl	8			dmg-min		25	35	hit-skill	81	11	6	charged	28	15	15	manasteal		6	8	regen		2	4																						0
+Warrior's Challenge	506	100	1			3	1	26	29	flb	flamberge		5	5000				invswrd2				dmg%		135	190	skill	137	5	5	skill	146	5	5	lifesteal		5	7	manasteal		5	5	swing2		20	20																										0
+Demolisher	507	100	1			1	1	33	38	gsd	great sword		5	5000								dmg-norm		60	120	crush		50	50	swing2		30	30	knock		1	1	allskills		1	1	sock		2	2																										0
+Arctic Edge	508	100	1			3	1	28	32	gsd	great sword		5	5000	cblu	cblu		invgsd				dmg%		165	200	dmg-cold	300	6	10	hit-skill	45	19	7	res-cold		65	65	pierce-cold		15	15																														0
+Celestial Tiger	509	100	1			1	1	55	48	92h	espadon		5	5000								dmg%		175	220	dmg-norm		25	50	res-all		20	30	addxp		2	4	block		25	35	block3		40	40	str		20	20																						0
+Sweet Agony	510	100	1			3	1	36	38	92h	espadon		5	5000	cred	cred		inv2hs				dmg%		190	240	regen		-2	-2	heal-kill		5	5	regen-mana		50	50	gethit-skill	42	7	7	att%		35	35	sock		2	2																						0
+Shirotachi	511	100	1			1	1	55	52	9cm	dacian falx		5	5000	lgld	lgld						dmg%		170	230	dmg-norm		25	50	lifesteal		7	7	openwounds		33	33	slow		15	25	vit		20	20	cast1		15	15																						0
+Sudden Epiphany	512	100	1			3	1	40	46	9cm	dacian falx		5	5000	oran	oran		invclm				dmg%		195	245	swing3		25	25	enr		25	25	lifesteal		6	8	manasteal		6	8	bar		2	2	skilltab	14	1	3																						0
+Thunderclap	513	100	1			1	1	55	56	9gs	tusk sword		5	5000				invswrd8				dmg%		160	200	swing2		20	20	dmg-ltng		75	150	pierce-ltng		10	15	oskill	thunder storm	3	5	oskill	lightning mastery	3	5	res-ltng		45	65	abs-ltng%		10	20																		0
+The Mangler	514	100	1			3	1	44	49	9gs	tusk sword		5	5000	dgld	dgld		invgis				dmg%		200	250	dmg%/lvl	8			deadly		25	40	crush		25	50	rep-dur	14			dur		50	50	openwounds		100	100																						0
+Na-Krul's Power	515	100	1			1	1	55	59	9b9	gothic sword		5	5000	lgry	lgry						dmg%		190	225	dmg-max		45	60	str/lvl	3			heal-kill		20	30	mana-kill		3	5	oskill	sword mastery	3	5	cast2		25	25	red-dmg%		10	15																		0
+No Quarter Given	516	100	1			3	1	48	51	9b9	gothic sword		5	5000	cgrn	cgrn		invbsw				dmg%		210	255	swing3		25	25	knock		3	3	oskill	stun	3	3	slow		20	20	move3		30	30	block3		30	30																						0
+Black Razor	517	100	1			1	1	55	61	9fb	zweihander		5	5000	blac	blac						dmg%		200	260	dmg-norm		25	50	deadly		44	44	openwounds		66	66	lifesteal		12	12	att%		30	30	bar		2	2																						0
+Demand for Justice	518	100	1			3	1	50	54	9fb	zweihander		5	5000	whit	whit		invflb				dmg%		215	260	allskills		1	1	addxp		6	10	demon-heal		5	12	kill-skill	Static Field	22	13	ac		75	75	charged	276	15	30	balance2		20	20																		0
+Thundercall	519	100	1			1	1	55	65	9gd	executioner sword		5	5000	dyel	dyel						dmg%		160	220	swing2		25	25	hit-skill	49	37	3	gethit-skill	53	4	11	res-ltng		35	70	res-fire		35	70	mag%		30	40	gold%		100	150	hp		50	50														0
+The Quick and the Dead	520	100	1			3	1	52	56	9gd	executioner sword		5	5000	cblu	cblu		invgsd				dmg%		220	260	swing3		50	50	sock		3	6	bar		1	1	oskill	sword mastery	1	3																														0
+Dragon's Breach	521	100	1			1	1	64	68	72h	legend sword		5	5000	dred	dred						dmg%		220	300	dmg-fire		200	300	dmg-cold	200	200	300	res-all		20	45	move2		20	20	balance2		20	20	allskills		2	2																						0
+Blade Of Mythos	522	100	1			2	1	50	54	72h	Legend Sword		5	5000								dmg%		200	300	red-dmg%		15	20	res-all		25	35	hp		50	50	swing2		25	25	att%		50	100	noheal		1	1																						0
+Blade of Conan	523	100	1			1	1	69	73	7cm	highland blade		5	5000	blac	blac						dmg%		200	300	dmg-max		100	200	res-mag		50	50	swing2		30	30	deadly		25	25	bar		2	2	gold%		100	100																						0
+Vorpal Blade	524	100	1			2	1	56	60	7cm	Highland Blade		5	5000	cblu							dmg%		225	275	crush		25	50	ignore-ac		1	1	deadly/lvl	13			heal-kill		15	25	oskill	whirlwind	1	20																										0
+Split Skull	525	100	1			1	1	73	77	7gs	balrog blade		5	5000				invgis				dmg%		200	300	dmg-undead		250	250	mana		75	75	att		300	300	addxp		2	2	vit/lvl	6			sock		1	1																						0
+Deadly Hunter	526	100	1			1	1	76	80	7b7	champion sword		5	5000								dmg%		200	300	deadly		75	75	swing2		25	25	manasteal		6	8	lifesteal		8	8	regen-mana		50	50	rep-dur	15																								0
+Nightscape	527	100	1			1	1	80	84	7fb	colossus sword		5	5000	blac	blac						dmg%		200	300	regen		5	7	ethereal		1	1	rep-dur	5			hp		40	50	mana%		10	10	bar		1	1	skilltab	14	3	3																		0
+Holy Avenger	528	100	1			2	1	71	75	7fb	Colossal Sword		5	5000	whit							dmg%		165	200	dmg%/lvl	10			aura	103	12	15	ac		200	500	swing2		20	20	rep-dur	500			death-skill	corpse explosion	100	60	kill-skill	corpse explosion	5	5																		0
+Grandmaster's Glory	529	100	1			1	1	83	87	7gd	colossus blade		5	5000								dmg%		200	300	dmg/lvl	16			oskill	sword mastery	15	20	gold%		300	300	mag%		60	100	allskills		1	2	balance3		20	20	swing3		40	40																		0
+Bramble Oak	530	100	1			1	1	24	24	clb	club		5	5000	dgrn	dgrn		invclb				dmg-min		10	15	dmg-max		40	50	block		10	15	swing1		15	15	allskills		1	1																														0
+Quickfeint	531	100	1			3	1	1	7	clb	club		5	5000				invmace21				dmg%		100	150	dmg-norm		3	6	swing2		20	20	ac		25	50	block		15	20	move1		15	15																										0
+Troll's Nail	532	100	1			1	1	28	30	spc	spiked club		5	5000	lgrn			invmace16				dmg-min		15	20	dmg-max		55	65	regen		6	9	regen-mana		60	60	dmg-pois	150	344	344	res-all		20	20	red-dmg		10	15																						0
+Oakheart	533	100	1			3	1	1	9	spc	spiked club		5	5000								dmg%		110	160	red-dmg%		8	12	red-dmg		3	6	red-mag		3	5	hp		20	30	regen		3	5																										0
+Dawn of Skeon	534	100	1			1	1	55	55	9cl	cudgel		5	5000	dyel							dmg-norm		40	120	dmg%		70	100	pal		1	1	dmg-fire		55	120	res-fire		65	65	dmg-undead		150	150	att%		35	35																						0
+Gladiator's Strike	535	100	1			3	1	26	40	9cl	cudgel		5	5000	oran	oran		invclb				dmg%		175	230	swing2		25	25	res-ltng		45	55	hit-skill	48	15	9	dmg-ltng		1	225	dru		2	2	noheal		1	1																						0
+Umbral's Bat	536	100	1			1	1	55	59	9sp	barbed club		5	5000				invmace20				dmg-norm		50	150	swing3		40	40	reduce-ac		15	15	noheal		66	66	pierce-fire		20	20	abs-fire		7	12	sock		2	2	rep-dur	25																				0
+Eater of Souls	537	100	1			3	1	36	46	9sp	barbed club		5	5000	dred			invmace23				dmg%		200	265	swing2		20	20	rip		1	1	oskill	sword mastery	3	5	lifesteal		5	9	dmg-norm		20	45	sock		1	1	block		15	25																		0
+Stirgi's Club	538	100	1			1	1	65	70	7cl	truncheon		5	5000	cred	cred		invclb				dmg%		290	350	knock		3	3	oskill	bash	1	1	allskills		1	1	ignore-ac		1	1	res-cold		40	40	res-ltng		40	40	hp		75	75																		0
+Blightsummoner	539	100	1			1	1	72	77	7sp	tyrant club		5	5000	dblu	dblu		invspc				dmg-min		60	90	dmg-max		180	235	swing2		20	20	lifesteal		12	12	manasteal		9	9	abs-ltng		15	25	res-ltng		35	35	res-pois		90	90	hit-skill	92	8	6														0
+Gnat Sting	540	100	1			1	1	35	35	whm	war hammer		5	5000	dgrn							dmg-min		20	40	dmg-max		75	100	swing2		20	20	stupidity		1	1	sock		2	4	slow		35	35	str		15	15																						0
+Stunhummer	541	100	1			3	1	15	32	whm	war hammer		5	5000				invmace11				dmg%		125	200	dmg/lvl	8			slow		50	50	swing2		20	20	pal		1	1	oskill	sword mastery	1	4	balance2		20	20																						0
+Hammer of Jholm	542	100	1			1	1	55	60	9wh	battle hammer		5	5000	oran	oran		invmace24				allskills		1	1	dmg/lvl	20			dmg-min		40	60	swing3		30	30	lifesteal		6	8	mana-kill		3	5	crush		25	25																						0
+Blasthammer	543	100	1			3	1	42	50	9wh	battle hammer		5	5000				invmace12				dmg%		200	255	swing3		30	30	allskills		1	1	skill	243	3	5	gethit-skill	84	12	7	ignore-ac		1	1	sock		1	2																						0
+Famorian's Club	544	100	1			1	1	31	39	mau	maul		5	5000	oran	oran		invmau				dmg-min		60	90	dmg-max		200	240	swing1		15	15	crush		50	50	hit-skill	243	5	7	sock		1	1																										0
+Spiritcrusher	545	100	1			3	1	15	25	mau	maul		5	5000								dmg%		150	200	dmg-norm		25	50	dmg-undead		250	250	rip		1	1	oskill	sword mastery	2	4	swing1		15	15																										0
+Konnan's Maul	546	100	1			1	1	40	46	gma	great maul		5	5000								dmg-norm		75	300	swing2		25	25	sock		5	5																																						0
+Vilifier	547	100	1			3	1	22	33	gma	great maul		5	5000	dgry	dgry						dmg%		175	200	oskill	find item	1	1	rep-dur	4			res-fire		25	25	res-ltng		25	25	mag%/lvl	8			sock		1	2																						0
+Hill Giant's Bludgeon	548	100	1			1	1	55	59	9m9	war club		5	5000	blac	blac						dmg%		80	100	dmg-min		120	150	dmg-max		300	350	hit-skill	139	9	5	dru		2	2	addxp		3	5	ease		25	25	str/lvl	4																				0
+Readiness for War	549	100	1			3	1	40	48	9m9	war club		5	5000				invmace7				dmg%		200	300	swing2		30	30	oskill	sword mastery	10	10	allskills		2	2	crush/lvl	6			addxp		3	5	move3		30	30																						0
+Doom Avatar	550	100	1			1	1	55	65	9gm	martel de fer		5	5000	blac			invmace25				dmg%		200	300	dmg-max		150	200	swing3		30	30	dex		25	25	allskills		1	1	charged	95	1	50	rep-dur	20																								0
+Burning Desire	551	100	1			3	1	45	55	9gm	martel de fer		5	5000	cred	cred						dmg%		225	300	gethit-skill	62	3	30	extra-fire		15	25	res-fire		35	50	res-fire-max		10	10	dmg-fire		100	200	dmg-to-mana		10	10	regen-mana		75	75																		0
+Astral Dreadnought	552	100	1			1	1	70	75	7m7	ogre maul		5	5000								dmg%		75	100	dmg-max		400	500	ethereal		1	1	indestruct		1	1	swing3		15	15	move1		15	15	red-dmg%		20	25	res-all		30	30																		0
+Hycandra	553	100	1			1	1	25	25	mac	mace		5	5000	oran	oran		invmac				dmg-norm		10	40	res-all		20	25	dex		15	15	balance3		40	40	block3		40	40																														0
+Lesson in Pain	554	100	1			3	1	1	13	mac	mace		5	5000								dmg%		100	150	aura	thorns	3	5	gethit-skill	66	20	3	dmg-norm		3	6	pal		1	1																														0
+Dawn's Mist	555	100	1			1	1	30	29	mst	morning star		5	5000				invmst				dmg-min		10	15	dmg-max		50	60	indestruct		1	1	indestruct		1	1	pal		1	1	sock		2	2																										0
+Endless Sleep	556	100	1			3	1	8	20	mst	morning star		5	5000	cblu	cblu		invmace1				dmg%		125	175	knock		3	3	stupidity		2	2	hit-skill	72	8	2	res-all		15	25	block		10	15																										0
+Lashfire	557	100	1			1	1	32	34	fla	flail		5	5000				invmace2				dmg-min		35	45	dmg-max		50	80	dmg-fire		50	60	res-fire		35	45	aura	102	5	7	abs-fire		10	15	swing2		30	30	dex		10	10																		0
+Quickening	558	100	1			3	1	14	29	fla	flail		5	5000	whit	whit						dmg%		150	200	dmg-min		30	40	swing2		25	25	ignore-ac		1	1	move2		20	20	cast2		20	20	balance2		20	20																						0
+Cat Tail	559	100	1			1	1	55	55	9ma	flanged mace		5	5000	dyel			invmace22				dmg-norm		50	125	stupidity		1	1	deadly		33	33	str		15	15	cast2		25	25	mana		60	60	regen-mana		75	75																						0
+Demise of the Weak	560	100	1			3	1	36	45	9ma	flanged mace		5	5000				invmace6				dmg%		180	230	regen		10	15	block		15	25	block2		20	20	balance3		50	50	att		225	225	addxp		2	5	charged	57	35	15																		0
+Comet's Tail	561	100	1			1	1	55	60	9mt	jagged star		5	5000	oran	oran		invmace8				dmg%		200	250	dmg-elem	150	1	200	res-all		50	50	heal-kill		7	10	addxp		3	5	ignore-ac		1	1	dmg-to-mana		10	15																						0
+Genoa's Trust	562	100	1			3	1	39	49	9mt	jagged star		5	5000	cred	cred		invmst				dmg%		190	240	res-all		25	50	pierce-ltng		25	25	extra-fire		15	15	freeze		3	3	mana		50	50	cheap		10	15																						0
+Efreeti's Eye	563	100	1			1	1	55	67	9fl	knout		5	5000								dmg%		200	250	dmg-norm		25	50	lifesteal		8	8	dmg-min		25	25	sock		3	3	allskills		2	2	swing2		20	20																						0
+Frantic Distress	564	100	1			3	1	45	53	9fl	knout		5	5000				invmace3				dmg%		200	250	howl		90	90	swing3		30	30	move3		40	40	dex		25	25	gethit-skill	58	5	10	sock		2	2	dmg-min		50	60																		0
+Star Dust	565	100	1			1	1	64	70	7ma	reinforced mace		5	5000				invmac				dmg%		250	300	hit-skill	154	12	7	all-stats		30	30	extra-fire		15	15	extra-ltng		15	15	extra-cold		15	15	cold-len	500																								0
+Fist of Lachdonnan	566	100	1			1	1	45	55	7ma	Reinforced Mace		5	5000	oran			invmace19				dmg%		200	275	enr		25	25	oskill	shiver armor	2	5	aura	115	3	5	allskills		1	1	dmg-demon		200	200	pierce-fire		10	20	dmg-fire		75	200																		0
+Soulgatherer	567	100	1			1	1	72	77	7mt	devil star		5	5000	blac			invmace18				dmg-norm		50	200	oskill	revive	1	1	oskill	skeleton mastery	1	1	dmg-undead		350	350	heal-kill		15	15	gethit-skill	74	10	10	enr		35	35	manasteal		8	8																		0
+Angelic Sympathy	568	100	1			1	1	25	24	scp	scepter		5	5000								dmg-min		5	10	dmg-max		25	40	regen		7	7	aura	99	3	5	red-dmg%		15	15	res-all		15	25																										0
+Ambercall	569	100	1			3	1	1	8	scp	scepter		5	5000	cred	cred						dmg%		100	150	fire-min		6	9	fire-max		15	20	oskill	shout	1	1	vit		10	10	dex		10	10																										0
+Avenger's Honor	570	100	1			1	1	28	35	gsc	grand scepter		5	5000	blac	blac						dmg-min		15	25	dmg-max		40	55	pal		1	1	lifesteal		6	6	skill-rand	3	96	125	addxp		3	5	sock		1	1																						0
+Angel's Grace	571	100	1			3	1	8	22	gsc	grand scepter		5	5000	whit	whit						dmg%		130	180	pal		1	1	dmg-undead		150	150	dmg-demon		200	200	swing2		20	20	balance2		15	15	red-dmg%		10	15																						0
+Crusader's Wrath	572	100	1			1	1	30	42	wsp	war scepter		5	5000				invmace13				dmg%		60	100	dmg-norm		30	60	crush		22	22	str		10	10	manasteal		6	6	skill	112	3	5	noheal		1	1																						0
+Dawnskein	573	100	1			3	1	18	29	wsp	war scepter		5	5000	lgld			invmace9				dmg%		150	200	dmg-norm		10	20	allskills		1	1	lifesteal		5	8	light		3	7	mana/lvl	8			hp/lvl	8																								0
+Runestar	574	100	1			1	1	55	51	9sc	rune scepter		5	5000								dmg-norm		50	125	skill-rand	3	96	125	skill-rand	4	96	125	res-mag		10	15	abs-mag%		30	30	res-all		20	20	allskills		1	1																						0
+Heavenly Wrath	575	100	1			3	1	29	39	9sc	rune scepter		5	5000	whit	whit						dmg%		190	240	skill-rand	3	96	125	skill-rand	2	96	125	skill-rand	2	96	125	dmg/lvl	8			res-fire		75	75	res-cold		35	50																						0
+Trianthalon's Sprinkler	576	100	1			1	1	55	58	9qs	holy water sprinkler		5	5000	cblu	cblu						dmg-norm		50	150	mag%		40	50	regen-mana		75	75	mana-kill		8	12	manasteal		8	8	heal-kill		20	20	vit		20	20	move2		20	20																		0
+Dragon Mephit	577	100	1			3	1	40	48	9qs	holy water sprinkler		5	5000	cgrn	cgrn						dmg%		200	250	dmg-fire		100	200	pierce-fire		15	15	swing2		25	25	cast1		15	15	mana		50	50	dex		10	10	mag%		35	35																		0
+Celestial Knight	578	100	1			1	1	55	62	9ws	divine scepter		5	5000	dgld			invmace17				dmg%		100	125	dmg-min		40	60	dmg-max		120	160	allskills		2	2	oskill	valkyrie	3	3	swing3		30	30	reduce-ac		20	20																						0
+Lord of Riddles	579	100	1			3	1	48	54	9ws	divine scepter		5	5000				invmace14				dmg%		225	260	dmg-max		25	35	heal-kill		5	8	regen		5	5	skill-rand	4	96	125	skill-rand	3	96	125	allskills		2	2	res-all		20	20																		0
+Celestial Judgment	580	100	1			1	1	78	81	7qs	seraph rod		5	5000								dmg%		250	325	dmg-ltng		10	500	dmg-fire		300	400	dmg-cold	150	100	200	freeze		3	3	hit-skill	55	9	2	gethit-skill	64	3	7	res-cold		80	80	res-fire		50	80														0
+Wrath Of Heaven	581	100	1			2	1	72	77	7qs	Seraph Rod		5	5000	whit							dmg%		200	300	swing2		20	20	extra-fire		20	20	oskill	Fire Wall	8	12	oskill	fire mastery	8	12	abs-fire		15	30	res-all		35	50	block		15	20																		0
+Wrath of the Seraphim	582	100	1			1	1	80	86	7ws	caduceus		5	5000				invmace15				dmg%		200	240	dmg/lvl	8			lifesteal		8	8	mana-kill		15	15	slow		90	90	stupidity		4	4	pal		3	3	swing3		40	40																		0
+Vampire's Fang	583	100	1			1	1	19	20	dgr	dagger		5	5000	whit	whit						dmg-norm		20	40	lifesteal		6	6	regen		6	6	regen-mana		50	50	res-cold		45	45																														0
+Darkflayer	584	100	1			3	1	1	6	dgr	dagger		5	5000								dmg-norm		7	15	swing1		15	15	allskills		1	1	res-all		10	15	noheal		1	1																														0
+Gornnagal's Dirk	585	100	1			1	1	23	25	dir	dirk		5	5000	cgrn	cgrn						dmg-norm		25	45	ignore-ac		1	1	res-pois		20	30	dex		15	15	pierce-cold		10	10	gold%		30	50																										0
+Prisoner's Anguish	586	100	1			3	1	6	14	dir	dirk		5	5000								dmg%		150	200	dmg-max		6	10	deadly		50	50	lifesteal		4	7	skill	66	1	3	skill	72	1	3	skill	73	1	3																						0
+Dragon Talon	587	100	1			1	1	25	29	kri	kris		5	5000	lyel	lyel						dmg-norm		30	55	crush		15	20	manasteal		5	5	cast2		20	20	swing2		25	25	oskill	poison dagger	1	5	sock		1	1																						0
+Zenkiller	588	100	1			3	1	8	22	kri	kris		5	5000								dmg%		175	200	slow		20	20	oskill	sacrifice	1	3	sock		2	2	res-fire		20	25	extra-pois		15	15																										0
+Moonsea Razor	589	100	1			1	1	35	35	bld	blade		5	5000	cblu	cblu						dmg-norm		35	70	dmg-cold	100	25	50	deadly		20	30	str		25	25	res-all		20	30	charged	42	22	7	mana		40	40																						0
+Deathprick	590	100	1			3	1	12	29	bld	blade		5	5000				invdagr3				dmg-norm		15	30	dmg-pois	100	145	145	deadly		15	25	crush		15	25	block		10	15	block1		15	15	move1		15	15																						0
+Cyan Bloodbane	591	100	1			1	1	55	47	9dg	piognard		5	5000	cred	cred						dmg-norm		25	50	dmg/lvl	8			heal-kill		15	15	mana-kill		15	15	allskills		1	1	charged	82	17	15	ac%		10	10																						0
+Chimera's Claw	592	100	1			3	1	26	37	9dg	piognard		5	5000	blac	blac		invdgr				dmg%		170	220	block		20	25	res-fire		25	30	deadly		25	25	dex		15	15	hit-skill	49	5	9	lifesteal		4	7																						0
+Rattlesnake Bite	593	100	1			1	1	55	49	9di	rondel		5	5000								dmg-norm		25	50	dmg/lvl	10			stupidity		2	2	slow		35	35	dmg-pois	100	466	466	swing3		40	40	res-cold		-25	-25	sock		2	2																		0
+Sweetwhisper	594	100	1			3	1	34	42	9di	rondel		5	5000	dyel	dyel		invdir				sor		1	1	dmg%		175	225	heal-kill		5	7	addxp		5	5	cheap		15	15	charged	32	10	10	mag%		25	25																						0
+Halfling's Blade	595	100	1			1	1	55	53	9kr	cinquedeas		5	5000								dmg-norm		25	50	dmg/lvl	12			mag%		35	50	gold%		100	100	cast2		20	20	manasteal		6	9	red-dmg%		5	5	dex/lvl	3																				0
+Basalisk's Touch	596	100	1			3	1	38	46	9kr	cinquedeas		5	5000	lgld	lgld		invkrs				dmg%		180	230	slow		25	25	dmg-pois	75	657	657	oskill	dim vision	5	7	ac		100	100	ignore-ac		1	1	dmg/lvl	6																								0
+Thieve's Lockpicker	597	100	1			1	1	55	56	9bl	stilleto		5	5000				invdagr1				cast2		30	30	mana		50	100	allskills		1	1	move2		25	25	block2		20	20	block		15	25	res-pois-len		90	90	rep-dur	5																				0
+Falcon Talon	598	100	1			3	1	40	48	9bl	stilleto		5	5000	lyel	lyel		invbld				dmg%		190	240	swing3		30	30	move2		30	30	charged	teleport	250	1	oskill	raven	6	6	deadly/lvl	12			hp		40	70	res-cold		25	50																		0
+Lich Dagger	599	100	1			1	1	65	70	7dg	bone knife		5	5000				invdagr2				dmg%		200	245	lifesteal		12	12	extra-fire		15	15	extra-cold		15	20	extra-ltng		10	15	dmg-norm		20	40	cast2		25	25	regen-mana		100	100																		0
+Elven Mystral	600	100	1			1	1	70	74	7di	mithral point		5	5000	cgrn	cgrn		invdir				dmg-norm		50	100	dmg/lvl	6			allskills		2	2	mag%		25	25	sock		2	2																														0
+Fall Of Myth Drannor	601	100	1			2	1	55	62	7di	Mithral Point		5	5000								dmg-min		20	40	dmg-max		75	100	regen		-15	-15	mag%		35	35	block		50	75	block3		50	50	cast3		35	35	mana%		25	25																		0
+Chaos Wail	602	100	1			1	1	75	80	7kr	fanged knife		5	5000	oran	oran		invkrs				dmg%		200	300	nec		1	1	oskill	grim ward	5	5	howl		155	155	swing2		25	25	skilltab	6	1	1	skill-rand	3	66	95																						0
+Dagger of Kara'Tir	603	100	1			1	1	80	85	7bl	legend spike		5	5000				invbld				oskill	find item	10	10	mag%		200	300	sock		3	3	dmg-min		40	60	dmg-max		100	150	swing2		25	25																										0
+Sleepthorn	604	100	1			1	1	20	18	spr	spear		5	5000	lgrn	lgrn						dmg-norm		35	70	stupidity		3	3	slow		80	80	res-pois		30	50	swing1		115	15	dur		60	60																										0
+Zealot's Branch	605	100	1			3	1	1	9	spr	spear		5	5000								dmg%		100	150	swing1		20	20	skill	106	3	3	res-pois		15	15	vit		10	10	str		10	10																										0
+Mako's Pierce	606	100	1			1	1	26	23	tri	trident		5	5000	dgry	dgry						dmg-norm		40	80	openwounds		25	50	demon-heal		15	15	lifesteal		15	15	thorns		15	20	att		100	100	str		10	10	dur		60	60																		0
+Deceiver's Device	607	100	1			3	1	4	15	tri	trident		5	5000								dmg%		110	165	move2		25	25	cheap		15	15	res-ltng		35	35	lifesteal		5	5	att		225	225																										0
+Spear of Hydragoon	608	100	1			1	1	27	25	brn	brandistock		5	5000								dmg-norm		45	90	swing2		20	20	dur		60	60	skill	143	8	8	str		10	10	dex		10	10																										0
+Fangtree	609	100	1			3	1	8	17	brn	brandistock		5	5000	dgry	dgry						dmg%		130	180	bloody		1	1	deadly/lvl	16			gethit-skill	81	25	3	sock		2	3																														0
+Dragon Turtle	610	100	1			1	1	29	32	spt	spetum		5	5000	blac	blac						dmg-norm		50	100	dur		60	60	res-all		20	30	red-dmg%		15	15	bar		1	1	mag%		30	50	swing2		30	30																						0
+Ruemonger	611	100	1			3	1	18	26	spt	spetum		5	5000								dmg%		150	200	dmg-norm		10	20	stupidity		1	1	oskill	sword mastery	2	2	allskills		1	1	extra-ltng		15	15	pierce-ltng		20	20																						0
+Footman's Picket	612	100	1			1	1	30	38	pik	pike		5	5000	dgld	dgld						dmg-norm		60	120	ethereal		1	1	rep-dur	25			lifesteal		7	7	manasteal		5	7	swing1		20	20	allskills		1	1	balance2		20	20																		0
+Woodclaw	613	100	1			3	1	22	30	pik	pike		5	5000								dmg%		180	200	dmg-norm		10	40	addxp		3	8	swing2		30	30	sock		1	6																														0
+Old Wolf	614	100	1			1	1	55	41	9sr	war spear		5	5000				invspea1				dmg%		120	160	dmg-norm		50	100	dur		60	60	addxp		3	3	oskill	wearwolf	5	5	oskill	shape shifting	3	5	swing3		40	40	lifesteal		5	5	oskill	fury	3	5														0
+Mandrake	615	100	1			3	1	28	35	9sr	war spear		5	5000	blac	blac		invspr				dmg%		180	230	heal-kill		8	8	lifesteal		6	8	hp		65	65	swing2		20	20	addxp		3	5	hit-skill	49	9	5																						0
+Flametongue	616	100	1			1	1	55	46	9tr	fuscina		5	5000	cred	cred						dmg%		120	160	dmg-norm		50	100	oskill	inferno	5	5	extra-fire		15	20	pierce-fire		15	20	dmg-fire		200	300	res-fire		65	65	dur		60	60																		0
+Frostband	617	100	1			3	1	30	39	9tr	fuscina		5	5000	cblu	cblu		invtri				dmg%		185	235	hit-skill	44	4	17	dmg-cold	175	200	250	allskills		1	1	str		15	15	enr		25	25	res-cold		25	25	res-fire		30	50																		0
+Dragoon's Shank	618	100	1			1	1	55	49	9br	war fork		5	5000								dmg%		125	175	dmg-norm		60	120	skill	143	10	15	swing2		20	20	sock		3	5	bar		2	2	dur		60	60																						0
+Fear and Loathing	619	100	1			3	1	35	44	9br	war fork		5	5000	dgld	dgld		invbrn				dmg%		190	240	dmg-norm		40	80	gethit-skill	77	6	4	hit-skill	86	10	3	swing3		30	30	manasteal		5	8	move2		20	20																						0
+Dragon Soul	620	100	1			1	1	55	54	9st	yari		5	5000	lred	lred						dmg%		125	175	dmg-norm		70	140	lifesteal		15	15	hp%		20	25	move3		40	40	balance2		25	25	res-all		20	40	dur		60	60																		0
+Dreams of Empire	621	100	1			3	1	38	47	9st	yari		5	5000	oran	oran		invspt				dmg%		205	255	crush		25	25	balance3		40	40	addxp		10	10	hp%		5	15	oskill	valkyrie	1	3	mag%		40	50	gold%/lvl	24																				0
+Imperial Dragonlance	622	100	1			1	1	55	57	9p9	lance		5	5000	whit	whit						dmg%		150	200	dmg-norm		80	160	swing3		60	60	sock		2	2	allskills		3	3	rep-dur	20			all-stats		10	10																						0
+Jouster's Boast	623	100	1			3	1	42	50	9p9	lance		5	5000				invpik				dmg%		215	260	bar		2	2	swing3		25	25	lifesteal		12	12	oskill	sword mastery	3	3	indestruct		1	1	dmg/lvl	16																								0
+Ice Mephit	624	100	1			1	1	54	60	7sr	hyperion spear		5	5000	dyel	dyel						dmg%		200	270	dur		60	60	dmg-cold		300	400	freeze		3	3	oskill	whirlwind	1	1	res-cold		50	50	res-fire		50	50																						0
+Kuo-Toa's Spear	625	100	1			1	1	64	69	7tr	stygian pike		5	5000	dgrn	dgrn						dmg%		200	280	dur		60	60	swing2		25	25	dmg-pois	400	8875	8875	howl		150	150																														0
+Breath Of Fire	626	100	1			2	1	50	58	7tr	Stygian Pike		5	5000	dred	dred						dmg%		200	250	swing3		30	30	oskill	inferno	40	40	res-fire		75	75	pierce-fire		30	30	abs-fire%		25	25																										0
+Imperial Passion	627	100	1			1	1	69	74	7br	mancatcher		5	5000								dmg%		250	300	swing3		30	30	addxp		20	20	cheap		5	5	dmg/lvl	24			rep-dur	50																												0
+Spirit of Lachdonan	628	100	1			1	1	74	79	7st	ghost spear		5	5000								dmg%		175	200	ethereal		1	1	fade		1	1	str/lvl	8			indestruct		1	1	dmg%/lvl	16			ease		-25	-25																						0
+Spirit Light	629	100	1			2	1	68	72	7st	Ghost Spear		5	5000	cblu	cblu						ethereal		1	1	indestruct		1	1	dmg%		200	300	ease		25	25	light		7	7	swing3		50	50	lifesteal		12	15	gethit-skill	60	50	12																		0
+Prancing Pike	630	100	1			1	1	80	86	7p7	war pike		5	5000	oran	oran						dmg%		150	200	swing3		60	60	balance3		40	40	allskills		3	3	dur		60	60	sock		1	1	heal-kill		35	50																						0
+Hylocan Axe	631	100	1			1	1	19	20	bar	bardiche		5	5000	lred	lred						dmg-min		20	30	dmg-max		50	70	dmg%		50	70	swing2		35	35	manasteal		4	6	dmg-cold	100	25	50																										0
+Knave's Ascendence	632	100	1			3	1	1	10	bar	bardiche		5	5000								dmg%		100	150	ac		25	50	str		15	15	dex		10	10	vit		10	10	hp		35	35																										0
 Simpering Edge	633	100	1			1	1	27	23	vou	voulge		5	5000								dmg-min		25	35	dmg-max		60	80	allskills		1	1	deadly		35	35	lifesteal		4	6	oskill	sword mastery	2	2																										0
-Oreseeker	634	100	1			3		1	14	vou	voulge		5	5000	blac	blac						dmg%		115	165	gold%		150	150	mag%		25	25	charged	142	100	5	ease		-35	-35	cheap		5	5																										0
-Slayer of Fields	635	100	1			1		30	26	scy	scythe		5	5000	dgry	dgry						dmg-min		30	40	dmg-max		70	80	dru		1	1	ignore-ac		1	1	fireskill		1	1	swing1		20	20																										0
-Rebuker	636	100	1			3		1	19	scy	scythe		5	5000				invpole9				dmg%		120	170	knock		2	2	slow		20	20	stupidity		2	2	sock		2	2																														0
-Axe of Sytherdan	637	100	1			1		31	29	pax	poleaxe		5	5000								dmg-min		35	45	dmg-max		80	90	res-fire/lvl	5			res-ltng		25	25	att		100	100	rep-dur	20			sock		1	2																						0
-Landsplitter	638	100	1			3		1	24	pax	poleaxe		5	5000	dgrn	dgrn						dmg%		135	185	swing2		30	30	heal-kill		5	8	skill	235	2	4	skill	244	2	4	skilltab	16	1	2																										0
-Snowy Sky	639	100	1			1		32	31	hal	halberd		5	5000	whit	whit						dmg-min		40	50	dmg-max		80	100	dur		40	40	knock		2	2	dmg-cold	200	25	50	mana-kill		3	5	res-pois		30	30																						0
-Ripskin	640	100	1			3		1	28	hal	halberd		5	5000								dmg%		150	200	lifesteal		7	7	manasteal		7	7	regen		5	5	regen-mana		25	25	res-cold		15	25	res-ltng		15	25																						0
-Sommerstrike Edge	641	100	1			1		33	35	wsc	war scythe		5	5000								dmg-min		50	50	dmg-max		110	125	dmg-fire		100	150	res-cold		45	45	res-fire		50	70	mag%		40	40	hp		30	50																						0
-Slayer's Debt	642	100	1			3		1	32	wsc	war scythe		5	5000	oran	oran						dmg%		175	200	dmg-norm		15	30	allskills		1	1	regen		-5	-5	ease		20	20	swing1		15	15	oskill	corpse explosion	1	4																						0
-Count Kidran's Scythe	643	100	1			1		55	44	9b7	lochaber axe		5	5000								dmg%		100	150	dmg-norm		25	50	addxp		3	3	res-all		20	40	balance2		20	20	mana		25	25	dex		15	15																						0
-Fire Mephit	644	100	1			3		1	38	9b7	lochaber axe		5	5000	cred	cred		invbar				dmg%		180	230	dmg%/lvl	9			dmg-fire		1	200	gethit-skill	46	12	13	res-fire		35	45	swing2		20	20	allskills		1	1																						0
-Griefspawn Touch	645	100	1			1		55	47	9vo	bill		5	5000								dmg%		100	150	dmg-norm		50	125	swing2		30	30	howl		133	133	lifesteal		6	8	regen-mana		25	25	res-ltng		35	35																						0
-Sunderblight	646	100	1			3		1	42	9vo	bill		5	5000	lgry	lgry		invvou				dmg%		185	235	dmg-dem/lvl	12			att-demon		200	200	demon-heal		20	25	hp		50	50	res-all		25	35	gethit-skill	87	7	3																						0
-Harbormaster's Victory	647	100	1			1		55	50	9s8	battle scythe		5	5000	dblu	dblu						dmg%		100	125	dmg-norm		50	100	dmg/lvl	12			swing3		40	40	allskills		1	1	sock		2	2																										0
-Survival Instinct	648	100	1			3		1	45	9s8	battle scythe		5	5000								dmg%		190	240	red-dmg%		15	25	res-mag		20	25	balance2		30	30	move2		20	20	swing2		25	25	dmg-cold	100	50	80																						0
+Oreseeker	634	100	1			3	1	4	14	vou	voulge		5	5000	blac	blac						dmg%		115	165	gold%		150	150	mag%		25	25	charged	142	100	5	ease		-35	-35	cheap		5	5																										0
+Slayer of Fields	635	100	1			1	1	30	26	scy	scythe		5	5000	dgry	dgry						dmg-min		30	40	dmg-max		70	80	dru		1	1	ignore-ac		1	1	fireskill		1	1	swing1		20	20																										0
+Rebuker	636	100	1			3	1	8	19	scy	scythe		5	5000				invpole9				dmg%		120	170	knock		2	2	slow		20	20	stupidity		2	2	sock		2	2																														0
+Axe of Sytherdan	637	100	1			1	1	31	29	pax	poleaxe		5	5000								dmg-min		35	45	dmg-max		80	90	res-fire/lvl	5			res-ltng		25	25	att		100	100	rep-dur	20			sock		1	2																						0
+Landsplitter	638	100	1			3	1	12	24	pax	poleaxe		5	5000	dgrn	dgrn						dmg%		135	185	swing2		30	30	heal-kill		5	8	skill	235	2	4	skill	244	2	4	skilltab	16	1	2																										0
+Snowy Sky	639	100	1			1	1	32	31	hal	halberd		5	5000	whit	whit						dmg-min		40	50	dmg-max		80	100	dur		40	40	knock		2	2	dmg-cold	200	25	50	mana-kill		3	5	res-pois		30	30																						0
+Ripskin	640	100	1			3	1	14	28	hal	halberd		5	5000								dmg%		150	200	lifesteal		7	7	manasteal		7	7	regen		5	5	regen-mana		25	25	res-cold		15	25	res-ltng		15	25																						0
+Sommerstrike Edge	641	100	1			1	1	33	35	wsc	war scythe		5	5000								dmg-min		50	50	dmg-max		110	125	dmg-fire		100	150	res-cold		45	45	res-fire		50	70	mag%		40	40	hp		30	50																						0
+Slayer's Debt	642	100	1			3	1	23	32	wsc	war scythe		5	5000	oran	oran						dmg%		175	200	dmg-norm		15	30	allskills		1	1	regen		-5	-5	ease		20	20	swing1		15	15	oskill	corpse explosion	1	4																						0
+Count Kidran's Scythe	643	100	1			1	1	55	44	9b7	lochaber axe		5	5000								dmg%		100	150	dmg-norm		25	50	addxp		3	3	res-all		20	40	balance2		20	20	mana		25	25	dex		15	15																						0
+Fire Mephit	644	100	1			3	1	28	38	9b7	lochaber axe		5	5000	cred	cred		invbar				dmg%		180	230	dmg%/lvl	9			dmg-fire		1	200	gethit-skill	46	12	13	res-fire		35	45	swing2		20	20	allskills		1	1																						0
+Griefspawn Touch	645	100	1			1	1	55	47	9vo	bill		5	5000								dmg%		100	150	dmg-norm		50	125	swing2		30	30	howl		133	133	lifesteal		6	8	regen-mana		25	25	res-ltng		35	35																						0
+Sunderblight	646	100	1			3	1	36	42	9vo	bill		5	5000	lgry	lgry		invvou				dmg%		185	235	dmg-dem/lvl	12			att-demon		200	200	demon-heal		20	25	hp		50	50	res-all		25	35	gethit-skill	87	7	3																						0
+Harbormaster's Victory	647	100	1			1	1	55	50	9s8	battle scythe		5	5000	dblu	dblu						dmg%		100	125	dmg-norm		50	100	dmg/lvl	12			swing3		40	40	allskills		1	1	sock		2	2																										0
+Survival Instinct	648	100	1			3	1	38	45	9s8	battle scythe		5	5000								dmg%		190	240	red-dmg%		15	25	res-mag		20	25	balance2		30	30	move2		20	20	swing2		25	25	dmg-cold	100	50	80																						0
 Moonlight Edge	649	100	1			1	1	55	53	9pa	partizan		5	5000	dyel	dyel						dmg%		100	150	dmg-norm		50	120	skill	224	3	3	dru		2	2	oskill	sword mastery	8	8	swing2		25	25	lifesteal		5	8	mana		35	50																		0
-Trial by Fire	650	100	1			3		1	49	9pa	partizan		5	5000								dmg%		200	250	dmg-fire		75	150	pierce-fire		15	20	aura	102	4	7	oskill	fire wall	5	8	res-fire-max		5	15	res-fire		20	50	sock		2	2																		0
-Kritchan's Ire	651	100	1			3		1	51	9h9	bec-de-corbin		5	5000	oran	oran						dmg%		100	150	dmg-norm		40	80	hit-skill	230	100	1	allskills		2	2	reduce-ac		25	25	openwounds		33	33	noheal		1	1																						0
-Father of Nations	652	100	1			1		55	57	9h9	bec-de-corbin		5	5000	dgld	dgld		invhal				dmg%		210	260	all-stats		25	25	hp%		15	15	mana%		15	15	lifesteal		8	11	manasteal		6	9	swing3		40	40	dmg-norm		50	100																		0
-Killer's Glee	653	100	1			1		55	60	9wc	grim scythe		5	5000	lred	lred						dmg%		100	150	dmg-norm		50	100	ethereal		1	1	rep-dur	20			sock		3	5																														0
-Dawn of the Dead	654	100	1			3		1	53	9wc	grim scythe		5	5000								dmg%		220	270	swing3		35	35	oskill	skeleton mastery	5	8	oskill	revive	5	8	dmg-undead		250	250	dmg-cold	200	35	70	slow		20	20																						0
-Ogre Cheiftain's Law	655	100	1			2		1	53	7o7	ogre axe		5	5000								dmg%		200	250	swing3		40	40	lifesteal		6	8	crush		33	33	slow		20	20	knock		3	3	rip		1	1																						0
-Titan's Reach	656	100	1			2	1	1	60	7vo	colossus voulge		5	5000	dgld	dgld						dmg%		200	275	swing1		15	15	oskill	sword mastery	12	12	bar		3	3	hp/lvl	16			regen		5	8	abs-cold%		20	20	abs-fire%		20	20																		0
-Kydra's Judgement	657	100	1			1		1	70	7vo	Colossus Voulge		5	5000								dmg%		200	250	dmg%/lvl	8			hit-skill	45	20	8	res-cold		45	45	dmg-cold		75	125	freeze		1	3	reduce-ac		10	10																						0
-Winter Solstice	658	100	1			1		1	75	7s8	thresher		5	5000	whit	whit						dmg%		100	140	dmg-min		75	125	dmg-max		300	400	dmg-cold		255	400	freeze		6	6	oskill	whirlwind	5	5	res-cold		80	80																						0
-Gatecleaver	659	100	1			1		1	79	7pa	cryptic axe		5	5000								dmg%		220	260	dex		35	35	ease		-50	-50	allskills		2	2	lifesteal		12	15	addxp		2	4	res-pois		35	55																						0
-Cloud Giant's Axe	660	100	1			1		1	83	7h7	great poleaxe		5	5000	dyel	dyel						dmg%		235	300	swing3		60	60	ease		25	25	str		75	75	heal-kill		15	20	dmg-ltng		1	500																										0
-Dreadfear	661	100	1			2		1	77	7h7	Great Poleaxe		5	5000								dmg%		300	450	sock		3	6	howl		100	100	vit		100																																			0
-Kraken's Backlash	662	100	1			1		1	86	7wc	giant thresher		5	5000								dmg%		200	240	dmg-norm		100	200	knock		6	6	swing2		20	20	dmg-cold		100	200	hit-skill	243	8	10	sock		2	2																						0
-Invoker	663	100	1			1		24	24	sst	short staff		5	5000				invsst				dmg-min		10	15	dmg-max		40	60	swing2		20	20	cast3		50	50	mana%		15	15	sock		2	2																										0
-Puzzler's Mystery	664	100	1			3		1	6	sst	short staff		5	5000	cblu	cblu						dmg-norm		5	10	skill-rand	2	36	44	skill-rand	2	36	44	mana		25	25	swing2		20	20																														0
-Touch of Evil	665	100	1			1		29	29	lst	long staff		5	5000	blac	blac		invlst				dmg-min		20	30	dmg-max		60	90	hit-skill	72	8	2	dru		1	1	balance2		20	20	mana		45	45	skill-rand	4	221	250																						0
-Puppeteer's Staff	666	100	1			3		1	12	lst	long staff		5	5000				invstaf3				dmg%		110	150	skill-rand	1	36	50	skill-rand	2	36	50	skill-rand	2	36	50	fireskill		1	1	cast2		20	20	oskill	clay golem	5	7	oskill	summon spirit wolf	3	3																		0
-Serpent Lord1	667	0	1			5		1	9	lst	Long Staff		5	5000	cgrn	cgrn						dmg-pois	75	40	40	res-pois		50	50	light		-1	-1	mana		10	10	dmg%		60	90	manasteal		100	100	reduce-ac		50	50																						0
-Wizard's Rule	668	100	1			1		30	32	cst	gnarled staff		5	5000				invcst				skill-rand	3	36	65	skill-rand	3	36	65	skill-rand	2	36	65	skill-rand	2	36	65	mana-kill		3	6	cast2		20	20	res-all		20	30																						0
-Sage's Retort	669	100	1			3		1	17	cst	gnarled staff		5	5000	oran	oran		invstaf9				dmg%		125	175	gethit-skill	44	50	2	gethit-skill	42	3	7	regen-mana		75	75	mana%		15	15	kill-skill	Frost Nova	6	6																										0
-Staff of the Arch-Magus	670	100	1			1		31	36	bst	battle staff		5	5000	cred	cred		invbst				allskills		2	2	mana/lvl	10			str		25	25	dex		25	25	cast3		30	30	skilltab	4	2	2	rip		1	1	addxp		3	5																		0
-Strange Alchemy	671	100	1			3		1	23	bst	battle staff		5	5000								oskill	warmth	1	3	oskill	frozen armor	1	3	oskill	bone armor	1	3	oskill	cyclone armor	1	3	dmg-norm		15	30	swing2		20	20	dmg%		100	100																						0
-Warmth of Ash	672	100	1			1		32	40	wst	war staff		5	5000	dgry			invstaf12				fireskill		5	5	dmg-min		15	25	dmg-max		60	80	dmg-fire		75	100	res-fire		65	65	abs-cold		10	20	skill-rand	2	36	65																						0
-Riddlesolver	673	100	1			3		1	29	wst	war staff		5	5000				invstaf2				dmg%		150	200	skill-rand	2	36	65	skill-rand	3	36	65	skill-rand	3	36	65	sor		1	1	cast2		25	25	balance2		30	30																						0
-Arctic Frost	674	100	1			1		55	45	8ss	jo staff		5	5000	lblu	lblu		invstaf10				skilltab	5	4	4	extra-cold		25	25	abs-cold%		25	25	pierce-cold		35	35	res-fire		80	100																														0
-Staff of Shadows	675	100	1			3		1	36	8ss	jo staff		5	5000	blac	blac		invsst				skill-rand	3	36	65	skill-rand	3	36	65	skill-rand	3	36	65	cast2		20	20	gethit-skill	71	11	2	red-dmg		8	12					allskills		1	1																		0
-Ter'Angreal	676	100	1			1		55	50	8ls	quarterstaff		5	5000	whit	whit						sor		2	2	cast3		40	40	mana%		50	50	addxp		5	5	mana-kill		20	20	dmg-to-mana		15	25																										0
-Silence of the Sphinx	677	100	1			3		1	39	8ls	quarterstaff		5	5000				invstaf4				skill-rand	2	36	65	skill-rand	2	36	65	skill-rand	2	36	65	sor		2	2	dmg-to-mana		15	15	addxp		3	5	cheap		10	15	mag%		60	60	sock		2	2														0
-Staff of Valere	678	100	1			1		55	56	8cs	cedar staff		5	5000				invstaf5				dmg-min		30	50	dmg-max		100	150	swing3		45	45	red-dmg%		15	20	str		15	15	dex		25	25	dru		1	1	cast2		15	15																		0
-Rubydawn	679	100	1			3		1	42	8cs	cedar staff		5	5000	cred	cred		invcst				skill-rand	4	66	95	skill-rand	3	66	95	skill-rand	2	66	95	nec		2	2	cast2		20	20	mana%		15	15	oskill	fire mastery	3	6	oskill	47	6	8																		0
-Knight's Prophet	680	100	1			1		55	60	8bs	gothic staff		5	5000				invstaf7				dmg-min		35	70	dmg-max		150	250	pal		3	3	res-all		40	50	move2		25	25	swing2		25	25	manasteal		4	7	lifesteal		7	7	oskill	whirlwind	3	3														0
-Grace of Isis	681	100	1			3		1	47	8bs	gothic staff		5	5000	dgld	dgld		invbst				dmg%		200	265	dru		1	2	skill-rand	3	221	250	skill-rand	2	221	250	skill-rand	3	221	250	dmg-norm		30	60	swing3		40	40	ignore-ac		1	1	crush		20	20														0
-Arcane Protection	682	100	1			1		55	65	8ws	rune staff		5	5000	dgrn	dgrn						sor		2	2	res-all		35	50	red-mag		25	25	gethit-skill	40	13	4	charged	58	27	9	dmg-to-mana		50	50	regen-mana		200	200																						0
-Survivor's Sonata	683	100	1			3		1	50	8ws	rune staff		5	5000				invstaf13				skill	48	3	5	skill	60	3	5	hp		75	75	cast2		25	25	allskills		2	2	addxp		5	5	gold%		200	200	mag%/lvl	10																				0
-Road to Perdition	684	100	1			1		1	67	6ss	walking stick		5	5000	lgry	lgry						allskills		3	3	mag%		200	300	cast2		40	40	mana/lvl	16																																				0
-Jadrik's Torment	685	100	1			2		1	49	6ss	Walking Stick		5	5000				invstaf8				enr		35	35	cast3		40	40	move3		50	50	dmg%		200	300	swing3		55	55	str		-50	-50	hp		200	200																						0
-Ogden's Wisdom	686	100	1			1		1	69	6ls	stalagmite		5	5000				invstaf6				allskills		2	2	cast2		20	20	enr		35	35	addxp		3	5	heal-kill		15	15	cheap		10	10	skill-rand	5	36	65	skill-rand	5	36	65	skill-rand	5	36	65														0
-Gorgon Strength	687	100	1			2		1	55	6ls	Stalagmite		5	5000	oran	oran						str		100	100	mana		150	150	sor		3	3	mag%/lvl	8			res-all		25	25	ac/lvl	40																												0
-Light of Ra	688	100	1			1		1	73	6cs	elder staff		5	5000	whit	whit		invcst				skilltab	4	5	5	skill	57	3	5	skill	63	3	5	light		5	5	thorns/lvl	10			sock		3	3																										0
-Summoner's Risk	689	100	1			1		1	79	6bs	shillelah		5	5000				invbst				oskill	bloodgolem	6	8	oskill	golem mastery	20	20	dmg-to-mana		35	35	cast2		30	30	res-all		100	100	balance3		40	40	regen		3	5																						0
-Sanctuary	690	100	1			2		1	76	6bs	Shillelah		5	5000	cred							cast2		20	20	mana		220	220	ac		350	550	red-dmg%		50	50	sor		2	2	mana%		25	25																										0
-Everkeeper	691	100	1			1		1	85	6ws	archon staff		5	5000				invstaf11				allskills		1	1	dmg-min		150	200	dmg-max		350	400	rep-dur	25			ignore-ac		1	1	swing3		40	40	regen		20	20	dmg%		300	340																		0
-Acolyte's Wand	692	100	1			1		24	25	wnd	wand		5	5000	lblu	lblu		invwnd				nec		1	1	cast2		20	20	mana		44	44	regen-mana		50	50	skill-rand	2	66	90	skill-rand	2	66	90																										0
-Bitter Sorrow	693	100	1			3		1	9	wnd	wand		5	5000				invwand1				dmg-min		2	7	dmg-max		12	20	skill-rand	3	66	75	skill-rand	3	66	75	sock		2	2																														0
-Ladrina's Enchantment	694	100	1			1		30	30	ywn	yew wand		5	5000	dgld	dgld		invywn				charged	66	200	12	charged	82	33	7	charged	42	19	20	charged	57	7	27	charged	17	112	29	charged	154	61	15	charged	235	17	20																						0
-Ire of Astaroth	695	100	1			3		1	19	ywn	yew wand		5	5000								skill-rand	1	66	80	skill-rand	2	66	80	skill-rand	2	66	80	skill-rand	3	66	80	nec		1	1	mana		40	40	cast2		25	25																						0
-Skeleton's Claw	696	100	1			1		34	33	bwn	bone wand		5	5000	whit	whit		invbwn				dmg-min		10	20	dmg-max		40	60	lifesteal		10	15	swing2		20	20	skill	69	3	5	hp		50	75	mag%		25	30	allskills		1	1																		0
-Child's Laughter	697	100	1			3		1	26	bwn	bone wand		5	5000								skill	72	3	5	skill	77	3	5	skill	81	3	5	levelup-skill	nova	100	40	mag%		50	50	addxp		4	4	extra-pois		25	25																						0
-Dracolich Fang	698	100	1			1		37	37	gwn	grim wand		5	5000	cgrn	cgrn		invgwn				nec		1	1	lifesteal		100	100	manasteal		100	100	regen		6	10	regen-mana		35	80	red-dmg%		10	10	nofreeze		1	1	res-pois-len		80	90																		0
-Scream of Despair	699	100	1			3		1	32	gwn	grim wand		5	5000								nec		2	2	skill-rand	3	66	95	skill-rand	5	66	95	gethit-skill	77	25	8	mana		20	20	hp		50	50	str		20	20																						0
-Epoch's End	700	100	1			1		55	43	9wn	burnt wand		5	5000				invwand2				allskills		1	1	mana/lvl	8			hp/lvl	8			extra-pois		20	30	res-pois		45	65	res-pois-len		50	50	oskill	94	3	5																						0
-Apoclypse Fire	701	100	1			3		1	39	9wn	burnt wand		5	5000	dred	dred		invwnd				charged	62	100	30	charged	51	100	30	charged	225	100	30	charged	244	100	30	addxp		10	10	res-all		65	65	cast2		25	25	allskills		1	1																		0
-Huclavee's Flinch	702	100	1			3		1	42	9yw	petrified wand		5	5000				invywn				dmg-norm		40	80	dmg%		175	200	swing3		35	35	knock		3	3	slow		25	25	oskill	zeal	8	8	lifesteal		8	8																						0
-Asylum's Ward	703	100	1			1		55	49	9bw	tomb wand		5	5000								nec		2	2	skill-rand	2	66	95	skill-rand	2	66	95	skill-rand	3	66	95	charged	72	42	8	gethit-skill	81	6	4	red-mag		10	15																						0
-Wand of Fireballs	704	100	1			3		1	45	9bw	tomb wand		5	5000	oran	oran		invbwn				gethit-skill	47	100	15	all-stats		20	20	skill-rand	3	66	95	skill-rand	3	66	95	allskills		1	1	cast2		25	25	sock		1	1																						0
-Nullwand	705	100	1			1		55	53	9gw	grave wand		5	5000								allskills		2	2	res-all		40	60	red-dmg%		20	25	abs-fire		10	10	abs-ltng		10	10	abs-cold		10	10	nofreeze		1	1	res-pois-len		70	70																		0
-Gravedancer's Union	706	100	1			3		1	49	9gw	grave wand		5	5000	dgry	dgry		invgwn				skill-rand	1	66	95	skill-rand	2	66	95	skill-rand	3	66	95	skill	69	2	5	mana		100	100	res-cold		25	40	res-pois		50	50	heal-kill		10	15																		0
-Voice of Reason	707	100	1			1		1	68	7wn	polished wand		5	5000				invwand3				enr		30	30	addxp		3	5	cheap		15	15	cast2		25	25	skill-rand	3	66	95	skill-rand	3	66	95	skilltab	6	2	3																						0
-Darkmantle	708	100	1			2		1	50	7wn	Polished Wand		5	5000	blac	blac						nec		1	3	oskill	dim vision	5	5	mana		50	50	skill-rand	7	66	95	rip		1	1	cast3		40	40	regen		35	35	ac/lvl	24																				0
-Chorus of the Cursed	709	100	1			1		1	73	7yw	ghost wand		5	5000	dpur	dpur		invywn				allskills		2	2	skilltab	6	2	2	res-mag		20	20	gethit-skill	91	3	18	dex		20	20	str		20	20	oskill	revive	1	1																						0
-Specral Immage	710	100	1			2		1	61	7yw	Ghost Wand		5	5000								allskills		1	1	res-all		25	35	addxp		5	10	abs-cold%		15	20	abs-ltng%		15	20	abs-fire%		15	20	skilltab	8	2	5																						0
-Vengeance of the Wronged	711	100	1			1		1	79	7bw	lich wand		5	5000				invbwn				nec		3	3	skill-rand	10	66	95	death-skill	92	100	50	mana		75	100	hp		75	100	mana-kill		3	5	addxp		3	5																						0
-Pull of Darkness	712	100	1			1		1	86	7gw	unearthed wand		5	5000				invgwn				allskills		2	2	gold%		125	125	mag%		60	60	skill	93	7	15	move3		40	40	block		25	25	block2		20	20																						0
-Freedom's Flight	713	100	1			1		24	25	sbw	short bow		5	5000								dmg-norm		20	40	swing1		20	20	skilltab	0	1	3	att%		50	50	skill	6	10	10																														0
-Violetwing	714	100	1			3		1	7	sbw	short bow		5	5000	dpur	dpur		invsbw				dmg-norm		4	8	swing1		15	15	skill	6	3	3	move2		20	20																																		0
-Target's	715	100	1			1		25	26	hbw	hunter's bow		5	5000				invbow10				dmg-norm		23	45	balance1		20	20	dmg-ltng		1	100	lifesteal		4	6	vit		15	15	oskill	6	1	3																										0
-Carrion Wing	716	100	1			3		1	10	hbw	hunter's bow		5	5000	dgry	dgry		invhbw				dmg%		100	150	dmg-max		6	10	dmg-undead		200	200	extra-fire		20	20	sock		1	2																														0
-Elven Bow of Duadon	717	100	1			1		26	27	lbw	long bow		5	5000	dgrn	dgrn						dmg-norm		25	50	swing2		20	20	allskills		1	1	manasteal		4	6	regen		1	2	balance2		20	20																										0
-Gale Song	718	100	1			3		1	16	lbw	long bow		5	5000				invlbw				dmg%		100	150	dmg-norm		5	12	ama		1	1	howl		144	144	dex		20	20	ease		-25	-25																										0
-Silver Oak Bow	719	100	1			1		27	28	cbw	composite bow		5	5000	whit			invbow6				dmg-norm		32	55	att		200	200	dmg-undead		200	200	dmg-demon		100	100	regen-mana		50	50	str		15	15	ease		-15	-15																						0
-Warpwind	720	100	1			3		1	21	cbw	composite bow		5	5000				invcbw				dmg%		125	175	dmg-norm		3	15	swing2		25	25	knock		1	1	skill	12	6	6	mana		35	35																										0
-Shayira's Flight	721	100	1			1		28	29	sbb	short battle bow		5	5000	oran	oran						dmg-fire		80	100	dmg-ltng		10	200	dmg-cold	100	40	50	dmg%		100	130	dmg-norm		10	20	all-stats		5	5																										0
-Willowsting	722	100	1			3		1	22	sbb	short battle bow		5	5000				invsbb				dmg%		125	175	gethit-skill	67	12	7	ease		-25	-25	balance2		20	20	gold%		50	100	lifesteal		6	6																										0
-Kirre Strike	723	100	1			1		29	32	lbb	long battle bow		5	5000	dgld	dgld						dmg-norm		35	60	oskill	strafe	3	3	res-fire		15	20	res-pois		40	50	knock		1	1	pierce		20	20																										0
-Beeswarm	724	100	1			3		1	26	lbb	long battle bow		5	5000				invlbb				dmg%		140	190	dmg-norm		10	20	oskill	multiple shot	6	6	swing2		25	25	allskills		1	1																														0
-Sylvan Battle Bow	725	100	1			1		30	35	swb	short war bow		5	5000	blac			invbow1				dmg-norm		35	70	swing3		30	30	hp%		10	10	mana%		20	20	oskill	ice arrow	2	2	ama		1	1	skilltab	0	1	2																						0
-Ranger's Sting	726	100	1			3		1	29	swb	short war bow		5	5000				invbow5				dmg-min		5	15	dmg-max		30	45	bar		2	2	swing2		20	20	oskill	strafe	6	6	dex		35	35	manasteal		6	6																						0
-Telena's War Bow	727	100	1			1		31	37	lwb	long war bow		5	5000	cblu	cblu						dmg-norm		40	80	swing2		25	25	lifesteal		5	7	mana-kill		7	7	addxp		2	2	dex		15	15	crush		10	15																						0
-Finalflight	728	100	1			3		1	31	lwb	long war bow		5	4000				invlwb				dmg-min		10	20	dmg-max		40	60	dmg%		100	125	rip		1	1	addxp		5	5	gethit-skill	54	10	1	ac		100	100																						0
-Teldicia's Sting	729	100	1			1		55	44	8sb	edge bow		5	5000				invbow8				dmg%		80	125	dmg-norm		25	50	swing2		30	30	dmg-pois	75	333	333	dex		10	10	hp		50	50	gethit-skill	22	7	1																						0
-Dead to the World	730	100	1			3		1	35	8sb	edge bow		5	5000	blac	blac		invsbw				dmg%		175	225	swing2		25	25	regen		5	5	oskill	guided arrow	4	4	charged	95	8	35	pierce		25	25	lifesteal		6	6																						0
-Sadira	731	100	1			1		55	46	8hb	razor bow		5	5000				invbow11				dmg%		80	125	dmg-norm		25	50	dmg-ltng		25	100	res-all		20	20	mana-kill		5	5	regen-mana		75	75	sock		1	1																						0
-Iceweaver	732	100	1			3		1	37	8hb	razor bow		5	5000	whit	whit		invhbw				dmg%		185	235	oskill	ice arrow	5	5	charged	60	3	10	gethit-skill	44	8	4	dmg-cold	300	40	80	extra-cold		15	15	dmg-norm		20	40																						0
-Fatima Ravenclaw	733	100	1			1		55	49	8lb	cedarbow		5	5000								dmg%		80	125	dmg-norm		25	50	att%		20	20	oskill	pierce	1	1	lifesteal		7	9	mana		30	30	bar		2	2	swing1		15	15																		0
-Bow of the Dead	734	100	1			3		1	40	8lb	cedar bow		5	5000	dgry	dgry		invlbw				dmg%		190	240	reanimate	649	10	10	res-cold		35	35	dmg-undead		150	150	manasteal		5	7	dex		20	20	allskills		1	1																						0
-Larissa's Aim	735	100	1			1		55	51	8cb	double bow		5	5000				invbow7				dmg%		175	220	dmg-norm		25	50	manasteal		5	5	vit		30	30	dex		15	15	res-cold		35	50	att		200	200																						0
-Ranger's Path	736	100	1			3		1	42	8cb	double bow		5	5000	dgrn	dgrn		invcbw				dmg%		195	250	allskills		2	2	swing2		25	25	dmg-max		30	40	charged	247	5	10	deadly/lvl	12			mag%		40	70																						0
-Hailstrike	737	100	1			1		55	52	8s8	short siege bow		5	5000	dred	dred						dmg%		160	190	dmg-norm		35	70	skill	11	3	3	skill	21	5	5	gethit-skill	31	4	1	cold-len	300			mag%		40	40																						0
-Pride's Paradox	738	100	1			3		1	45	8s8	short siege bow		5	5000	oran	oran		invsbb				dmg%		200	255	knock		2	2	dmg-cold	1000	1	1	freeze		3	3	pierce		30	30	sock		2	3																										0
-Heartseeker	739	100	1			1		55	54	8l8	long siege bow		5	5000								dmg%		175	200	deadly		100	100	noheal		1	1	openwounds		100	100	lifesteal		6	8	att%		50	50	ama		2	2																						0
-Crimson Crusade	740	100	1			3		1	48	8l8	long siege bow		5	5000	dred	dred		invlbb				dmg%		210	265	swing2		20	20	hp		45	45	mana		65	65	bloody		1	1	noheal		1	1	openwounds		100	100	dmg-norm		20	40																		0
-Dune Runner	741	100	1			1		55	56	8sw	rune bow		5	5000				invbow2				dmg%		150	190	dmg-norm		35	70	move3		30	30	balance2		35	35	heal-kill		10	12	oskill	weaken	1	1	sock		2	2																						0
-Remorhaz	742	100	1			3		1	50	8sw	rune bow		5	5000	cblu			invbow12				dmg%		225	275	swing3		40	40	ama		1	1	res-fire		75	75	pierce-fire		30	30	oskill	immolation arrow	3	3	charged	17	100	10	move3		30	30																		0
-Ghost Mount	743	100	1			1		55	59	8lw	gothic bow		5	5000								dmg%		200	240	dmg-norm		20	40	res-all		25	50	move3		30	30	dex		20	30	move1		15	15	swing1		15	15	skilltab	0	3	3																		0
-Harper's Call	744	100	1			3		1	53	8lw	gothic bow		5	5000	oran	oran		invlwb				dmg%		225	275	dmg/lvl	8			allskills		1	1	all-stats		15	15	ease		-20	-20	regen		12	15	manasteal		8	8																						0
-Arachnid's Bite	745	100	1			1		1	65	6sb	spider bow		5	5000								dmg%		190	240	openwounds		50	100	dmg-pois	200	750	750	dmg-pois/lvl	56			stupidity		3	3	balance1		15	15	allskills		2	2																						0
-Black Widow	746	100	1			2		1	51	6sb	Spider Bow		5	5000	blac	blac						dmg%		175	225	swing2		20	20	dmg-pois	150	900	900	slow		25	25	fade		1	1	move3		50	50	dex/lvl	4																								0
-Foxfire Leaf	747	100	1			1		1	68	6hb	blade bow		5	5000				invbow13				dmg%		180	230	dmg-fire		200	400	dmg-fire/lvl	24			dex		15	15	res-all		20	30	gold%		100	100	mag%		35	35																						0
-Razor Strike	748	100	1			2		1	55	6hb	Blade Bow		5	5000	dpur	dpur						dmg%		200	250	bloody		1	1	noheal		1	1	crush		20	30	dex		25	25	sock		2	2	aura	fanaticism	1	1																						0
-Golgomere	749	100	1			1		1	72	6lb	shadow bow		5	5000								dmg%		200	240	dmg-norm		35	70	ease		-60	-60	magicarrow		1	1	cast2		25	25	mana/lvl	10			sor		2	2																						0
-Death Shade	750	100	1			2		1	60	6lb	Shadow Bow		5	5000	blac	blac						dmg%		220	270	swing2		25	25	oskill	revive	5	5	oskill	skeleton mastery	5	12	res-all		35	35	knock		2	2																										0
-Oathbow	751	100	1			1		1	74	6cb	great bow		5	5000				invbow9				dmg%		160	200	dmg-norm		40	90	addxp		2	5	all-stats		25	25	red-dmg		20	30	red-mag		20	30	res-mag		25	25																						0
-Phantom Pegasus	752	100	1			2		1	64	6cb	Great Bow		5	5000	oran			invbow4				dmg%		200	300	move3		25	25	vit		35	35	cast2		25	25	allskills		2	2	addxp		12	12	hp%		15	25																						0
-Nine Lives Stealer	753	100	1			1		1	77	6s7	diamond bow		5	5000	blac	blac						dmg%		200	240	gethit-skill	53	9	9	lifesteal		9	9	heal-kill		9	9	mana-kill		9	9	nofreeze		1	1	skilltab	0	1	3																						0
-Celestial Strike	754	100	1			2		1	67	6s7	Diamond Bow		5	5000	dblu	dblu						dmg%		100	150	dmg-cold	400	75	100	dmg-fire		250	400	dmg-ltng		1	500	manasteal		8	10	lifesteal		6	12	all-stats		20	30	kill-skill	inner sight	100	5	dmg-norm		20	40														0
-Elflord's Victory	755	100	1			1		1	79	6l7	crusader bow		5	5000								dmg%		190	250	dmg/lvl	8			ama		1	2	skilltab	0	1	3	swing2		30	30	str		20	20	balance3		40	40																						0
-Patron of Perversity	756	100	1			1		1	82	6sw	ward bow		5	5000				invbow3				dmg%		210	250	dru		2	2	swing3		40	40	balance2		25	25	oskill	magic arrow	15	20	noheal		1	1	dmg-norm		50	100	skill	224	4	7																		0
-Adamantine Bow	757	100	1			1		4	8	6lw	hydra bow		5	5000								dmg-min		100	175	dmg-max		275	400	red-dmg%		15	15	res-mag		15	15	gethit-skill	12	6	20	swing1		15	15	allskills		1	2	skilltab	0	2	2																		0
-Replenishing Quiver	758	100	0			1		6	6	z01	Arrows		5	5000	oran	oran		invarro1				dmg-norm		2	8	swing1		10	10																																										0
-Quiver of Piercing	759	100	1			1		35	35	z01	Arrows		5	5000	cblu	cblu		invarro2				dmg-norm		4	12	swing1		15	15	pierce		15	15																																						0
-Quiver of Slaying	760	100	1			1		65	65	z01	Arrows		5	5000	blac	blac		invarro3				dmg-norm		5	20	swing1		20	20	pierce		25	25	skilltab	0	1	1																																		0
-Rethral	761	100	1			1		25	25	lxb	light crossbow		5	5000	dred	dred		invcbow4				dmg-norm		20	40	swing2		20	20	ama		1	1	dmg-ltng		1	40	red-dmg%		10	15	sock		1	1																										0
-Nail Flinger	762	100	1			3		1	12	lxb	light crossbow		5	5000				invlxb				dmg%		100	150	dmg-max		7	12	pierce		100	100	red-dmg		4	6	red-mag		2	5																														0
-Piercing Bolt	763	100	1			1		28	28	mxb	crossbow		5	5000				invcbow5				dmg-norm		25	50	pierce		100	100	res-all		20	30	knock		1	1	att%		20	20	lifesteal		5	5	addxp		2	3																						0
-Janglebright	764	100	1			3		1	18	mxb	crossbow		5	5000	whit	whit		invmxb				dmg%		125	175	light		3	5	res-all		25	25	balance2		15	15	swing1		10	10	sock		1	1																										0
-Harpo Bogglinn	765	100	1			1		32	32	hxb	heavy crossbow		5	5000								dmg-norm		25	50	swing1		10	10	slow		15	15	pierce-fire		10	10	extra-fire		10	10	allskills		1	1																										0
-Spikethrower 	766	100	1			3		1	24	hxb	heavy crossbow		5	5000				invhxb				dmg%		150	200	dmg-norm		10	20	crush		25	25	deadly		25	25	noheal		1	1	ama		1	1																										0
-Synthalus	767	100	1			1		33	35	rxb	repeating crossbow		5	5000				invcbow3				dmg-norm		35	70	att		200	200	balance2		20	20	dex		15	15	mana		35	35	dmg/lvl	4			magicarrow		1	1																						0
-King's Nail	768	100	1			3		1	30	rxb	repeating crossbow		5	5000				invrxb				allskills		1	1	oskill	guided arrow	3	5	swing2		30	30	lifesteal		5	5	manasteal		3	3	gold%		50	50	hit-skill	87	15	3	dmg-min		10	20	dmg-max		30	50	dmg%		100	125										0
-Kyuss' Crossbow	769	100	1			1		55	48	8lx	arbalest		5	5000				invcbow6				dmg%		175	220	swing2		20	20	oskill	freezing arrow	1	1	heal-kill		10	15	regen-mana		60	60	mag%		30	50	gold%		75	75																						0
-Garlana Firebolt	770	100	1			3		1	38	8lx	arbalest		5	5000	dred	dred		invlxb				dmg%		180	240	swing2		25	25	ama		1	1	oskill	exploding arrow	6	6	res-cold		25	40	dmg-norm		15	30	fireskill		2	2																						0
-Giant Hair Crossbow	771	100	1			1		55	53	8mx	siege crossbow		5	5000								dmg%		200	250	swing3		40	40	ignore-ac		1	1	lifesteal		6	6	dmg-max		25	25	ease		15	15	pierce-cold		10	15																						0
-Raven Myst	772	100	1			3		1	43	8mx	siege crossbow		5	5000	whit	whit		invmxb				dmg%		150	150	dmg/lvl	13			swing3		30	30	oskill	raven	5	5	aura	120	3	6	sock		2	2	knock		1	1																						0
-Whyte Stag	773	100	1			1		55	56	8hx	ballista		5	5000	whit	whit						dmg%		200	300	dmg-cold	300	100	200	freeze		1	1	noheal		1	1	half-freeze		1	1	res-cold		35	50	sock		1	1																						0
-Senmet's Boltcaster	774	100	1			3		1	47	8hx	ballista		5	5000				invcbow1				dmg%		200	250	swing2		25	25	heal-kill		15	15	addxp		5	5	charged	149	10	10	balance2		20	20	magicarrow		1	1																						0
-Ashira's Stunbeam	775	100	1			1		55	61	8rx	chu-ko-nu		5	5000				invcbow8				dmg-norm		75	150	swing2		30	30	lifesteal		6	8	manasteal		5	7	gethit-skill	38	100	5	all-stats		15	15	mana		40	40																						0
-Widow's Refrain	776	100	1			3		1	54	8rx	chu-ko-nu		5	5000	dgry	dgry		invrxb				dmg%		215	270	swing2		20	20	dmg-norm		25	50	charged	quickness	17	12	charged	fade	22	8	dmg-to-mana		12	12	rip		1	1																						0
-Stoneblaster	777	100	1			1		1	67	6lx	pellet bow		5	5000	dgry	dgry						dmg%		200	240	knock		1	1	slow		20	20	stupidity		1	1	swing2		15	15	addxp		3	3																										0
-Doubleshot Machine	778	100	1			2		1	55	6lx	Pellet Bow		6	6000								oskill	multiple shot	1	3	pierce		100	100	dmg%		150	250	sock		2	3	dmg-norm		40	80																														0
-Wightslayer	779	100	1			1		1	74	6mx	gorgon crossbow		5	5000				invcbow2				dmg%		220	260	dmg-undead		175	175	att-undead		300	300	red-dmg%		10	15	red-mag		15	25																														0
-Grey Render	780	100	1			2		1	64	6mx	Gorgon Crossbow		5	5000	lgry	lgry						dmg%		200	300	swing2		25	25	manasteal		5	8	mana		35	60	ama		2	2	crush		25	25	ignore-ac		1	1																						0
-Bluebeard	781	100	1			1		1	79	6hx	colossus crossbow		5	5000	dblu	dblu						dmg%		175	200	swing2		20	20	allskills		1	1	mag%		30	30	hp		55	55	dmg-cold	200	75	150	pierce-cold		25	25	extra-cold		20	20																		0
-Thor's Bolt	782	100	1			1		26	26	6rx	demon crossbow		5	5000				invcbow7				dmg-min		50	75	dmg-max		150	200	dmg-ltng		1	555	gethit-skill	49	8	17	res-ltng		40	50	pierce-ltng		35	35	res-mag		15	15																						0
-Replenishing Bolt Case	783	100	0			1		6	6	z02	Bolts		5	5000	oran	oran						dmg-norm		2	8	swing1		10	10																																										0
-Bolt Case of Piercing	784	100	1			1		35	35	z02	Bolts		5	5000	cblu	cblu						dmg-norm		4	12	swing1		15	15	pierce		15	15																																						0
-Bolt Case of Slaying	785	100	1			1		65	65	z02	Bolts		5	5000	blac	blac						dmg-norm		5	20	swing1		20	20	pierce		15	15	skilltab	0	1	1																																		0
-Hippogriff Wing	786	100	1			1		20	21	jav	javelin		5	5000	dgld	dgld						dmg-norm		20	40	dmg%		65	90	swing1		15	15	allskills		1	1	move1		15	15	rep-quant	20																												0
-Leafrazor	787	100	1			3		1	6	jav	javelin		5	5000								dmg%		100	150	rep-quant	20			stack		75	75	dmg-norm		2	4	deadly		35	35	pierce		40	40	skill	9	1	2																						0
-Stone Eater	788	100	1			5		1	3	jav	Javelin		5	5000	lgry	lgry						dmg-norm		3	8	hp		20	20	ac		45	75	red-dmg		2	4	red-mag		2	4	block		10	15																										0
-Amazon's Kiss	789	100	1			1		24	23	pil	pilum		5	5000	lred	lred		invjav2				dmg%		70	100	dmg-norm		25	45	ama		1	1	lifesteal		5	8	stack		150	150	regen		4	8	res-fire		15	30																						0
-Skyglow	790	100	1			3		1	15	pil	pilum		5	5000	oran	oran						dmg%		100	165	rep-quant	20			stack		75	75	dmg-fire		8	12	ama		1	1	block2		20	20	heal-kill		5	5																						0
-Luck Chaser	791	100	1			5		1	11	pil	Pilum		5	5000				invjav6				dmg%		60	100	bar		1	1	ama		1	1	oskill	critical strike	1	1	swing1		15	15	res-ltng		25	25	stack		75	75																						0
-Chaoskiller	792	100	1			1		26	27	ssp	short spear		5	5000	oran	oran						dmg%		75	100	dmg-norm		25	50	rep-quant	25			stack		50	50	rip		1	1	addxp		2	5	ignore-ac		1	1																						0
-Teeth of Infinity	793	100	1			3		1	21	ssp	short spear		5	5000				invjav9				dmg%		135	185	rep-quant	20			stack		75	75	oskill	teeth	5	5	charged	67	250	30	swing2		20	20	lifesteal		7	7																						0
-Pridebreaker	794	100	1			5		1	17	ssp	Short Spear		5	5000	whit	whit						dmg%		60	100	rep-quant	35			dmg-throw		5	10	dmg-demon		75	75	att		75	75	stack		30	30																										0
+Trial by Fire	650	100	1			3	1	42	49	9pa	partizan		5	5000								dmg%		200	250	dmg-fire		75	150	pierce-fire		15	20	aura	102	4	7	oskill	fire wall	5	8	res-fire-max		5	15	res-fire		20	50	sock		2	2																		0
+Kritchan's Ire	651	100	1			3	1	45	51	9h9	bec-de-corbin		5	5000	oran	oran						dmg%		100	150	dmg-norm		40	80	hit-skill	230	100	1	allskills		2	2	reduce-ac		25	25	openwounds		33	33	noheal		1	1																						0
+Father of Nations	652	100	1			1	1	55	57	9h9	bec-de-corbin		5	5000	dgld	dgld		invhal				dmg%		210	260	all-stats		25	25	hp%		15	15	mana%		15	15	lifesteal		8	11	manasteal		6	9	swing3		40	40	dmg-norm		50	100																		0
+Killer's Glee	653	100	1			1	1	55	60	9wc	grim scythe		5	5000	lred	lred						dmg%		100	150	dmg-norm		50	100	ethereal		1	1	rep-dur	20			sock		3	5																														0
+Dawn of the Dead	654	100	1			3	1	46	53	9wc	grim scythe		5	5000								dmg%		220	270	swing3		35	35	oskill	skeleton mastery	5	8	oskill	revive	5	8	dmg-undead		250	250	dmg-cold	200	35	70	slow		20	20																						0
+Ogre Cheiftain's Law	655	100	1			2	1	46	53	7o7	ogre axe		5	5000								dmg%		200	250	swing3		40	40	lifesteal		6	8	crush		33	33	slow		20	20	knock		3	3	rip		1	1																						0
+Titan's Reach	656	100	1			2	1	54	60	7vo	colossus voulge		5	5000	dgld	dgld						dmg%		200	275	swing1		15	15	oskill	sword mastery	12	12	bar		3	3	hp/lvl	16			regen		5	8	abs-cold%		20	20	abs-fire%		20	20																		0
+Kydra's Judgement	657	100	1			1	1	66	70	7vo	Colossus Voulge		5	5000								dmg%		200	250	dmg%/lvl	8			hit-skill	45	20	8	res-cold		45	45	dmg-cold		75	125	freeze		1	3	reduce-ac		10	10																						0
+Winter Solstice	658	100	1			1	1	70	75	7s8	thresher		5	5000	whit	whit						dmg%		100	140	dmg-min		75	125	dmg-max		300	400	dmg-cold		255	400	freeze		6	6	oskill	whirlwind	5	5	res-cold		80	80																						0
+Gatecleaver	659	100	1			1	1	75	79	7pa	cryptic axe		5	5000								dmg%		220	260	dex		35	35	ease		-50	-50	allskills		2	2	lifesteal		12	15	addxp		2	4	res-pois		35	55																						0
+Cloud Giant's Axe	660	100	1			1	1	80	83	7h7	great poleaxe		5	5000	dyel	dyel						dmg%		235	300	swing3		60	60	ease		25	25	str		75	75	heal-kill		15	20	dmg-ltng		1	500																										0
+Dreadfear	661	100	1			2	1	73	77	7h7	Great Poleaxe		5	5000								dmg%		300	450	sock		3	6	howl		100	100	vit		100																																			0
+Kraken's Backlash	662	100	1			1	1	82	86	7wc	giant thresher		5	5000								dmg%		200	240	dmg-norm		100	200	knock		6	6	swing2		20	20	dmg-cold		100	200	hit-skill	243	8	10	sock		2	2																						0
+Invoker	663	100	1			1	1	24	24	sst	short staff		5	5000				invsst				dmg-min		10	15	dmg-max		40	60	swing2		20	20	cast3		50	50	mana%		15	15	sock		2	2																										0
+Puzzler's Mystery	664	100	1			3	1	1	6	sst	short staff		5	5000	cblu	cblu						dmg-norm		5	10	skill-rand	2	36	44	skill-rand	2	36	44	mana		25	25	swing2		20	20																														0
+Touch of Evil	665	100	1			1	1	29	29	lst	long staff		5	5000	blac	blac		invlst				dmg-min		20	30	dmg-max		60	90	hit-skill	72	8	2	dru		1	1	balance2		20	20	mana		45	45	skill-rand	4	221	250																						0
+Puppeteer's Staff	666	100	1			3	1	4	12	lst	long staff		5	5000				invstaf3				dmg%		110	150	skill-rand	1	36	50	skill-rand	2	36	50	skill-rand	2	36	50	fireskill		1	1	cast2		20	20	oskill	clay golem	5	7	oskill	summon spirit wolf	3	3																		0
+Serpent Lord1	667	0	1			5	1	1	9	lst	Long Staff		5	5000	cgrn	cgrn						dmg-pois	75	40	40	res-pois		50	50	light		-1	-1	mana		10	10	dmg%		60	90	manasteal		100	100	reduce-ac		50	50																						0
+Wizard's Rule	668	100	1			1	1	30	32	cst	gnarled staff		5	5000				invcst				skill-rand	3	36	65	skill-rand	3	36	65	skill-rand	2	36	65	skill-rand	2	36	65	mana-kill		3	6	cast2		20	20	res-all		20	30																						0
+Sage's Retort	669	100	1			3	1	6	17	cst	gnarled staff		5	5000	oran	oran		invstaf9				dmg%		125	175	gethit-skill	44	50	2	gethit-skill	42	3	7	regen-mana		75	75	mana%		15	15	kill-skill	Frost Nova	6	6																										0
+Staff of the Arch-Magus	670	100	1			1	1	31	36	bst	battle staff		5	5000	cred	cred		invbst				allskills		2	2	mana/lvl	10			str		25	25	dex		25	25	cast3		30	30	skilltab	4	2	2	rip		1	1	addxp		3	5																		0
+Strange Alchemy	671	100	1			3	1	8	23	bst	battle staff		5	5000								oskill	warmth	1	3	oskill	frozen armor	1	3	oskill	bone armor	1	3	oskill	cyclone armor	1	3	dmg-norm		15	30	swing2		20	20	dmg%		100	100																						0
+Warmth of Ash	672	100	1			1	1	32	40	wst	war staff		5	5000	dgry			invstaf12				fireskill		5	5	dmg-min		15	25	dmg-max		60	80	dmg-fire		75	100	res-fire		65	65	abs-cold		10	20	skill-rand	2	36	65																						0
+Riddlesolver	673	100	1			3	1	15	29	wst	war staff		5	5000				invstaf2				dmg%		150	200	skill-rand	2	36	65	skill-rand	3	36	65	skill-rand	3	36	65	sor		1	1	cast2		25	25	balance2		30	30																						0
+Arctic Frost	674	100	1			1	1	55	45	8ss	jo staff		5	5000	lblu	lblu		invstaf10				skilltab	5	4	4	extra-cold		25	25	abs-cold%		25	25	pierce-cold		35	35	res-fire		80	100																														0
+Staff of Shadows	675	100	1			3	1	24	36	8ss	jo staff		5	5000	blac	blac		invsst				skill-rand	3	36	65	skill-rand	3	36	65	skill-rand	3	36	65	cast2		20	20	gethit-skill	71	11	2	red-dmg		8	12					allskills		1	1																		0
+Ter'Angreal	676	100	1			1	1	55	50	8ls	quarterstaff		5	5000	whit	whit						sor		2	2	cast3		40	40	mana%		50	50	addxp		5	5	mana-kill		20	20	dmg-to-mana		15	25																										0
+Silence of the Sphinx	677	100	1			3	1	28	39	8ls	quarterstaff		5	5000				invstaf4				skill-rand	2	36	65	skill-rand	2	36	65	skill-rand	2	36	65	sor		2	2	dmg-to-mana		15	15	addxp		3	5	cheap		10	15	mag%		60	60	sock		2	2														0
+Staff of Valere	678	100	1			1	1	55	56	8cs	cedar staff		5	5000				invstaf5				dmg-min		30	50	dmg-max		100	150	swing3		45	45	red-dmg%		15	20	str		15	15	dex		25	25	dru		1	1	cast2		15	15																		0
+Rubydawn	679	100	1			3	1	32	42	8cs	cedar staff		5	5000	cred	cred		invcst				skill-rand	4	66	95	skill-rand	3	66	95	skill-rand	2	66	95	nec		2	2	cast2		20	20	mana%		15	15	oskill	fire mastery	3	6	oskill	47	6	8																		0
+Knight's Prophet	680	100	1			1	1	55	60	8bs	gothic staff		5	5000				invstaf7				dmg-min		35	70	dmg-max		150	250	pal		3	3	res-all		40	50	move2		25	25	swing2		25	25	manasteal		4	7	lifesteal		7	7	oskill	whirlwind	3	3														0
+Grace of Isis	681	100	1			3	1	37	47	8bs	gothic staff		5	5000	dgld	dgld		invbst				dmg%		200	265	dru		1	2	skill-rand	3	221	250	skill-rand	2	221	250	skill-rand	3	221	250	dmg-norm		30	60	swing3		40	40	ignore-ac		1	1	crush		20	20														0
+Arcane Protection	682	100	1			1	1	55	65	8ws	rune staff		5	5000	dgrn	dgrn						sor		2	2	res-all		35	50	red-mag		25	25	gethit-skill	40	13	4	charged	58	27	9	dmg-to-mana		50	50	regen-mana		200	200																						0
+Survivor's Sonata	683	100	1			3	1	42	50	8ws	rune staff		5	5000				invstaf13				skill	48	3	5	skill	60	3	5	hp		75	75	cast2		25	25	allskills		2	2	addxp		5	5	gold%		200	200	mag%/lvl	10																				0
+Road to Perdition	684	100	1			1	1	59	67	6ss	walking stick		5	5000	lgry	lgry						allskills		3	3	mag%		200	300	cast2		40	40	mana/lvl	16																																				0
+Jadrik's Torment	685	100	1			2	1	40	49	6ss	Walking Stick		5	5000				invstaf8				enr		35	35	cast3		40	40	move3		50	50	dmg%		200	300	swing3		55	55	str		-50	-50	hp		200	200																						0
+Ogden's Wisdom	686	100	1			1	1	63	69	6ls	stalagmite		5	5000				invstaf6				allskills		2	2	cast2		20	20	enr		35	35	addxp		3	5	heal-kill		15	15	cheap		10	10	skill-rand	5	36	65	skill-rand	5	36	65	skill-rand	5	36	65														0
+Gorgon Strength	687	100	1			2	1	46	55	6ls	Stalagmite		5	5000	oran	oran						str		100	100	mana		150	150	sor		3	3	mag%/lvl	8			res-all		25	25	ac/lvl	40																												0
+Light of Ra	688	100	1			1	1	66	73	6cs	elder staff		5	5000	whit	whit		invcst				skilltab	4	5	5	skill	57	3	5	skill	63	3	5	light		5	5	thorns/lvl	10			sock		3	3																										0
+Summoner's Risk	689	100	1			1	1	73	79	6bs	shillelah		5	5000				invbst				oskill	bloodgolem	6	8	oskill	golem mastery	20	20	dmg-to-mana		35	35	cast2		30	30	res-all		100	100	balance3		40	40	regen		3	5																						0
+Sanctuary	690	100	1			2	1	70	76	6bs	Shillelah		5	5000	cred							cast2		20	20	mana		220	220	ac		350	550	red-dmg%		50	50	sor		2	2	mana%		25	25																										0
+Everkeeper	691	100	1			1	1	80	85	6ws	archon staff		5	5000				invstaf11				allskills		1	1	dmg-min		150	200	dmg-max		350	400	rep-dur	25			ignore-ac		1	1	swing3		40	40	regen		20	20	dmg%		300	340																		0
+Acolyte's Wand	692	100	1			1	1	24	25	wnd	wand		5	5000	lblu	lblu		invwnd				nec		1	1	cast2		20	20	mana		44	44	regen-mana		50	50	skill-rand	2	66	90	skill-rand	2	66	90																										0
+Bitter Sorrow	693	100	1			3	1	1	9	wnd	wand		5	5000				invwand1				dmg-min		2	7	dmg-max		12	20	skill-rand	3	66	75	skill-rand	3	66	75	sock		2	2																														0
+Ladrina's Enchantment	694	100	1			1	1	30	30	ywn	yew wand		5	5000	dgld	dgld		invywn				charged	66	200	12	charged	82	33	7	charged	42	19	20	charged	57	7	27	charged	17	112	29	charged	154	61	15	charged	235	17	20																						0
+Ire of Astaroth	695	100	1			3	1	7	19	ywn	yew wand		5	5000								skill-rand	1	66	80	skill-rand	2	66	80	skill-rand	2	66	80	skill-rand	3	66	80	nec		1	1	mana		40	40	cast2		25	25																						0
+Skeleton's Claw	696	100	1			1	1	34	33	bwn	bone wand		5	5000	whit	whit		invbwn				dmg-min		10	20	dmg-max		40	60	lifesteal		10	15	swing2		20	20	skill	69	3	5	hp		50	75	mag%		25	30	allskills		1	1																		0
+Child's Laughter	697	100	1			3	1	16	26	bwn	bone wand		5	5000								skill	72	3	5	skill	77	3	5	skill	81	3	5	levelup-skill	nova	100	40	mag%		50	50	addxp		4	4	extra-pois		25	25																						0
+Dracolich Fang	698	100	1			1	1	37	37	gwn	grim wand		5	5000	cgrn	cgrn		invgwn				nec		1	1	lifesteal		100	100	manasteal		100	100	regen		6	10	regen-mana		35	80	red-dmg%		10	10	nofreeze		1	1	res-pois-len		80	90																		0
+Scream of Despair	699	100	1			3	1	22	32	gwn	grim wand		5	5000								nec		2	2	skill-rand	3	66	95	skill-rand	5	66	95	gethit-skill	77	25	8	mana		20	20	hp		50	50	str		20	20																						0
+Epoch's End	700	100	1			1	1	55	43	9wn	burnt wand		5	5000				invwand2				allskills		1	1	mana/lvl	8			hp/lvl	8			extra-pois		20	30	res-pois		45	65	res-pois-len		50	50	oskill	94	3	5																						0
+Apoclypse Fire	701	100	1			3	1	28	39	9wn	burnt wand		5	5000	dred	dred		invwnd				charged	62	100	30	charged	51	100	30	charged	225	100	30	charged	244	100	30	addxp		10	10	res-all		65	65	cast2		25	25	allskills		1	1																		0
+Huclavee's Flinch	702	100	1			3	1	34	42	9yw	petrified wand		5	5000				invywn				dmg-norm		40	80	dmg%		175	200	swing3		35	35	knock		3	3	slow		25	25	oskill	zeal	8	8	lifesteal		8	8																						0
+Asylum's Ward	703	100	1			1	1	55	49	9bw	tomb wand		5	5000								nec		2	2	skill-rand	2	66	95	skill-rand	2	66	95	skill-rand	3	66	95	charged	72	42	8	gethit-skill	81	6	4	red-mag		10	15																						0
+Wand of Fireballs	704	100	1			3	1	38	45	9bw	tomb wand		5	5000	oran	oran		invbwn				gethit-skill	47	100	15	all-stats		20	20	skill-rand	3	66	95	skill-rand	3	66	95	allskills		1	1	cast2		25	25	sock		1	1																						0
+Nullwand	705	100	1			1	1	55	53	9gw	grave wand		5	5000								allskills		2	2	res-all		40	60	red-dmg%		20	25	abs-fire		10	10	abs-ltng		10	10	abs-cold		10	10	nofreeze		1	1	res-pois-len		70	70																		0
+Gravedancer's Union	706	100	1			3	1	40	49	9gw	grave wand		5	5000	dgry	dgry		invgwn				skill-rand	1	66	95	skill-rand	2	66	95	skill-rand	3	66	95	skill	69	2	5	mana		100	100	res-cold		25	40	res-pois		50	50	heal-kill		10	15																		0
+Voice of Reason	707	100	1			1	1	62	68	7wn	polished wand		5	5000				invwand3				enr		30	30	addxp		3	5	cheap		15	15	cast2		25	25	skill-rand	3	66	95	skill-rand	3	66	95	skilltab	6	2	3																						0
+Darkmantle	708	100	1			2	1	40	50	7wn	Polished Wand		5	5000	blac	blac						nec		1	3	oskill	dim vision	5	5	mana		50	50	skill-rand	7	66	95	rip		1	1	cast3		40	40	regen		35	35	ac/lvl	24																				0
+Chorus of the Cursed	709	100	1			1	1	66	73	7yw	ghost wand		5	5000	dpur	dpur		invywn				allskills		2	2	skilltab	6	2	2	res-mag		20	20	gethit-skill	91	3	18	dex		20	20	str		20	20	oskill	revive	1	1																						0
+Specral Immage	710	100	1			2	1	54	61	7yw	Ghost Wand		5	5000								allskills		1	1	res-all		25	35	addxp		5	10	abs-cold%		15	20	abs-ltng%		15	20	abs-fire%		15	20	skilltab	8	2	5																						0
+Vengeance of the Wronged	711	100	1			1	1	72	79	7bw	lich wand		5	5000				invbwn				nec		3	3	skill-rand	10	66	95	death-skill	92	100	50	mana		75	100	hp		75	100	mana-kill		3	5	addxp		3	5																						0
+Pull of Darkness	712	100	1			1	1	81	86	7gw	unearthed wand		5	5000				invgwn				allskills		2	2	gold%		125	125	mag%		60	60	skill	93	7	15	move3		40	40	block		25	25	block2		20	20																						0
+Freedom's Flight	713	100	1			1	1	24	25	sbw	short bow		5	5000								dmg-norm		20	40	swing1		20	20	skilltab	0	1	3	att%		50	50	skill	6	10	10																														0
+Violetwing	714	100	1			3	1	1	7	sbw	short bow		5	5000	dpur	dpur		invsbw				dmg-norm		4	8	swing1		15	15	skill	6	3	3	move2		20	20																																		0
+Target's	715	100	1			1	1	25	26	hbw	hunter's bow		5	5000				invbow10				dmg-norm		23	45	balance1		20	20	dmg-ltng		1	100	lifesteal		4	6	vit		15	15	oskill	6	1	3																										0
+Carrion Wing	716	100	1			3	1	1	10	hbw	hunter's bow		5	5000	dgry	dgry		invhbw				dmg%		100	150	dmg-max		6	10	dmg-undead		200	200	extra-fire		20	20	sock		1	2																														0
+Elven Bow of Duadon	717	100	1			1	1	26	27	lbw	long bow		5	5000	dgrn	dgrn						dmg-norm		25	50	swing2		20	20	allskills		1	1	manasteal		4	6	regen		1	2	balance2		20	20																										0
+Gale Song	718	100	1			3	1	4	16	lbw	long bow		5	5000				invlbw				dmg%		100	150	dmg-norm		5	12	ama		1	1	howl		144	144	dex		20	20	ease		-25	-25																										0
+Silver Oak Bow	719	100	1			1	1	27	28	cbw	composite bow		5	5000	whit			invbow6				dmg-norm		32	55	att		200	200	dmg-undead		200	200	dmg-demon		100	100	regen-mana		50	50	str		15	15	ease		-15	-15																						0
+Warpwind	720	100	1			3	1	8	21	cbw	composite bow		5	5000				invcbw				dmg%		125	175	dmg-norm		3	15	swing2		25	25	knock		1	1	skill	12	6	6	mana		35	35																										0
+Shayira's Flight	721	100	1			1	1	28	29	sbb	short battle bow		5	5000	oran	oran						dmg-fire		80	100	dmg-ltng		10	200	dmg-cold	100	40	50	dmg%		100	130	dmg-norm		10	20	all-stats		5	5																										0
+Willowsting	722	100	1			3	1	7	22	sbb	short battle bow		5	5000				invsbb				dmg%		125	175	gethit-skill	67	12	7	ease		-25	-25	balance2		20	20	gold%		50	100	lifesteal		6	6																										0
+Kirre Strike	723	100	1			1	1	29	32	lbb	long battle bow		5	5000	dgld	dgld						dmg-norm		35	60	oskill	strafe	3	3	res-fire		15	20	res-pois		40	50	knock		1	1	pierce		20	20																										0
+Beeswarm	724	100	1			3	1	12	26	lbb	long battle bow		5	5000				invlbb				dmg%		140	190	dmg-norm		10	20	oskill	multiple shot	6	6	swing2		25	25	allskills		1	1																														0
+Sylvan Battle Bow	725	100	1			1	1	30	35	swb	short war bow		5	5000	blac			invbow1				dmg-norm		35	70	swing3		30	30	hp%		10	10	mana%		20	20	oskill	ice arrow	2	2	ama		1	1	skilltab	0	1	2																						0
+Ranger's Sting	726	100	1			3	1	16	29	swb	short war bow		5	5000				invbow5				dmg-min		5	15	dmg-max		30	45	bar		2	2	swing2		20	20	oskill	strafe	6	6	dex		35	35	manasteal		6	6																						0
+Telena's War Bow	727	100	1			1	1	31	37	lwb	long war bow		5	5000	cblu	cblu						dmg-norm		40	80	swing2		25	25	lifesteal		5	7	mana-kill		7	7	addxp		2	2	dex		15	15	crush		10	15																						0
+Finalflight	728	100	1			3	1	20	31	lwb	long war bow		5	4000				invlwb				dmg-min		10	20	dmg-max		40	60	dmg%		100	125	rip		1	1	addxp		5	5	gethit-skill	54	10	1	ac		100	100																						0
+Teldicia's Sting	729	100	1			1	1	55	44	8sb	edge bow		5	5000				invbow8				dmg%		80	125	dmg-norm		25	50	swing2		30	30	dmg-pois	75	333	333	dex		10	10	hp		50	50	gethit-skill	22	7	1																						0
+Dead to the World	730	100	1			3	1	23	35	8sb	edge bow		5	5000	blac	blac		invsbw				dmg%		175	225	swing2		25	25	regen		5	5	oskill	guided arrow	4	4	charged	95	8	35	pierce		25	25	lifesteal		6	6																						0
+Sadira	731	100	1			1	1	55	46	8hb	razor bow		5	5000				invbow11				dmg%		80	125	dmg-norm		25	50	dmg-ltng		25	100	res-all		20	20	mana-kill		5	5	regen-mana		75	75	sock		1	1																						0
+Iceweaver	732	100	1			3	1	25	37	8hb	razor bow		5	5000	whit	whit		invhbw				dmg%		185	235	oskill	ice arrow	5	5	charged	60	3	10	gethit-skill	44	8	4	dmg-cold	300	40	80	extra-cold		15	15	dmg-norm		20	40																						0
+Fatima Ravenclaw	733	100	1			1	1	55	49	8lb	cedarbow		5	5000								dmg%		80	125	dmg-norm		25	50	att%		20	20	oskill	pierce	1	1	lifesteal		7	9	mana		30	30	bar		2	2	swing1		15	15																		0
+Bow of the Dead	734	100	1			3	1	30	40	8lb	cedar bow		5	5000	dgry	dgry		invlbw				dmg%		190	240	reanimate	649	10	10	res-cold		35	35	dmg-undead		150	150	manasteal		5	7	dex		20	20	allskills		1	1																						0
+Larissa's Aim	735	100	1			1	1	55	51	8cb	double bow		5	5000				invbow7				dmg%		175	220	dmg-norm		25	50	manasteal		5	5	vit		30	30	dex		15	15	res-cold		35	50	att		200	200																						0
+Ranger's Path	736	100	1			3	1	32	42	8cb	double bow		5	5000	dgrn	dgrn		invcbw				dmg%		195	250	allskills		2	2	swing2		25	25	dmg-max		30	40	charged	247	5	10	deadly/lvl	12			mag%		40	70																						0
+Hailstrike	737	100	1			1	1	55	52	8s8	short siege bow		5	5000	dred	dred						dmg%		160	190	dmg-norm		35	70	skill	11	3	3	skill	21	5	5	gethit-skill	31	4	1	cold-len	300			mag%		40	40																						0
+Pride's Paradox	738	100	1			3	1	35	45	8s8	short siege bow		5	5000	oran	oran		invsbb				dmg%		200	255	knock		2	2	dmg-cold	1000	1	1	freeze		3	3	pierce		30	30	sock		2	3																										0
+Heartseeker	739	100	1			1	1	55	54	8l8	long siege bow		5	5000								dmg%		175	200	deadly		100	100	noheal		1	1	openwounds		100	100	lifesteal		6	8	att%		50	50	ama		2	2																						0
+Crimson Crusade	740	100	1			3	1	38	48	8l8	long siege bow		5	5000	dred	dred		invlbb				dmg%		210	265	swing2		20	20	hp		45	45	mana		65	65	bloody		1	1	noheal		1	1	openwounds		100	100	dmg-norm		20	40																		0
+Dune Runner	741	100	1			1	1	55	56	8sw	rune bow		5	5000				invbow2				dmg%		150	190	dmg-norm		35	70	move3		30	30	balance2		35	35	heal-kill		10	12	oskill	weaken	1	1	sock		2	2																						0
+Remorhaz	742	100	1			3	1	40	50	8sw	rune bow		5	5000	cblu			invbow12				dmg%		225	275	swing3		40	40	ama		1	1	res-fire		75	75	pierce-fire		30	30	oskill	immolation arrow	3	3	charged	17	100	10	move3		30	30																		0
+Ghost Mount	743	100	1			1	1	55	59	8lw	gothic bow		5	5000								dmg%		200	240	dmg-norm		20	40	res-all		25	50	move3		30	30	dex		20	30	move1		15	15	swing1		15	15	skilltab	0	3	3																		0
+Harper's Call	744	100	1			3	1	44	53	8lw	gothic bow		5	5000	oran	oran		invlwb				dmg%		225	275	dmg/lvl	8			allskills		1	1	all-stats		15	15	ease		-20	-20	regen		12	15	manasteal		8	8																						0
+Arachnid's Bite	745	100	1			1	1	57	65	6sb	spider bow		5	5000								dmg%		190	240	openwounds		50	100	dmg-pois	200	750	750	dmg-pois/lvl	56			stupidity		3	3	balance1		15	15	allskills		2	2																						0
+Black Widow	746	100	1			2	1	41	51	6sb	Spider Bow		5	5000	blac	blac						dmg%		175	225	swing2		20	20	dmg-pois	150	900	900	slow		25	25	fade		1	1	move3		50	50	dex/lvl	4																								0
+Foxfire Leaf	747	100	1			1	1	60	68	6hb	blade bow		5	5000				invbow13				dmg%		180	230	dmg-fire		200	400	dmg-fire/lvl	24			dex		15	15	res-all		20	30	gold%		100	100	mag%		35	35																						0
+Razor Strike	748	100	1			2	1	46	55	6hb	Blade Bow		5	5000	dpur	dpur						dmg%		200	250	bloody		1	1	noheal		1	1	crush		20	30	dex		25	25	sock		2	2	aura	fanaticism	1	1																						0
+Golgomere	749	100	1			1	1	66	72	6lb	shadow bow		5	5000								dmg%		200	240	dmg-norm		35	70	ease		-60	-60	magicarrow		1	1	cast2		25	25	mana/lvl	10			sor		2	2																						0
+Death Shade	750	100	1			2	1	50	60	6lb	Shadow Bow		5	5000	blac	blac						dmg%		220	270	swing2		25	25	oskill	revive	5	5	oskill	skeleton mastery	5	12	res-all		35	35	knock		2	2																										0
+Oathbow	751	100	1			1	1	68	74	6cb	great bow		5	5000				invbow9				dmg%		160	200	dmg-norm		40	90	addxp		2	5	all-stats		25	25	red-dmg		20	30	red-mag		20	30	res-mag		25	25																						0
+Phantom Pegasus	752	100	1			2	1	56	64	6cb	Great Bow		5	5000	oran			invbow4				dmg%		200	300	move3		25	25	vit		35	35	cast2		25	25	allskills		2	2	addxp		12	12	hp%		15	25																						0
+Nine Lives Stealer	753	100	1			1	1	71	77	6s7	diamond bow		5	5000	blac	blac						dmg%		200	240	gethit-skill	53	9	9	lifesteal		9	9	heal-kill		9	9	mana-kill		9	9	nofreeze		1	1	skilltab	0	1	3																						0
+Celestial Strike	754	100	1			2	1	60	67	6s7	Diamond Bow		5	5000	dblu	dblu						dmg%		100	150	dmg-cold	400	75	100	dmg-fire		250	400	dmg-ltng		1	500	manasteal		8	10	lifesteal		6	12	all-stats		20	30	kill-skill	inner sight	100	5	dmg-norm		20	40														0
+Elflord's Victory	755	100	1			1	1	74	79	6l7	crusader bow		5	5000								dmg%		190	250	dmg/lvl	8			ama		1	2	skilltab	0	1	3	swing2		30	30	str		20	20	balance3		40	40																						0
+Patron of Perversity	756	100	1			1	1	78	82	6sw	ward bow		5	5000				invbow3				dmg%		210	250	dru		2	2	swing3		40	40	balance2		25	25	oskill	magic arrow	15	20	noheal		1	1	dmg-norm		50	100	skill	224	4	7																		0
+Adamantine Bow	757	100	1			1	1	4	8	6lw	hydra bow		5	5000								dmg-min		100	175	dmg-max		275	400	red-dmg%		15	15	res-mag		15	15	gethit-skill	12	6	20	swing1		15	15	allskills		1	2	skilltab	0	2	2																		0
+Replenishing Quiver	758	100	0			1	1	6	6	z01	Arrows		5	5000	oran	oran		invarro1				dmg-norm		2	8	swing1		10	10																																										0
+Quiver of Piercing	759	100	1			1	1	35	35	z01	Arrows		5	5000	cblu	cblu		invarro2				dmg-norm		4	12	swing1		15	15	pierce		15	15																																						0
+Quiver of Slaying	760	100	1			1	1	65	65	z01	Arrows		5	5000	blac	blac		invarro3				dmg-norm		5	20	swing1		20	20	pierce		25	25	skilltab	0	1	1																																		0
+Rethral	761	100	1			1	1	25	25	lxb	light crossbow		5	5000	dred	dred		invcbow4				dmg-norm		20	40	swing2		20	20	ama		1	1	dmg-ltng		1	40	red-dmg%		10	15	sock		1	1																										0
+Nail Flinger	762	100	1			3	1	1	12	lxb	light crossbow		5	5000				invlxb				dmg%		100	150	dmg-max		7	12	pierce		100	100	red-dmg		4	6	red-mag		2	5																														0
+Piercing Bolt	763	100	1			1	1	28	28	mxb	crossbow		5	5000				invcbow5				dmg-norm		25	50	pierce		100	100	res-all		20	30	knock		1	1	att%		20	20	lifesteal		5	5	addxp		2	3																						0
+Janglebright	764	100	1			3	1	6	18	mxb	crossbow		5	5000	whit	whit		invmxb				dmg%		125	175	light		3	5	res-all		25	25	balance2		15	15	swing1		10	10	sock		1	1																										0
+Harpo Bogglinn	765	100	1			1	1	32	32	hxb	heavy crossbow		5	5000								dmg-norm		25	50	swing1		10	10	slow		15	15	pierce-fire		10	10	extra-fire		10	10	allskills		1	1																										0
+Spikethrower 	766	100	1			3	1	10	24	hxb	heavy crossbow		5	5000				invhxb				dmg%		150	200	dmg-norm		10	20	crush		25	25	deadly		25	25	noheal		1	1	ama		1	1																										0
+Synthalus	767	100	1			1	1	33	35	rxb	repeating crossbow		5	5000				invcbow3				dmg-norm		35	70	att		200	200	balance2		20	20	dex		15	15	mana		35	35	dmg/lvl	4			magicarrow		1	1																						0
+King's Nail	768	100	1			3	1	15	30	rxb	repeating crossbow		5	5000				invrxb				allskills		1	1	oskill	guided arrow	3	5	swing2		30	30	lifesteal		5	5	manasteal		3	3	gold%		50	50	hit-skill	87	15	3	dmg-min		10	20	dmg-max		30	50	dmg%		100	125										0
+Kyuss' Crossbow	769	100	1			1	1	55	48	8lx	arbalest		5	5000				invcbow6				dmg%		175	220	swing2		20	20	oskill	freezing arrow	1	1	heal-kill		10	15	regen-mana		60	60	mag%		30	50	gold%		75	75																						0
+Garlana Firebolt	770	100	1			3	1	24	38	8lx	arbalest		5	5000	dred	dred		invlxb				dmg%		180	240	swing2		25	25	ama		1	1	oskill	exploding arrow	6	6	res-cold		25	40	dmg-norm		15	30	fireskill		2	2																						0
+Giant Hair Crossbow	771	100	1			1	1	55	53	8mx	siege crossbow		5	5000								dmg%		200	250	swing3		40	40	ignore-ac		1	1	lifesteal		6	6	dmg-max		25	25	ease		15	15	pierce-cold		10	15																						0
+Raven Myst	772	100	1			3	1	32	43	8mx	siege crossbow		5	5000	whit	whit		invmxb				dmg%		150	150	dmg/lvl	13			swing3		30	30	oskill	raven	5	5	aura	120	3	6	sock		2	2	knock		1	1																						0
+Whyte Stag	773	100	1			1	1	55	56	8hx	ballista		5	5000	whit	whit						dmg%		200	300	dmg-cold	300	100	200	freeze		1	1	noheal		1	1	half-freeze		1	1	res-cold		35	50	sock		1	1																						0
+Senmet's Boltcaster	774	100	1			3	1	36	47	8hx	ballista		5	5000				invcbow1				dmg%		200	250	swing2		25	25	heal-kill		15	15	addxp		5	5	charged	149	10	10	balance2		20	20	magicarrow		1	1																						0
+Ashira's Stunbeam	775	100	1			1	1	55	61	8rx	chu-ko-nu		5	5000				invcbow8				dmg-norm		75	150	swing2		30	30	lifesteal		6	8	manasteal		5	7	gethit-skill	38	100	5	all-stats		15	15	mana		40	40																						0
+Widow's Refrain	776	100	1			3	1	44	54	8rx	chu-ko-nu		5	5000	dgry	dgry		invrxb				dmg%		215	270	swing2		20	20	dmg-norm		25	50	charged	quickness	17	12	charged	fade	22	8	dmg-to-mana		12	12	rip		1	1																						0
+Stoneblaster	777	100	1			1	1	59	67	6lx	pellet bow		5	5000	dgry	dgry						dmg%		200	240	knock		1	1	slow		20	20	stupidity		1	1	swing2		15	15	addxp		3	3																										0
+Doubleshot Machine	778	100	1			2	1	45	55	6lx	Pellet Bow		6	6000								oskill	multiple shot	1	3	pierce		100	100	dmg%		150	250	sock		2	3	dmg-norm		40	80																														0
+Wightslayer	779	100	1			1	1	68	74	6mx	gorgon crossbow		5	5000				invcbow2				dmg%		220	260	dmg-undead		175	175	att-undead		300	300	red-dmg%		10	15	red-mag		15	25																														0
+Grey Render	780	100	1			2	1	56	64	6mx	Gorgon Crossbow		5	5000	lgry	lgry						dmg%		200	300	swing2		25	25	manasteal		5	8	mana		35	60	ama		2	2	crush		25	25	ignore-ac		1	1																						0
+Bluebeard	781	100	1			1	1	74	79	6hx	colossus crossbow		5	5000	dblu	dblu						dmg%		175	200	swing2		20	20	allskills		1	1	mag%		30	30	hp		55	55	dmg-cold	200	75	150	pierce-cold		25	25	extra-cold		20	20																		0
+Thor's Bolt	782	100	1			1	1	26	26	6rx	demon crossbow		5	5000				invcbow7				dmg-min		50	75	dmg-max		150	200	dmg-ltng		1	555	gethit-skill	49	8	17	res-ltng		40	50	pierce-ltng		35	35	res-mag		15	15																						0
+Replenishing Bolt Case	783	100	0			1	1	6	6	z02	Bolts		5	5000	oran	oran						dmg-norm		2	8	swing1		10	10																																										0
+Bolt Case of Piercing	784	100	1			1	1	35	35	z02	Bolts		5	5000	cblu	cblu						dmg-norm		4	12	swing1		15	15	pierce		15	15																																						0
+Bolt Case of Slaying	785	100	1			1	1	65	65	z02	Bolts		5	5000	blac	blac						dmg-norm		5	20	swing1		20	20	pierce		15	15	skilltab	0	1	1																																		0
+Hippogriff Wing	786	100	1			1	1	12	21	jav	javelin		5	5000	dgld	dgld						dmg-norm		20	40	dmg%		65	90	swing1		15	15	allskills		1	1	move1		15	15	rep-quant	20																												0
+Leafrazor	787	100	1			3	1	1	6	jav	javelin		5	5000								dmg%		100	150	rep-quant	20			stack		75	75	dmg-norm		2	4	deadly		35	35	pierce		40	40	skill	9	1	2																						0
+Stone Eater	788	100	1			5	1	1	3	jav	Javelin		5	5000	lgry	lgry						dmg-norm		3	8	hp		20	20	ac		45	75	red-dmg		2	4	red-mag		2	4	block		10	15																										0
+Amazon's Kiss	789	100	1			1	1	10	23	pil	pilum		5	5000	lred	lred		invjav2				dmg%		70	100	dmg-norm		25	45	ama		1	1	lifesteal		5	8	stack		150	150	regen		4	8	res-fire		15	30																						0
+Skyglow	790	100	1			3	1	3	15	pil	pilum		5	5000	oran	oran						dmg%		100	165	rep-quant	20			stack		75	75	dmg-fire		8	12	ama		1	1	block2		20	20	heal-kill		5	5																						0
+Luck Chaser	791	100	1			5	1	1	11	pil	Pilum		5	5000				invjav6				dmg%		60	100	bar		1	1	ama		1	1	oskill	critical strike	1	1	swing1		15	15	res-ltng		25	25	stack		75	75																						0
+Chaoskiller	792	100	1			1	1	26	27	ssp	short spear		5	5000	oran	oran						dmg%		75	100	dmg-norm		25	50	rep-quant	25			stack		50	50	rip		1	1	addxp		2	5	ignore-ac		1	1																						0
+Teeth of Infinity	793	100	1			3	1	10	21	ssp	short spear		5	5000				invjav9				dmg%		135	185	rep-quant	20			stack		75	75	oskill	teeth	5	5	charged	67	250	30	swing2		20	20	lifesteal		7	7																						0
+Pridebreaker	794	100	1			5	1	8	17	ssp	Short Spear		5	5000	whit	whit						dmg%		60	100	rep-quant	35			dmg-throw		5	10	dmg-demon		75	75	att		75	75	stack		30	30																										0
 Cadin'Sor	795	100	1			1	1	28	33	glv	glaive		5	5000	blac	blac						dmg%		80	100	dmg-norm		30	55	stack		60	60	res-ltng		20	30	dex		15	15	oskill	sword mastery	1	1	res-pois		15	25																						0
-Sting of Humiliation	796	100	1			3		1	28	glv	glaive		5	5000								dmg%		160	200	rep-quant	20			stack		100	100	bar		1	1	skill	140	5	5	howl		144	144	res-all		35	35																						0
-Mind Creche	797	100	1			5		1	24	glv	Glaive		5	5000	oran							dmg%		90	120	mana		40	40	ease		-35	-35	cast1		15	15	oskill	poison javelin	1	2	deadly		25	40	stupidity		1	1																						0
-Dancing Scarecrow	798	100	1			1		31	37	tsp	throwing spear		5	5000								dmg-norm		40	70	swing1		15	15	balance1		15	15	cast1		15	15	block1		15	15	att		200	200	knock		1	1	pierce		33	33																		0
-Splinterfreeze	799	100	1			3		1	32	tsp	throwing spear		5	5000	cblu	cblu		invjav1				dmg%		180	200	rep-quant	20			stack		125	125	hit-skill	44	100	6	aura	holy freeze	1	3	oskill	frozen orb	1	1	oskill	cold mastery	1	1	mana		75	75																		0
-Baba Yaga's Needle	800	100	1			5		1	29	tsp	Throwing Spear		5	5000								dmg%		100	145	rep-quant	25			lifesteal		6	8	res-pois		25	40	move2		25	25	stack		40	40	abs-mag		3	7																						0
-Aiel Javelins	801	100	1			1		55	54	9ja	war javelin		5	5000								dmg%		100	125	dmg-norm		35	70	dmg/lvl	4			rep-quant	20			swing2		20	20	pierce		25	25	reduce-ac		15	15																						0
-Rhyme of the Bard	802	100	1			3		1	37	9ja	war javelin		5	5000	lpur	lpur						dmg%		200	250	rep-quant	25			stack		60	60	charged	149	200	3	charged	138	200	3	charged	154	200	2	swing3		35	35																						0
-Severalkill	803	100	1			5		1	31	9ja	War Javelin		5	5000	dyel	dyel						dmg%		165	210	rep-quant	20			stack		25	25	res-cold		20	30	res-fire		20	30	heal-kill		12	12	crush		25	25																						0
+Sting of Humiliation	796	100	1			3	1	16	28	glv	glaive		5	5000								dmg%		160	200	rep-quant	20			stack		100	100	bar		1	1	skill	140	5	5	howl		144	144	res-all		35	35																						0
+Mind Creche	797	100	1			5	1	12	24	glv	Glaive		5	5000	oran							dmg%		90	120	mana		40	40	ease		-35	-35	cast1		15	15	oskill	poison javelin	1	2	deadly		25	40	stupidity		1	1																						0
+Dancing Scarecrow	798	100	1			1	1	31	37	tsp	throwing spear		5	5000								dmg-norm		40	70	swing1		15	15	balance1		15	15	cast1		15	15	block1		15	15	att		200	200	knock		1	1	pierce		33	33																		0
+Splinterfreeze	799	100	1			3	1	18	32	tsp	throwing spear		5	5000	cblu	cblu		invjav1				dmg%		180	200	rep-quant	20			stack		125	125	hit-skill	44	100	6	aura	holy freeze	1	3	oskill	frozen orb	1	1	oskill	cold mastery	1	1	mana		75	75																		0
+Baba Yaga's Needle	800	100	1			5	1	16	29	tsp	Throwing Spear		5	5000								dmg%		100	145	rep-quant	25			lifesteal		6	8	res-pois		25	40	move2		25	25	stack		40	40	abs-mag		3	7																						0
+Aiel Javelins	801	100	1			1	1	55	54	9ja	war javelin		5	5000								dmg%		100	125	dmg-norm		35	70	dmg/lvl	4			rep-quant	20			swing2		20	20	pierce		25	25	reduce-ac		15	15																						0
+Rhyme of the Bard	802	100	1			3	1	28	37	9ja	war javelin		5	5000	lpur	lpur						dmg%		200	250	rep-quant	25			stack		60	60	charged	149	200	3	charged	138	200	3	charged	154	200	2	swing3		35	35																						0
+Severalkill	803	100	1			5	1	24	31	9ja	War Javelin		5	5000	dyel	dyel						dmg%		165	210	rep-quant	20			stack		25	25	res-cold		20	30	res-fire		20	30	heal-kill		12	12	crush		25	25																						0
 Gnomebane	804	100	1			1	1	55	58	9pi	great pilum		5	5000				invjav3				dmg%		100	125	dmg-norm		35	70	dmg/lvl	5			bar		2	2	oskill	sword mastery	2	2	stack		65	65	res-ltng		25	35	hp		35	55																		0
-Weeping at the Gate	805	100	1			3		1	43	9pi	great pilum		5	5000	lgrn	lgrn						dmg%		200	250	rep-quant	25			stack		65	65	mana		65	65	dmg-to-mana		25	25	regen-mana		150	150	red-dmg%		10	15																						0
-Trump of Jericho	806	100	1			5		1	35	9pi	Great Pilum		5	5000	lyel	lyel						dmg%		150	200	rep-quant	30			mag%		35	50	ac/lvl	10			swing2		25	25	str		25	25	dex		25	25																						0
-Artimus's Spiculum	807	100	1			1		55	61	9s9	simbilan		5	5000	oran	oran						dmg%		100	125	dmg-norm		40	80	dmg/lvl	6			stack		75	75	mag%		35	35	pierce-ltng		25	25	extra-ltng		10	15																						0
-Cursed One	808	100	1			3		1	47	9s9	simbilan		5	5000	blac	blac						dmg%		200	250	rep-quant	25			stack		70	70	gethit-skill	81	12	7	regen		-1	-1	dmg/lvl	6			str		15	25																						0
-Hatemonger	809	100	1			5		1	38	9s9	Simbilan		5	5000				invjav7				dmg%		140	225	ac-hth		200	300	regen		10	15	manasteal		7	7	lifesteal		7	7	dmg-throw		20	40	oskill	attract	5	5																						0
-Confusion Flight	810	100	1			1		55	65	9gl	spiculum		5	5000	cred	cred						dmg%		110	140	dmg-norm		45	90	dmg/lvl	7			stack		100	100	rep-quant	40			stupidity		2	2	swing2		20	20	red-dmg		15	20	red-mag		25	25														0
-Blessed One	811	100	1			3		1	50	9gl	spiculum		5	5000	whit	whit						dmg%		215	265	rep-quant	25			stack		75	75	aura	99	5	15	block		25	25	ac		70	100	all-stats		10	10	allskills		1	1																		0
-Warbreeder	812	100	1			5		1	41	9gl	Spiculum		5	5000	blac	blac						dmg%		175	235	rep-quant	35			res-all		40	50	hp		75	75	oskill	charged strike	6	6	pierce-ltng		35	35	slow		15	15	dmg-ltng		1	250																		0
-Silver-Tipped Harpoons	813	100	1			1		55	69	9ts	harpoon		5	5000	whit	whit						dmg%		120	150	dmg-norm		40	80	dmg/lvl	8			stack		45	45	allskills		2	2	res-all		20	30	dmg-undead		200	200	thorns		20	30	dmg-ltng		15	150														0
-Blessings of Osiris	814	100	1			3		1	54	9ts	harpoon		5	5000	oran	oran						dmg%		225	270	rep-quant	25			stack		80	80	oskill	lightning fury	3	5	pierce-ltng		10	10	res-ltng		35	60	abs-ltng%		15	15	hp%		10	15																		0
-Bowel Twister	815	100	1			5		1	45	9ts	Harpoon		5	5000				invjav8				dmg%		180	240	rep-quant	35			stack		100	100	aura	118	9	15	res-ltng		65	65	abs-ltng%		35	35	noheal		1	1																						0
-Jaguar's Claw	816	100	1			1		1	70	7ja	hyperion javelin		5	5000	dyel	dyel						dmg%		225	275	rep-quant	40			stack		40	40	reduce-ac		15	20	bloody		1	1	deadly/lvl	8			lifesteal		7	7																						0
-Arc of the Rainbow	817	100	1			2		1	55	7ja	Hyperion Javelin		5	5000								dmg%		180	250	ac-miss		200	300	dmg-fire		75	200	dmg-ltng		10	300	dmg-cold	200	100	140	swing3		40	40	addxp		5	10	gold%		200	200																		0
-Woundripper	818	100	1			2		1	61	7pi	stygian pilum		5	5000				invjav10				dmg%		225	275	rep-quant	20			stack		65	65	heal-kill		10	10	noheal		1	1	openwounds		88	88	oskill	plague javelin	5	5	block2		25	25																		0
-Summerstrike	819	100	1			1		23	23	7pi	Stygian Pilum		5	5000	cred	cred						dmg%		200	250	rep-quant	30			dmg-fire		300	500	abs-fire%		40	50	ethereal		1	1	stack		75	75																										0
-Clockwork Horror	820	100	1			1		1	77	7s7	balrog spear		5	5000				invjav4				dmg%		230	280	rep-quant	25			stack		50	50	crush		22	33	howl		41	41	move2		25	25	str/lvl	5			dex/lvl	5																				0
-Invisible Stalker	821	100	1			1		1	81	7gl	ghost glaive		5	5000								dmg%		250	300	stack		300	300	dmg/lvl	8			allskills		1	1	fade		1	1	oskill	quickness	3	3	move3		60	60																						0
-Spectral Slayer	822	100	1			1		20	20	tax	throwing axe		5	5000	dgry	dgry						dmg%		80	80	dmg-norm		20	40	stack		50	50	rep-quant	15			bar		1	1	fade		1	1	ethereal		1	1																						0
-Tonguecutter	823	100	1			3		1	10	tax	throwing axe		5	5000				invaxe17				dmg%		100	150	rep-quant	20			stack		75	75	bloody		1	1	lifesteal		5	7	manasteal		5	7	bar		1	1																						0
-Solstice Edge	824	100	1			5		1	6	tax	Throwing Axe		5	5000	oran	oran						dmg-throw		4	12	stack		60	60	rep-quant	45			dmg-fire		3	9	mag%		20	30	knock		1	1																										0
-Oakplume	825	100	1			1		28	35	bal	balanced axe		5	5000								dmg%		80	120	dmg-norm		30	60	stack		75	75	rep-quant	50			skill	140	3	3	swing2		20	20	balance2		20	20	res-pois		35	35	lifesteal		6	6														0
-Timbersplitter	826	100	1			3		1	27	bal	balanced axe		5	5000	lgrn	lgrn						dmg%		175	200	rep-quant	20			stack		75	75	pierce		25	25	oskill	critical strike	1	1	openwounds		35	35	res-ltng		15	15	abs-ltng%		5	5																		0
-Spleen Feaster	827	100	1			5		1	22	bal	Balanced Axe		5	5000	dgrn	dgrn						dmg-norm		10	20	stack		60	60	dmg-pois	150	122	122	noheal		1	1	dex		15	15	att%		30	30	deadly		20	40																						0
-Banshee's Cry	828	100	1			1		55	50	9ta	francisca		5	5000								dmg%		120	140	dmg-norm		25	50	dmg-throw		25	40	skilltab	13	2	2	howl		122	122	hit-skill	48	4	5	slow		25	25	knock		2	2																		0
-Despicable Behavior	829	100	1			3		1	43	9ta	francisca		5	5000	dblu	dblu						dmg%		200	250	rep-quant	25			stack		60	60	bar		2	2	att%		25	25	swing2		20	20	block3		30	30	hit-skill	59	5	7																		0
-Axes of Jahadra	830	100	1			1		55	60	9b8	hurlbat		5	5000	lpur	lpur						dmg%		125	150	dmg-norm		30	60	dmg-throw		30	50	allskills		1	1	mag%		25	35	hit-skill	51	3	1	thorns		25	35	red-mag		10	15																		0
-Instigator	831	100	1			3		1	54	9b8	hurlbat		5	5000	dgld	dgld						dmg%		225	270	rep-quant	25			stack		60	60	bar		2	2	manasteal		6	6	swing2		25	25	balance3		30	30	gethit-skill	42	7	4																		0
-Brainraver	832	100	1			5		1	47	9b8	Hurlbat		5	5000								dmg%		165	225	rep-quant	30			stack		45	45	swing3		40	40	allskills		1	1	stupidity		2	2	slow		50	50																						0
-Winged Serpent	833	100	1			1		1	77	7ta	flying axe		5	5000	cgrn	cgrn						dmg%		250	300	rep-quant	15			stack		70	70	bar		1	2	dmg-pois	200	1250	1250	res-all		25	30	charged	54	255	1	str		20	20																		0
-Golden Wyndlass	834	100	1			1		1	85	7b8	winged axe		5	5000	dgld	dgld						dmg%		250	300	rep-quant	50			skilltab	14	1	3	ignore-ac		1	1	swing2		20	20	stupidity		2	2	mana		50	50	oskill	redemption	3	3	move2		20	20														0
-Sheera's Knives	835	100	1			1		25	22	tkf	throwing knife		5	5000	dred	dred						dmg%		60	80	dmg-norm		20	40	stack		50	50	rep-quant	20			ac-hth		100	100	pierce		20	20	red-dmg		6	10	res-all		15	15																		0
-Subtle Slice	836	100	1			3		1	7	tkf	throwing knife		5	5000	lyel	lyel						dmg%		100	150	rep-quant	20			stack		75	75	dmg-norm		4	8	deadly		35	35	dmg-pois	125	55	55	gethit-skill	36	14	3	dex		10	10																		0
-Splinterbeam	837	100	1			5		1	4	tkf	Throwing Knife		5	5000	lgld	dgrn						dmg%		65	100	rep-quant	25			swing2		25	25	manasteal		3	6	res-cold		25	35	res-ltng		25	35	reduce-ac		10	15																						0
-Deadly Needle	838	100	1			1		32	38	bkf	balanced knife		5	5000								dmg%		85	105	dmg-norm		25	50	stack		90	90	rep-quant	25			str		15	15	deadly/lvl	9			res-fire		20	30	res-ltng		20	30																		0
-Initiator	839	100	1			3		1	22	bkf	balanced knife		5	5000	oran							dmg%		170	200	rep-quant	25			stack		75	75	dmg-throw		8	20	swing2		25	25	slow		20	20	aura	108	4	4	str		15	15	ease		-15	-15														0
-Dead Scoffer	840	100	1			5		1	19	bkf	Balanced Knife		5	5000	blac							dmg-throw		10	20	dmg%		75	110	stack		100	100	heal-kill		8	10	oskill	raise skeleton	3	5	dmg-undead		350	350																										0
-Swarming Blades	841	100	1			1		55	57	9tk	battle dart		5	5000		cblu						dmg%		100	100	dmg/lvl	12			swing3		60	60	stack		100	100	rep-quant		20	20	hp		50	60	res-pois		25	35	reduce-ac		15	15																		0
-Silt Runner	842	100	1			3		1	42	9tk	battle dart		5	5000	dgry	dgry						dmg%		200	250	rep-quant	20			stack		55	55	stupidity		2	2	lifesteal		8	8	move3		35	35	all-stats		20	20	hp		50	65																		0
-Darts of Evermeet	843	100	1			1		55	69	9bk	war dart		5	5000								dmg%		120	150	rep-quant	10			stack		60	60	dmg-norm		40	80	allskills		1	1	extra-fire		15	25	dmg-fire		60	120	ac%		20	20	dex		15	20														0
-Ravenstar	844	100	1			3		1	52	9bk	war dart		5	5000	lblu							dmg%		220	270	rep-quant	15			stack		75	75	slow		25	25	manasteal		8	8	cast3		30	30	allskills		1	1	mana		30	50																		0
-Pain Harvester	845	100	1			5		1	45	9bk	War Dart		5	5000	lpur							dmg%		160	200	stack		75	75	att%		50	50	dex		20	20	str		20	20	bar		2	2	nofreeze		1	1																						0
-Fallen Glory	846	100	1			1		20	20	7tk	flying knife		5	5000		dred						dmg%		260	325	stack		65	65	rep-quant	15			allskills		2	2	skilltab	12	1	3	swing2		20	20	oskill	56	2	2	oskill	61	2	2																		0
-Shard of the North Star	847	100	1			2		1	64	7tk	Flying Knife		5	5000	lgld	lgld						dmg%		200	300	rep-quant	35			res-all		25	40	lifesteal		5	10	dmg-elem	300	50	100	freeze		3	3	hit-skill	56	12	8																						0
-Frostbite Shard	848	100	1			1		1	80	7bk	winged knife		5	5000								dmg%		275	325	rep-quant	20			stack		65	65	dmg-cold		250	300	freeze		6	6	dmg/lvl	6			res-cold		35	50	mana		65	65																		0
-Hungerpang	849	100	1			1		1	11	qui	quilted armor		5	5000				invbody20				ac		30	50	regen		-1	-1	hp		65	65	lifesteal		4	6	regen-mana		40	40																														0
-Ashenwrath	850	100	1			3		1	6	qui	quilted armor		5	5000				invbody5				ac		20	30	nec		1	1	fireskill		1	1	res-fire		35	35	sock		1	2																														0
-Ogden's Shroud	851	100	1			1		1	13	lea	leather armor		5	5000				invbody46				ac		45	65	res-ltng		25	25	balance2		20	20	addxp		2	3	gold%		100	100																														0
-JuJu Flame	852	100	1			3		1	8	lea	leather armor		5	5000				invbody49				ac		30	40	sor		1	1	kill-skill	teeth	25	4	charged	36	200	17																																		0
-Armor of Gloom	853	100	1			1		1	15	hla	hard leather		5	5000				invbody72				ac		70	85	stupidity		1	1	gethit-skill	71	7	2	res-pois		25	35	vit		10	10	sock		1	1																										0
-Stinkshroud	854	100	1			3		1	10	hla	hard leather		5	5000				invbody50				ac		50	65	gethit-skill	72	5	9	ass		1	1	skill-rand	2	252	257	res-pois		35	35																														0
-Scarab of Protection	855	100	1			1		1	17	stu	studded leather		5	5000				invbody4				ac		100	115	red-dmg		8	12	res-mag		10	10	res-all		10	20	hp		35	45	block2		15	15																										0
-Gemini Coat	856	100	1			3		1	12	stu	studded leather		5	5000				invbody27				ac%		80	100	ac		25	40	ama		1	1	aura	might	1	1	dur%		25	25	dmg-throw		5	10																										0
-The Shadowed One	857	100	1			1		1	19	rng	ring mail		5	5000	blac	blac						ac		115	130	light		-3	-3	ass		1	1	move2		20	20	ignore-ac		1	1	mana		25	35																										0
-Steelflesh	858	100	1			3		1	14	rng	ring mail		5	5000				invbody2				ac%		125	200	bar		1	1	dmg%		20	25	red-dmg%		10	15	oskill	sacrifice	3	5																														0
-Red Dragon Scails	859	100	1			1		1	21	scl	scale mail		5	5000	dred	dred		invbody25				ac		130	150	red-dmg%		10	15	res-fire		45	65	abs-fire%		10	15	pierce-fire		10	15	extra-fire		10	15																										0
-Mandrake's Bloom	860	100	1			3		1	16	scl	scale mail		5	5000								ac%		125	170	pal		1	1	gethit-skill	68	5	8	block		10	15	dmg-fire		10	20																														0
-Ghosly Chainmail	861	100	1			1		1	23	chn	chain mail		5	5000		whit						ac		155	175	ethereal		1	1	rep-dur	25			res-cold		30	50	pierce-cold		10	15	extra-cold		10	15																										0
-Xanadu Dreams	862	100	1			3		1	18	chn	chain mail		5	5000				invbody8				ac%		100	200	dru		1	1	dur%		100	100	hit-skill	71	5	2	res-all		15	25	lifesteal		3	3																										0
-Breastplate of Gond	863	100	1			1		1	25	brs	breast plate		5	5000	dgrn			invbody70				ac		180	200	pierce-ltng		10	15	abs-ltng%		10	15	extra-ltng		10	15	res-ltng		40	60	dmg-ltng		1	75																										0
-Shattering Blow	864	100	1			3		1	21	brs	breast plate		5	5000				invbody68				ac%		120	150	crush/lvl	8			deadly/lvl	8			dmg-norm		5	10	swing1		15	15																														0
-Starsong	865	100	1			1		1	26	spl	splint mail		5	5000	lgry	lgry						ac		205	220	hp		25	50	mana		25	55	mana-kill		3	5	heal-kill		8	12	res-pois		30	50																										0
-Russetfire	866	100	1			3		1	22	spl	splint mail		5	5000				invbody35				ac		100	150	mag%		35	50	res-fire		40	50	abs-fire%		20	20	aura	holy fire	3	5	sock		1	2																										0
-Armor of Warmth	867	100	1			1		1	28	plt	plate mail		5	5000	dred	cred		invbody71				ac		225	250	oskill	warmth	3	5	att		75	75	dex		15	15	enr		15	15																														0
-Celestial Revelation	868	100	1			3		1	25	plt	plate mail		5	5000				invbody21				extra-fire		15	20	extra-cold		15	20	extra-pois		15	20	extra-ltng		15	20	cast1		20	20	ac%		125	150																										0
-Dreamscape	869	100	1			1		1	29	fld	field plate		5	5000	blac	blac						ac		260	300	stupidity		2	2	vit		20	20	block		15	15	block2		30	30	sock		1	2																										0
-Ion Storm	870	100	1			3		1	26	fld	field plate		5	5000	dgrn	dgrn		invbody43				dmg-elem	200	1	65	ac		150	190	addxp		4	7	sock		3	4																																		0
-A Knight's Tale	871	100	1			1		1	30	gth	gothic plate		5	5000	lgry	lgry						ac		300	350	allskills		1	1	sock		4	4																																						0
-Golem's Gain 	872	100	1			3		1	26	gth	gothic plate		5	5000				invbody66				ac%		120	200	str		25	25	oskill	golem mastery	8	8	oskill	bloodgolem	2	5	charged	75	5	30	res-all		25	25																										0
-Kaz's Battle Armor	873	100	1			1		1	32	ful	full plate mail		5	5000				invbody67				ac		355	400	dmg-norm		5	10	swing1		15	15	balance2		20	20	gethit-skill	58	6	3	mana		35	35																										0
-Halcyon Shroud	874	100	1			3		1	28	ful	full plate mail		5	5000				invful				allskills		1	1	res-fire		25	40	res-cold		25	40	res-ltng		25	40	red-dmg		10	20	regen		8	12	ac%		100	200																						0
-Greyhawk Dragon	875	100	1			1		1	34	aar	ancient armor		5	5000	dgry	dgry						ac		400	500	balance3		40	40	heal-kill		5	5	addxp		2	3	sock		2	2	res-all		35	35																										0
-Killing Blow	876	100	1			3		1	30	aar	ancient armor		5	5000	oran	oran						ac%		150	200	dmg-max		25	25	noheal		1	1	bloody		1	1	deadly		33	33	oskill	attract	2	4	knock		1	1																						0
-Weightless Grace	877	100	1			1		1	36	ltp	light plate		5	5000				invbody53				ac		300	400	ease		-50	-50	dex		25	25	allskills		1	1	gold%		50	50	mag%		35	50	hp		50	60																						0
-Madness of Chthulu	878	100	1			3		1	30	ltp	light plate		5	5000				invbody19				ac		200	250	ease		25	25	all-stats		20	20	rip		1	1	ignore-ac		1	1	death-skill	poison nova	100	15																										0
-Rainbow Cloak	879	100	1			3		1	32	xui	ghost armor		5	5000				invbody23				ac%		100	150	res-all		15	25	allskills		1	1	res-all-max		5	5																																		0
-Gillian's Brazier	880	100	1			1		1	41	xui	ghost armor		5	5000				invbody42				ac%		90	125	ama		1	2	ass		1	2	sor		1	2	dex		35	35	str		25	25	cast2		25	25																						0
-Anaconda Skin	881	100	1			1		1	42	xea	serpentskin armor		5	5000				invbody13				ac%		110	160	crush		20	40	move2		25	25	res-pois		25	35	str		15	15	red-dmg		10	20	red-mag		10	15																						0
-Scavanger's Carapace	882	100	1			3		1	34	xea	serpentskin armor		5	5000				invbody38				ac%		95	130	rep-dur	20			red-dmg%		10	20	res-cold		35	50	res-cold-max		10	10	ac/lvl	10			dmg-und/lvl	24																								0
-Torn Flesh of Souls	883	100	1			1		1	43	xla	demonhide armor		5	5000	dgry	dgry						ac%		120	170	dmg-demon		75	75	nec		1	1	skill-rand	3	66	95	skill-rand	3	66	95	cast2		20	20	mana/lvl	6																								0
-The Defiler's Flesh	884	100	1			3		1	36	xla	demonhide armor		5	5000				invbody24				ac%		100	150	heal-kill		5	8	mag%		40	40	balance2		25	25	lifesteal		4	6	hp		40	40	skill	83	1	3	skill	89	1	3																		0
-Lilt of the Dryad	885	100	1			1		1	44	xtu	trellised armor		5	5000				invbody16				ac%		130	180	swing3		20	20	ama		1	1	skilltab	1	1	2	res-fire		20	40	res-ltng		20	40	slow		15	15																						0
-Cold Comfort	886	100	1			3		1	38	xtu	trellised armor		5	5000	dblu	dblu		invbody57				ac%		110	150	ac		200	250	gethit-skill	60	15	8	res-cold		50	50	pierce-cold		15	15	abs-cold%		10	10	extra-cold		5	10	nofreeze		1	1																		0
-Heartbane	887	100	1			3		1	41	xng	linked mail		5	5000				invbody17				ac%		135	185	dex		15	15	enr		15	15	heal-kill		5	9	addxp		1	3	red-mag		10	15	red-dmg%		10	15	noheal		1	1																		0
-Adamantine Mail	888	100	1			1		1	26	xng	linked mail		5	5000	whit	whit		invrng				ac/lvl	48			ac		150	200	red-dmg%		25	35	sock		3	3	allskills		1	1																														0
-Weakest Link	889	100	1			1		1	47	xcl	tigulated mail		5	5000				invbody36				ac%		140	190	rep-dur	15			dmg%		20	30	balance2		20	20	manasteal		6	8	dmg-to-mana		8	8	allskills		1	1																						0
-Panic of Thousands	890	100	1			3		1	43	xcl	tigulated mail		5	5000	cblu	cblu		invscl				ac%		125	150	gethit-skill	77	33	3	oskill	enchant	4	4	res-fire		35	50	res-ltng		35	50	dex/lvl	4			dur		100	100																						0
-Drow Chainmail	891	100	1			3		1	44	xhn	mesh armor		5	5000	blac	blac						ac%		150	200	ease		-25	-25	extra-fire		10	15	res-all		20	30	all-stats		10	10	hp/lvl	8			mana		40	60																						0
-Disparate Paths	892	100	1			1		1	49	xhn	mesh armor		5	5000	oran	oran		invchn				ac%		125	150	dru		1	1	skill-rand	3	221	250	skill-rand	3	221	250	skill-rand	3	221	250	swing1		10	10	res-all		20	30																						0
-Tesla's Cuirass	893	100	1			3		1	47	xrs	cuirass		5	5000	dgry	dgry		invbody39				ac%		160	210	dmg/lvl	2			reduce-ac		10	15	move1		15	15	lifesteal		4	4	sock		2	2																										0
-Mother's Milk	894	100	1			1		1	51	xrs	cuirass		5	5000	lgry	lgry		invbody58				ac%		125	150	ama		1	1	swing2		25	25	skill-rand	5	6	35	ease		-25	-25	balance2		20	20	aura	113	1	6																						0
-Brimstone Hearth	895	100	1			3		1	50	xpl	russet armor		5	5000	dred	dred						ac%		170	220	res-fire		30	50	pierce-fire		20	20	dmg-fire		25	100	nofreeze		1	1	fireskill		2	2	dur		30	30																						0
-Scars of the Forefathers	896	100	1			1		1	55	xpl	russet armor		5	5000	lblu	dblu		invbody28				ac%		125	150	ac/lvl	20			bar		1	1	red-dmg%		15	30	skill-rand	3	126	155	dmg%		40	60	block2		20	20	att-skill	82	3	12																		0
-Demonspike Coat	897	100	1			1		1	57	xlt	templar coat		5	5000				invbody63				ac%		180	230	dmg-demon		75	75	demon-heal		25	25	lifesteal		6	6	regen		1	4	thorns/lvl	16																												0
-Succulent Sin	898	100	1			3		1	52	xlt	templar coat		5	5000		dpur		invbody41				ac%		140	165	ass		1	1	skill-rand	4	251	280	skill-rand	3	251	280	oskill	zeal	1	1	deadly		15	15	vit/lvl	4																								0
-Bloodlust Frenzy	899	100	1			1		1	59	xld	sharktooth armor		5	5000	lgrn	lgrn		invbody56				ac		185	235	swing2		20	20	allskills		1	1	skilltab	13	1	1	skill	147	1	4	lifesteal		6	8	hp%		10	20																						0
-Seaflame	900	100	1			3		1	55	xld	sharktooth armor		5	5000	oran			invbody59				ac%		150	175	res-all		50	60	red-mag		12	15	heal-kill		8	12	regen		10	12	regen-mana		50	50	mag%		60	60	dur		200	200																		0
-Royal Plate	901	100	1			1		1	60	xth	embossed plate		5	5000				invbody33				ac%		190	240	red-dmg%		15	25	res-mag		10	15	res-all		15	30	cheap		5	10	ease		-15	-15	rep-dur	20																								0
-Nightcrawler	902	100	1			3		1	56	xth	embossed plate		5	5000	blac	blac		invgth				ac		300	500	oskill	fade	2	4	rip		1	1	sock		4	4	ease		-35	-35																														0
-Shambling Mound	903	100	1			1		1	61	xul	chaos armor		5	5000				invbody65				ac/lvl	40			ac%		50	75	res-pois		40	70	dmg-pois	200	400	400	extra-pois		15	15	move1		10	10	sock		2	2																						0
-Evening Sky	904	100	1			3		1	57	xul	chaos armor		5	5000		oran		invbody61				ac%		175	210	dmg-fire		75	150	res-fire		75	75	move3		30	30	cast2		20	20	mana		50	50	hp		50	50																						0
-Adamantine Plate	905	100	1			1		1	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		30	30	res-all		50	75	rep-dur	20																																				0
-Iceskin	906	100	1			3		1	58	xar	ornate armor		5	5000	cblu	cblu		invaar				ac%		180	215	gethit-skill	60	50	8	gethit-skill	64	5	5	res-cold		100	100	extra-cold		15	20	allskills		1	1	block2		25	25																						0
-Plate of Fistindantalas	907	100	1			1		1	63	xtp	mage plate		5	5000				invbody54				ac		400	600	ac%		50	75	allskills		1	1	mana/lvl	8			hp/lvl	8			addxp		1	3	sock		2	3																						0
-Serendipity	908	100	1			3		1	59	xtp	mage plate		5	5000				invbody47				ac%		185	225	ac/lvl	16			allskills		1	1	cast3		30	30	mana		75	75	mag%		30	30	light		1	3	addxp		5	5																		0
-Blanket of Stars	909	100	1			1		1	65	uui	dusk shroud		5	5000				invbody3				ac%		100	200	regen		4	8	regen-mana		50	50	enr		25	25	vit		25	25	block2		25	25	balance3		30	30																						0
-Ancient Dragon	910	100	1			1		1	67	uea	wyrmhide		5	5000				invbody14				ac%		100	200	allskills		1	1	mana%		15	25	hp/lvl	16			stupidity		1	1	knock		2	2	sock		1	1																						0
-Crescent of Secrets	911	100	1			2		1	57	uea	Wyrmhide		5	5000				invbody11				ac%		75	100	allskills		1	1	gold%		75	75	all-stats		50	50	mag%		50	50	sock		2	2																										0
-Zaratan Hide	912	100	1			1		1	69	ula	scarab husk		5	5000				invbody1				ac%		160	200	move3		30	30	red-dmg		35	50	red-mag		20	25	res-cold		75	75	half-freeze		1	1	gold%		100	100																						0
-Aprhodite's Girdle	913	100	1			2		1	60	ula	Scarab Husk		5	5000				invbody64				ac		300	500	ama		2	2	sor		2	2	ass		2	2	move3		30	30	enr		35	35	mana		75	75	cast2		20	20																		0
-Wyrmbane	914	100	1			1		1	73	utu	wire fleece		5	5000				invbody15				ac%		120	200	allskills		1	1	red-dmg%		10	15	balance2		25	25	dmg-demon		65	65	dex		25	25	ac		150	250																						0
-Adamantine Links	915	100	1			1		1	73	ung	diamond mail		5	5000				invbody6				ac%		150	200	red-dmg%		25	35	allskills		1	1	all-stats		10	10	res-fire		35	55	res-ltng		35	55	mag%		40	60																						0
-Feathering Mithril	916	100	1			2		1	65	ung	Diamond Mail		5	5000				invbody9				ac%		100	200	ease		-75	-75	red-dmg%		15	20	move3		40	40	rep-dur	30			nofreeze		1	1	hp%		20	20																						0
-Will-O'-Wisp	917	100	1			1		1	74	ucl	loricated mail		5	5000	whit	oran						ac%		100	200	allskills		1	2	move3		40	40	oskill	teleport	7	7	ethereal		1	1	rep-dur	25			fade		1	1	oskill	evade	1	1																		0
-Golden Lotus	918	100	1			2		1	67	ucl	Loricated Mail		5	5000	dgld	dgld		invbody18				ac%		100	150	gold%		300	300	mag%/lvl	12			res-all-max		5	5	att%		20	25	allskills		1	1																										0
-Chains of the Abyss	919	100	1			2		1	68	uhn	boneweave		5	5000	lred	lred						ac%		100	200	red-dmg		20	30	abs-ltng%		20	25	swing1		-5	-5	move1		-5	-5	cast2		25	25	mana		80	120	abs-fire%		20	30																		0
-Tarrasque Hide	920	100	1			1		1	86	uhn	Boneweave		5	5000	blac	blac						ac%		200	300	ac		300	500	red-dmg%		30	50	red-mag		35	50	res-fire		50	60	res-ltng		70	80	res-cold		30	50	res-pois		45	80																		0
-Celestial Unicorn	921	100	1			2		1	70	urs	great hauberk		5	5000				invbody48				ac%		100	120	allskills		2	2	regen		12	15	aura	109	4	7	mag%		40	50	gold%/lvl	21																												0
-Gray God's Mantle	922	100	1			1		1	77	urs	Great Hauberk		5	5000	blac	blac		invbody30				ac%		125	150	allskills		4	4	sock		3	3																																						0
-Diablo's Scale	923	100	1			1		1	78	upl	balrog skin		5	5000	oran	lgry		invbody74				ac%		150	200	allskills		1	1	block		25	40	block3		35	35	move2		30	30	res-all		35	65	red-dmg%		20	30																						0
-Hellshifter	924	100	1			1		1	80	ult	hellforged plate		5	5000	dred	dred		invbody22				ac%		100	200	pal		2	2	skill-rand	1	96	125	skill-rand	3	96	125	skill-rand	2	96	125	dmg%		30	50	balance2		30	30																						0
-Lunatic Fringe	925	100	1			2		1	73	ult	Hellforged Plate		5	5000	dgld	dgld		invbody32				ac%		130	165	block		25	35	block2		25	25	howl		88	88	stupidity		3	3	hp%		15	15																										0
-Ocean's Embrace	926	100	1			1		1	82	uld	kraken shell		5	5000	lblu	dblu		invbody69				ac%		100	200	regen		3	5	regen-mana		200	200	cast2		20	20	abs-cold		20	30	res-fire		60	80	extra-cold		15	20																						0
-Lachdonnan's Heart	927	100	1			1		1	83	uth	lacquered plate		5	5000	lred	lred		invbody45				ac%		160	200	ease		20	20	dmg%		140	160	swing3		60	60	dmg-max		25	25	allskills		1	1																										0
-Pride of the Barony	928	100	1			2		1	75	uth	Lacquered Plate		5	5000	cblu	cblu						ac%		120	150	ac		200	300	swing2		25	25	dmg%		50	50	dmg-norm		15	30	balance2		30	30	addxp		25	25																						0
-Shadowtrick	929	100	1			1		1	84	uul	shadow plate		5	5000								ac%		130	200	oskill	fade	3	4	oskill	quickness	3	4	oskill	teleport	3	4	oskill	shout	3	4	oskill	battle orders	3	4	allskills		2	2	aura	123	3	4																		0
-Heaven's Treasure	930	100	1			1		1	87	utp	archon plate		5	5000	dyel	dyel		invbody55				ac%		100	200	allskills		2	2	mag%		200	350	sock		2	4																																		0
-Legacy of the Eternals	931	100	1			2		1	79	utp	Archon Plate		5	5000	oran	oran						ac%		75	100	allskills		1	2	cast2		30	30	mana%		25	25	abs-cold%		25	35	abs-fire%		25	35	abs-ltng%		25	35	res-all-max		10	10	block		20	20														0
-Nameweaver	932	100	1			1		1	8	cap	cap		5	5000				invhelm41				ac		20	30	dex		10	10	dmg-max		5	10	regen-mana		45	45	res-ltng		35	35																														0
-Trickster's Guise	933	100	1			3		1	5	cap	cap		5	5000				invcap				ac		15	25	enr		15	15	red-dmg%		8	8	gethit-skill	38	27	3	res-all		6	13	sock		1	1																										0
-Liespreader	934	100	1			1		1	16	skp	skull cap		5	5000				invhelm42				ac		30	40	cheap		15	15	skilltab	1	1	1	hp		25	25	mana		25	25	sock		1	1																										0
-Devourer of Dreams	935	100	1			3		1	13	skp	skull cap		5	5000	lgld	lgld						ac		15	25	cast1		15	15	oskill	warmth	1	1	regen		3	5	knock		1	1																														0
-Barbazu's Smile	936	100	1			1		1	20	hlm	helm		5	5000				invhelm16				ac		25	40	skilltab	3	1	1	mana%		15	15	regen-mana		40	40	mana-kill		3	5	cast1		15	15																										0
-Freedom's Facade	937	100	1			3		1	16	hlm	helm		5	5000	cred			invhelm24				ac		18	30	swing1		10	10	move1		10	10	dex		20	20	regen		-1	-1	dmg-to-mana		10	10																										0
-Harpy's Call	938	100	1			1		1	23	fhl	full helm		5	5000				invhelm27				ac		30	40	skilltab	6	1	1	res-all		20	20	addxp		3	3	aura	99	1	1	gethit-skill	77	7	3																										0
-Equinox Visor	939	100	1			3		1	20	fhl	full helm		5	5000				invhelm22				ac		20	33	hp		35	35	res-ltng		20	25	skill	224	1	3	oskill	summon spirit wolf	3	3	mana-kill		3	5																										0
-Satyr's Speech	940	100	1			1		1	27	bhm	bone helm		5	5000	lred	lred						ac		40	50	skilltab	10	1	1	rep-dur	20			att		125	125	freeze		1	2	howl		77	77	res-all		15	15																						0
-Hindsight	941	100	1			3		1	24	bhm	bone helm		5	5000				invbhm				ac		25	35	cast1		15	15	balance2		20	20	mag%		20	30	oskill	meditation	2	2	pal		1	1	res-mag		5	8	gethit-skill	82	10	3																		0
-Fool's Crest	942	100	1			1		1	30	ghm	great helm		5	5000				invhelm30				ac		40	50	skilltab	12	1	1	dmg%		25	25	hp		50	50	lifesteal		4	6	mag%		30	40	res-cold		25	25																						0
-Morning's Tears	943	100	1			3		1	28	ghm	great helm		5	5000	dblu			invhelm11				ac		32	40	regen		5	5	hp%		10	10	mana%		10	10	allskills		1	1	gold%		50	50	res-pois-max		75	75	res-pois		40	60																		0
-Gaiden's Loss	944	100	1			3		1	30	crn	crown		5	5000	dyel	dyel						ac		45	55	skilltab	16	1	1	mana		25	25	manasteal		3	5	ignore-ac		1	1	gold%		50	50	dmg-undead		100	100																						0
-Crown of Thorns	945	100	1			1		1	32	crn	crown		5	5000								ac		37	50	gethit-skill	235	15	5	gethit-skill	40	10	3	mana		20	30	bar		1	1	res-fire		30	30	res-cold		30	30	red-dmg		8	10	aura	103	1	2														0
-Blindman's Bluff	946	100	1			1		1	28	msk	mask		5	5000								ac		50	65	skilltab	19	1	1	fade		1	1	res-all		20	20	dex		15	15	str		15	15	rep-dur	25																								0
-Treachery's Allure	947	100	1			3		1	23	msk	mask		5	5000								ac%		80	120	slow		15	15	manasteal		3	5	cheap		15	15	all-stats		10	10	sock		2	2																										0
-Pepin's Blessing	948	100	1			1		1	36	xap	war hat		5	5000				invhelm08				ac%		100	125	regen		5	8	regen-mana		75	75	addxp		3	3	allskills		1	1	mana-kill		4	4	manasteal		5	5																						0
-Hushmaker	949	100	1			3		1	33	xap	war hat		5	5000	lyel	lyel		invhelm40				ac%		80	120	red-dmg		8	12	red-mag		6	8	balance2		20	20	slow		10	15	sock		1	1	oskill	resist lightning	1	1																						0
-Drunken Fury	950	100	1			3		1	36	xkp	sallet		5	5000	dgry	dgry						ac%		100	125	oskill	lightning fury	14	14	dex		-10	-10	dmg%		25	25	dmg-max		20	30	swing1		-10	-10	balance2		-10	-10																						0
-Neonate's Sallet	951	100	1			1		1	40	xkp	sallet		5	5000	cblu	cblu		invskp				ac%		80	120	sor		1	2	skill-rand	2	36	65	skill-rand	2	36	65	mana		75	75	cast2		20	20	res-mag		15	15	dmg-to-mana		15	20																		0
-Helm of Ra	952	100	1			3		1	39	xlm	casque		5	5000				invhelm26				ac%		110	135	allskills		1	1	str		15	15	extra-fire		15	15	res-fire		25	25	res-fire-max		10	10	move1		10	10																						0
-Troubled Thoughts	953	100	1			1		1	43	xlm	casque		5	5000				invhelm25				ac%		80	120	nec		1	2	skill-rand	2	66	95	skill-rand	2	66	95	rep-dur	10			heal-kill		15	20	mana-kill		8	12	str		15	15																		0
-Knight's Crest	954	100	1			3		1	43	xhl	basinet		5	5000				invhelm13				ac%		120	140	pal		1	2	block		10	10	skill-rand	2	96	125	heal-kill		10	15	cast2		20	20	slow		15	15																						0
-Wraithwatch	955	100	1			1		1	46	xhl	basinet		5	5000				invhelm12				ac%		80	120	ass		1	2	skill-rand	2	251	280	skill-rand	2	251	280	move2		25	25	swing1		10	10	sock		2	2	ease		-30	-30																		0
-Gotterdamerung	956	100	1			3		1	50	xhm	winged helm		5	5000				invhelm10				ac%		90	130	res-all		35	35	red-dmg%		15	15	abs-fire		8	12	balance2		25	25	hit-skill	67	4	7	wounds/lvl	8																								0
-Embracing Solitude	957	100	1			1		1	53	xhm	winged helm		5	5000				invhelm20				ac%		80	120	dru		1	2	skill-rand	2	221	250	skill-rand	2	221	250	swing1		15	15	lifesteal		6	6	cast1		15	15	res-all		15	25																		0
-Usurper's Ambition	958	100	1			3		1	53	xrn	grand crown		5	5000				invhelm36				ac%		130	150	allskills		2	2	sock		3	3	addxp		3	3	mag%		25	25																														0
-Reign of Deceit	959	100	1			1		1	56	xrn	grand crown		5	5000	oran	oran		invcrn				ac%		80	120	bar		1	2	skill-rand	2	126	155	skill-rand	2	126	155	dmg%		20	25	dmg-norm		5	10	block2		20	20	hp		25	50																		0
-Wraithshadow	960	100	1			3		1	44	xsk	death mask		5	5000	dred	dred		invhelm15				ac%		135	155	fade		1	1	move2		20	20	swing2		20	20	gold%		35	35	mag%		20	20	vit		20	20																						0
-Archnemesis	961	100	1			1		1	48	xsk	death mask		5	5000				invhelm1				ac%		80	120	ama		1	2	skill-rand	2	6	35	skill-rand	2	6	35	swing1		15	15	move1		15	15	dmg-cold	100	25	50	mag%		20	30																		0
-Ghoulslayer	962	100	1			3		1	46	xh9	grim helm		5	5000	cblu	cblu						ac%		140	165	rip		1	1	allskills		1	1	dmg-undead		100	100	str		15	25	vit		15	25	red-dmg%		5	10	sock		1	1																		0
-Skull of Fistindantalas	963	100	1			1		1	49	xh9	grim helm		5	5000	dgrn	dgrn						ac%		80	120	pal		1	2	skill-rand	2	96	125	skill-rand	2	96	125	rip		1	1	cast1		15	15	mana		50	50	dex		15	15																		0
-Bane's Dark Wisdom	964	100	1			1		1	55	uap	shako		5	5000				invhelm38				ac		100	125	allskills		1	1	addxp		50	50																																						0
-Overlord's Helm	965	100	1			1		1	67	ukp	hydraskull		5	5000	lblu	lblu						allskills		4	4	sock		2	2	ac%		100	120	cast3		30	30	mana/lvl	8																																0
-Slaver's Price	966	100	1			2		1	58	ukp	Hydraskull		5	5000				invhelm09				ac		80	120	regen		-15	-15	dmg%		50	50	dmg-max		15	15	swing2		20	20	rip		1	1																										0
-Conch of Dismay	967	100	1			1		1	74	uhl	giant conch		5	5000				invhelm21				hp		300	350	mana		125	150	mag%		50	50	ac/lvl	16			allskills		1	1	half-freeze		1	1	res-pois-len		60	70																						0
-Judas Kiss	968	100	1			2		1	66	uhl	Giant Conch		5	5000	blac	blac		invhelm19				ac		200	300	heal-kill		15	15	ignore-ac		1	1	res-pois-len		50	50	nofreeze		1	1	move2		20	20	res-all		15	25																						0
-King Conan's Rule	969	100	1			1		1	84	urn	corona		5	5000								ac%		150	200	allskills		2	2	addxp		2	4	gold%		200	200	dmg-norm		10	30	res-all		25	25	str/lvl	8			dex		35	35																		0
-Lolith's Crest	970	100	1			1		1	77	usk	demonhead		5	5000				invhelm18				allskills		1	1	ac%		150	200	heal-kill		10	15	block		15	20	balance2		30	30	cast2		20	20	dmg-to-mana		15	15																						0
-Kiss of the Vampire	971	100	1			1		1	81	uh9	bone visage		5	5000	dred	dred						ac		200	300	allskills		1	1	hp		50	75	mana		50	75	regen		10	15	regen-mana		75	75	manasteal		8	10	lifesteal		8	10	mana-kill		5	7	heal-kill		10	15										0
-Fairweather	972	100	1			1		1	32	ci0	circlet		5	5000	cblu	cblu						ac%		140	175	abs-fire		10	15	abs-ltng		10	15	abs-cold		10	15	res-pois-len		65	90	half-freeze		1	1	sock		1	1	allskills		1	1																		0
-Muddled Thoughts	973	100	1			3		1	25	ci0	circlet		5	5000	cred	cred		invhelm03				ac%		100	120	cast2		25	25	enr		15	15	sor		1	1	res-all		15	25	hp		35	50	dmg-to-mana		10	15																						0
-Charon's Token	974	100	1			5		1	18	ci0	Circlet		5	5000				invhelm06				ac		20	30	move1		15	15	block1		15	15	balance1		15	15	cast1		15	15	swing1		15	15	all-stats		15	15	res-all		15	15																		0
-Gainsayer	975	100	1			1		19	19	ci1	coronet		5	5000	dpur	dpur						ac%		140	175	addxp		4	7	cheap		5	10	all-stats		15	20	res-all		20	30	balance2		25	25	skilltab	14	1	3	skilltab	6	1	3																		0
-Threatspeaker	976	100	1			3		1	12	ci1	coronet		5	5000	cblu	cblu						ac		50	75	dmg-min		5	10	dmg-max		20	25	swing1		10	10	oskill	war cry	10	10	oskill	conversion	1	6	res-all		15	20																						0
-Sorcerer's Cache	977	100	1			5		1	39	ci1	Coronet		5	5000				invhelm02				ac%		100	135	allskills		1	1	cast2		30	30	mana		50	50	extra-fire		10	15	extra-cold		10	15	extra-ltng		10	15																						0
-Gillian's Hairpin	978	100	1			1		30	30	ci2	tiara		5	5000								ac		75	150	block		15	25	block2		20	20	slow		25	25	oskill	teleport	2	4	regen		8	8																										0
-Mystic Angel	979	100	1			3		1	68	ci2	tiara		5	5000								ac%		100	140	oskill	valkyrie	1	1	mana%		20	20	res-ltng		20	35	res-fire		25	35	red-dmg%		10	15																										0
-Blindsight	980	100	1			1		1	86	ci3	diadam		5	5000								ac/lvl	20			allskills		2	2	stupidity		3	3	att%		35	35	dex		20	20	res-ltng		65	65	gethit-skill	28	12	5																						0
-Royal Circlet	981	100	1			3		1	83	ci3	diadam		5	5000				invhelm32				ac%		130	175	ac/lvl	10			allskills		1	1	gold%		250	300	str		25	25	dex		15	15	gethit-skill	53	7	4																						0
-Lightreaper	982	100	1			1		1	8	buc	buckler		5	5000				invshld2				ac		20	35	block		15	25	dmg-ltng		10	20	balance2		25	25	cast2		20	20	vit		5	5																										0
-Traitor's Mark	983	100	1			3		1	5	buc	buckler		5	5000				invshld3				ac		15	30	block		10	20	block2		15	15	lifesteal		3	4	swing1		10	10	dmg%		25	25																										0
-Golgomere's Shield	984	100	1			1		1	14	sml	small shield		5	5000				invshld35				ac%		100	120	block2		20	20	heal-kill		5	8	regen-mana		50	50	extra-cold		10	10	res-cold		25	25	hp		20	20																						0
-Skein of Deceit	985	100	1			3		1	11	sml	small shield		5	5000	cred	cred		invshld34				ac		25	35	block		15	20	block2		20	20	skill	36	1	3	skill	38	1	3	skill	39	1	3	mana		25	25																						0
-Crest of the Horned Society	986	100	1			1		1	19	lrg	large shield		5	5000				invshld11				ac%		80	120	block		20	30	swing2		15	15	thorns		8	12	noheal		1	1	manasteal		4	4																										0
-Lepertouch	987	100	1			3		1	16	lrg	large shield		5	5000	cgrn	cgrn		invlrg				ac%		100	125	block		15	25	block2		20	20	res-pois-len		50	50	res-pois		75	75	dmg-pois	100	100	100	oskill	poison dagger	1	1																						0
-Doomhedge	988	100	1			1		1	28	bsh	bone shield		5	5000				invshld22				ac		25	50	block2		30	30	balance2		15	15	dmg-max		8	8	gethit-skill	66	13	1	deadly		10	10	res-all		15	15																						0
-Cacophony	989	100	1			3		1	24	bsh	bone shield		5	5000	dyel	dyel		invbsh				ac%		100	125	block		20	25	block2		20	20	gethit-skill	77	20	2	howl		35	35	res-all		10	15	sock		1	2																						0
-Fanged Shield	990	100	1			1		1	22	spk	spiked shield		5	5000				invshld38				ac%		100	125	thorns/lvl	8			block2		20	20	allskills		1	1	ignore-ac		1	1	mana		25	35	openwounds		30	80																						0
-Debtfinisher	991	100	1			3		1	18	spk	spiked shield		5	5000	lyel	lyel		invspk				ac%		110	135	block		20	30	block2		25	25	oskill	zeal	1	5	pal		1	1	skill	96	1	3	skill	104	1	3	ac		30	40																		0
-Crest of Avalon	992	100	1			1		1	24	kit	kite shield		5	5000				invshld1				ac%		120	140	block		60	70	block3		40	40	red-dmg%		50	50																																		0
-Killhunger	993	100	1			3		1	21	kit	kite shield		5	5000				invshld7				ac%		115	140	block		25	30	block2		30	30	lifesteal		3	5	heal-kill		6	6	nec		1	1	skill	69	1	3	skill	80	1	3																		0
-Bigby's Crushing Fist	994	100	1			3		1	25	tow	tower shield		5	5000				invshld8				ac		40	70	crush/lvl	5			dmg%		20	30	allskills		1	1	sock		2	3																														0
-Knight's Dawn	995	100	1			1		1	29	tow	tower shield		5	5000								ac%		120	150	block		25	35	block2		30	30	bar		1	1	oskill	holy shield	1	1	oskill	vengeance	1	3	oskill	concentration	1	2	sock		2	3																		0
-Pathfinder	996	100	1			1		1	31	gts	gothic shield		5	5000				invshld15				ac%		100	125	ac/lvl	8			str/lvl	3			dex/lvl	3			vit/lvl	3			enr/lvl	3			move3		30	30																						0
-Shield of Osirus	997	100	1			3		1	29	gts	gothic shield		5	5000	oran	oran		invshld27				ac%		125	150	block		30	40	block3		40	40	allskills		1	1	res-all		25	25	balance2		30	30	aura	109	6	6	regen-mana		35	35	regen		2	5														0
-Yemista's Defender	998	100	1			1		1	37	xuc	defender		5	5000		blac		invshld29				ac		70	100	nec		1	1	cast1		15	15	hp		100	100	regen		3	5	mana-kill		3	5																										0
-Mongolian Trust	999	100	1			3		1	34	xuc	defender		5	5000	oran	oran		invbuc				ac%		80	130	ass		1	1	skill-rand	2	251	280	skill-rand	2	251	280	block		15	30	lifesteal		3	5	stupidity		1	1	reduce-ac		10	10																		0
-Doom's Mirror	1000	100	1			1		1	39	xml	round shield		5	5000				invshld30				block		30	40	block2		25	25	ac/lvl	12			abs-fire		15	15	abs-ltng		15	15	abs-cold		15	15	stupidity		2	2	sock		2	2																		0
-Undead Buckler	1001	100	1			3		1	35	xml	round shield		5	5000	dgry	dgry		invsml				ac%		80	130	dru		1	1	skill-rand	2	221	250	skill-rand	2	221	250	block		15	30	oskill	skeleton mastery	5	5	oskill	revive	1	1	dmg-to-mana		10	10																		0
-Savant Sin	1002	100	1			1		1	42	xrg	scutum		5	5000				invshld16				ac%		120	150	pal		1	1	oskill	holy shield	1	1	balance2		20	20	dmg-norm		5	15	swing1		10	10	res-ltng		35	35																						0
-Spellbreaker	1003	100	1			3		1	39	xrg	scutum		5	5000				invshld9				ac%		80	130	sor		1	1	skill-rand	2	36	65	skill-rand	2	36	65	block		15	30	cast1		15	15	mana-kill		4	7	mana%		10	10																		0
-Under Dragon's Wing	1004	100	1			1		1	48	xit	dragon shield		5	5000		blac		invshld17				dmg%		50	50	ac		75	100	block2		50	50	red-dmg%		10	15	res-mag		10	15	res-all		35	35	dmg-fire		10	77																						0
-Wishgranter	1005	100	1			3		1	44	xit	dragon shield		5	5000				invshld18				ac%		80	130	bar		1	1	skill-rand	2	126	155	skill-rand	2	126	155	block		15	30	dmg-max		10	15	hp%		10	10	att		200	200																		0
-Adamantine Shield	1006	100	1			1		1	53	xow	pavise		5	5000				invshld21				ac/lvl	20			red-dmg%		20	20	indestruct		1	1	allskills		1	1	red-mag		25	25	str		15	15	ease		10	10	sock		1	1																		0
-Shieldmaiden's Shield	1007	100	1			3	1	1	49	xow	pavise		5	5000				invshld19				ac%		80	130	ama		1	1	skill-rand	2	6	35	skill-rand	2	6	35	block		15	30	oskill	sword mastery	1	1	red-dmg%		10	15	manasteal		5	5																		0
-Dreadwall	1008	100	1			3		1	55	xts	ancient sheild		5	5000				invshld36				ac%		140	170	block		25	35	gethit-skill	77	100	1	thorns/lvl	8			mag%		25	25	mana-kill		2	4	addxp		3	5																						0
-Crusader's Wall	1009	100	1			1		1	59	xts	ancient shield		5	5000				invshld24				ac%		80	130	pal		1	1	skill-rand	2	96	125	skill-rand	2	96	125	block		15	30	res-all		25	35	red-dmg%		10	10	block2		20	20																		0
-Ghoulspawner	1010	100	1			1		1	48	xsh	grim shield		5	5000				invshld41				ac%		100	125	reanimate	10	10	15	charged	95	10	10	dmg-undead		75	75	att%		20	20	lifesteal		6	6	res-all		30	40	rep-dur	12																				0
-Lichward	1011	100	1			3		1	45	xsh	grim shield		5	5000	blac	blac		invbsh				ac%		80	130	nec		1	1	skill-rand	2	66	95	skill-rand	2	66	95	block		15	30	mana		35	35	aura	119	1	4	pierce-pois		15	15																		0
-Raptarfang	1012	100	1			1		1	46	xpk	barbed shield		5	5000								ac/lvl	10			balance2		25	25	block		20	40	gold%		100	100	dmg-max		15	30	red-dmg		15	20	sock		1	1																						0
-Razorbite Deflecter	1013	100	1			3		1	41	xpk	barbed sheild		5	5000	oran	oran		invspk				ac%		80	130	allskills		1	1	openwounds		33	33	dmg-norm		5	15	dmg%		25	40	red-dmg		10	15	red-mag		10	15	block		25	45																		0
-Chill of Winter	1014	100	1			1		1	58	uuc	heater		5	5000				invshld39				ac%		150	200	dmg-cold		100	200	freeze		4	4	extra-cold		15	25	abs-cold%		15	15	res-cold		75	100	pierce-cold		60	60																						0
-Sun Tormenter	1015	100	1			2		1	53	uuc	Heater		5	5000				invshld23				ac/lvl	20			res-fire		50	50	abs-fire%		25	25	dmg-fire		75	200	pierce-fire		25	25	extra-fire		20	25	res-fire-max		20	20	block		20	30	block2		30	30														0
-Solar Eclipse	1016	100	1			1		1	67	uml	luna		5	5000				invshld28				ac%		100	150	lifesteal		8	8	stupidity		2	2	slow		10	10	block		30	30	allskills		1	1	res-all		20	20	regen-mana		25	25																		0
-Shield of Myth	1017	100	1			1		1	70	urg	hyperion		5	5000				invshld31				ac%		150	200	block		25	35	block2		20	20	balance3		40	40	hp		150	150	mag%		75	75																										0
-Safewarden	1018	100	1			2		1	65	urg	Hyperion		5	5000				invshld33				ac%		100	200	red-dmg%		15	20	abs-mag%		25	25	res-all		20	30	block		75	75	block3		60	60																										0
-Fortress of Solitude	1019	100	1			1		1	78	uit	monarch		5	5000	dgrn	dgrn		invshld4				ac%		200	225	block		35	50	balance2		35	35	enr		40	40	addxp		3	5	red-dmg%		15	25	res-mag		15	25	sock		1	2																		0
-Lachdonnan's Guard	1020	100	1			1		1	82	uow	aegis		5	5000				invshld12				ac%		100	120	ac/lvl	16			allskills		3	3	ease		50	50	block		50	75	balance1		15	15	abs-fire%		30	30																						0
-Medusa's Gaze1	1021	100	1			2		1	76	uow	aegis		3	5000	lred	lred						ac%		150	180	slow		20	20	gethit-skill	Lower Resist	10	7	lifesteal		5	9	death-skill	Nova	100	44	res-cold		40	80																										0
-Braced for Battle	1022	100	1			1		1	86	uts	ward		5	5000				invshld10				ac%		100	150	ease		-70	-70	block2		30	30	balance3		60	60	swing2		20	20	sock		2	2																										0
-Cry of the Wretched	1023	100	1			1		1	80	ush	troll nest		5	5000	lgrn	lgrn		invbsh				gethit-skill	91	15	3	ac%		200	240	block		25	35	cast2		25	25	nec		1	2	mana		50	50	manasteal		5	5																						0
-Baal's Wing	1024	100	1			1		52	52	upk	blade barrier		5	5000								ac		200	300	block		35	50	block1		15	15	move2		20	20	oskill	bone wall	5	5	hit-skill	53	33	8	noheal		1	1	openwounds		77	77																		0
-Blisterpain	1025	100	1			1		1	11	lgl	gloves		5	5000				invglov5				ac		30	40	dmg-max		5	5	dmg-fire		12	18	res-fire		45	45	swing1		15	15	noheal		1	1																										0
-Goblin Touch	1026	100	1			3		1	8	lgl	gloves		5	5000	lgrn	lgrn		invglov10				ac		10	20	res-pois		15	25	dmg-demon		100	100	rep-dur	10			att		75	75	demon-heal		10	15																										0
-Healing Touch	1027	100	1			1		1	18	vgl	heavy gloves		5	5000								ac		35	45	lifesteal		6	8	regen		3	5	heal-kill		4	7	mana-kill		4	6	regen-mana		35	35																										0
-Fiendfeast	1028	100	1			3		1	14	vgl	heavy gloves		5	5000				invglov21				ac		20	25	dmg-demon		50	50	dmg-undead		50	50	manasteal		4	6	mag%		15	15	gold%		25	25	red-dmg%		5	10																						0
-Horseman's Gloves	1029	100	1			3		1	20	mgl	bracers		5	5000								ac		40	50	red-dmg%		7	10	swing1		10	10	skilltab	10	1	3	res-pois		15	25	hp		30	30																										0
-Green God's Bracers	1030	100	1			1		1	25	mgl	bracers		5	5000	dgrn	dgrn						ac%		100	115	swing1		15	15	skilltab	1	1	3	dmg-ltng		1	35	res-all		10	20	hp		25	35																										0
-Prismatic Gauntlets	1031	100	1			1		1	30	tgl	light gauntlets		5	5000	oran	oran		invglov2				ac		45	55	res-all		20	30	dmg-elem	150	15	30	swing2		20	20	dmg-min		3	5	all-stats		5	5																										0
-Skein of Pain	1032	100	1			3		1	27	tgl	light gauntlets		5	5000				invglov11				ac%		120	140	dmg-norm		3	12	swing1		10	10	mana		20	20	res-fire		15	25	res-ltng		20	40	skilltab	13	1	3																						0
-Viridian Gloves	1033	100	1			1		1	33	hgl	gauntlets		5	5000				invglov20				ac		50	60	ease		-25	-25	dex		15	15	att		75	75	slow		15	15	res-fire		25	25	cast1		10	10																						0
-Firesign	1034	100	1			3		1	31	hgl	gauntlets		5	5000	dred	dred						ac%		125	150	dmg-fire		20	35	res-fire		35	45	res-fire-max		5	5	abs-fire%		5	5	half-freeze		1	1	light		2	4	fireskill		1	1																		0
-Devil's Invocation	1035	100	1			1		1	37	xlg	demonhide gloves		5	5000				invglov17				ac%		100	125	cast2		20	20	mana		30	50	dmg-to-mana		10	15	regen-mana		50	50	mana-kill		3	5	manasteal		5	5																						0
-Marauder's Claw	1036	100	1			3		1	34	xlg	demonhide gloves		5	5000				invglov4				ac%		100	125	dmg-min		6	10	reduce-ac		5	5	crush		5	5	gold%		100	100	res-cold		20	30	res-fire		20	30																						0
-Lady of the Lake	1037	100	1			1		1	43	xvg	sharkskin gloves		5	5000	dblu	dblu						ac%		120	140	sor		1	1	ama		1	1	ass		1	1	mana		40	50	cast2		15	15	swing1		15	15																						0
-Conspiracy of Thieves	1038	100	1			3		1	39	xvg	sharkskin gloves		5	5000				invglov1				ac%		125	160	dex		25	25	mag%		20	30	abs-fire		10	15	abs-cold		10	15	abs-ltng		10	15	ac		20	40																						0
-Spikefiend Bracers	1039	100	1			1		1	48	xmg	heavy bracers		5	5000	dgry	dgry						ac%		140	160	bar		1	1	pal		1	1	dmg%		20	20	hp		25	35	lifesteal		5	5																										0
-Rapturous Blessings	1040	100	1			3		1	44	xmg	heavy bracers		5	5000				invglov15				ac		75	125	oskill	salvation	1	1	cast1		10	10	res-all-max		5	5	res-all		10	15	enr		15	15	vit		15	15																						0
-Warlock's Touch	1041	100	1			1		1	54	xtg	battle gauntlets		5	5000				invglov7				ac%		125	150	nec		1	1	dru		1	1	cast2		20	20	mana-kill		5	5	mana		25	40	regen-mana		50	50																						0
-Gryphon's Claw	1042	100	1			3		1	50	xtg	battle gauntlets		5	5000				invglov12				ac%		130	160	dmg-max		6	10	swing1		10	10	skilltab	15	1	3	heal-kill		5	5	res-pois		25	25	res-cold		20	30																						0
-Burning Soul	1043	100	1			1		1	60	xhg	war gauntlets		5	5000				invglov16				ac		100	150	dmg-fire		77	122	res-fire		35	35	abs-fire%		10	15	extra-fire		10	15	pierce-fire		10	15																										0
-Threat of Retribution	1044	100	1			3		1	55	xhg	war gauntlets		5	5000	lgrn	lgrn						ac/lvl	16			ac%		50	75	charged	8	77	10	gethit-skill	42	3	1	hit-skill	39	3	10	balance1		15	15	move1		15	15																						0
-Mephisto's Claw	1045	100	1			1		1	64	ulg	bramble mitts		5	5000	oran	oran						ac%		125	150	aura	114	4	6	dmg-cold		70	100	freeze		2	2	mag%		35	50																														0
-Griefspawn	1046	100	1			2		1	57	ulg	Bramble Mitts		5	5000				invglov18				ac%		75	100	dmg-norm		10	20	swing3		40	40	rip		1	1	hp%		10	10																														0
-Bloodyearn	1047	100	1			1		36	36	uvg	vampirebone gloves		5	5000	cred	cred		invglov6				ac%		120	150	hp%		25	25	hp/lvl	6			lifesteal		6	6	swing2		20	20	skilltab	13	1	3																										0
-Lachdonnan's Bracers	1048	100	1			1		1	80	umg	vambraces		5	5000								ac%		160	200	ease		40	40	skilltab	9	1	3	dmg-norm		10	20	dmg-demon		100	100	res-fire		25	35	mag%		35	50																						0
-Paladin's Quest	1049	100	1			1		1	84	utg	crusader gauntlets		5	5000				invglov9				allskills		1	1	addxp		1	1	skill	117	1	3	skill	122	1	3	block		20	20	block2		20	20																										0
-Hellhunger	1050	100	1			2		34	34	utg	Crusader Gauntlets		5	5000				invglov3				ac		75	125	allskills		1	1	oskill	lower resist	1	5	cast1		10	10	mag%		20	25																														0
-Black Lotus	1051	100	1			1		1	87	uhg	ogre gauntlets		5	5000				invglov22				ac/lvl	24			swing3		30	30	dex		25	25	deadly		25	25	pierce		20	20	res-all		15	20																										0
-Cheetah Speed	1052	100	1			1		1	10	lbt	leather boots		5	5000				invboot19				ac		20	30	move1		30	30	balance2		30	30	res-all		10	15	heal-kill		5	5																														0
-Marathon Slipper	1053	100	1			3		1	7	lbt	leather boots		5	5000				invboot25				ac		15	25	move2		25	25	balance2		20	20	dex		15	15	res-ltng		20	30	gold%		35	35																										0
-Gillian's Boots	1054	100	1			1		43	43	vbt	heavy boots		5	5000				invboot4				ac		25	35	move2		15	15	kick		3	3	gold%		50	50	skilltab	19	1	1	str		10	10																										0
-Angel's Tread	1055	100	1			3		1	13	vbt	heavy boots		5	5000	whit	whit						ac		25	35	skilltab	11	1	3	skill	99	1	3	balance2		25	25	res-all		15	20	mag%		15	25	res-fire		25	35																						0
-Pepin's Grace	1056	100	1			1		1	23	mbt	chain boots		5	5000				invboot23				ac		30	40	move2		20	20	regen		2	5	oskill	dodge	1	1	thorns		6	9	dex		10	15																										0
-Bonemesh	1057	100	1			3		1	19	mbt	chain boots		5	5000				invboot3				ac%		100	125	skilltab	8	1	2	oskill	skeleton mastery	5	5	oskill	raise skeleton	1	1	dmg-undead		75	75	regen		3	3																										0
-Dawn Scion	1058	100	1			1		1	30	tbt	light plated boots		5	5000				invboot21				ac		35	45	skilltab	11	1	2	str		5	15	addxp		1	2	balance2		15	15	mag%		20	30	light		1	3																						0
-Lilith's Heels	1059	100	1			3		1	26	tbt	light plate boots		5	5000				invboot5				ac%		115	140	dmg-to-mana		5	10	skill	54	1	2	skill	37	1	1	mana		25	25	move2		20	20	res-cold		25	40																						0
-Dark Familiar	1060	100	1			1		1	34	hbt	plate boots		5	5000	lgry	lgry						ac		40	50	kick		3	5	skilltab	6	1	1	lifesteal		3	4	mana		25	35	red-mag		10	15																										0
-Grimleaper	1061	100	1			3		46	46	hbt	plate boots		5	5000				invboot15				ac%		125	150	dmg%		20	30	skill	143	1	2	heal-kill		2	3	aura	prayer	1	6	gethit-skill	68	5	8	res-pois		25	35	hp%		5	5																		0
-Hooves of Satan	1062	100	1			1		1	40	xlb	demonhide boots		5	5000				invboot10				ac%		90	140	cast3		30	30	rep-dur	15			slow		10	15	dex		-5	-5	res-fire		45	60	extra-fire		10	10	kick		3	5																		0
-Deepwander	1063	100	1			3		1	35	xlb	demonhide boots		5	5000				invboot6				ac		50	80	move2		25	25					light		1	7	nofreeze		1	1	hp		25	25	mana		25	25																						0
-Asheara's Slippers	1064	100	1			1		1	45	xvb	sharkskin boots		5	5000				invboot12				ac%		110	150	ac		25	40	res-pois		25	35	res-cold		30	40	move3		25	25	balance2		20	20	extra-cold		10	15																						0
-Road to Perdition1	1065	100	1			3		1	38	xvb	sharkskin boots		5	5000	lgry	lgry		invboot1				ac%		120	160	move1		15	15	balance2		25	25	dex		20	20	rep-dur	8			addxp		4	7	charged	96	250	20																						0
-Whirling Dervish	1066	100	1			1		1	48	xmb	mesh boots		5	5000				invboot2				ac%		130	170	oskill	whirlwind	7	12	skilltab	12	1	1	dmg%		10	15	swing1		10	10	ease		25	25	move2		20	20																						0
-Zebrastride	1067	100	1			3		1	43	xmb	mesh boots		5	5000				invboot28				ac%		125	165	move3		40	40	dex/lvl	5			crush		10	10	kick		5	10	res-all		15	15	regen-mana		25	25																						0
-Halbu's Gift	1068	100	1			1		1	56	xtb	battle boots		5	5000				invboot20				ac%		125	160	ac/lvl	6			addxp		2	4	cheap		5	5	red-dmg		10	15	res-all		15	25	dex		15	25																						0
-Zero Effect	1069	100	1			3		1	49	xtb	battle boots		5	5000	dred	dred		invboot7				ac%		130	170	red-dmg%		15	20	abs-cold%		10	15	abs-fire%		10	15	abs-ltng%		10	15	res-pois-len		50	50	nofreeze		1	1																						0
-River Stalker	1070	100	1			1		1	60	xhb	war boots		5	5000				invboot17				ac		100	140	balance2		30	30	oskill	avoid	1	1	oskill	dodge	1	1	oskill	evade	1	1	mana		30	50	regen-mana		35	35	mana-kill		3	5																		0
-Doubtraiser	1071	100	1			3		1	55	xhb	war boots		5	5000				invboot13				ac/lvl	12			str		20	20	move1		15	15	addxp		-3	-3	heal-kill		12	12	res-all		25	25	kick		5	5	mag%		25	25																		0
-Dance of the Cobra	1072	100	1			2		1	56	ulb	wyrmhide boots		5	5000				invboot8				ac%		100	150	stupidity		1	1	move1		15	15	res-pois		75	75	res-pois-len		25	80	dmg-pois	100	777	777	noheal		1	1																						0
-Stallion Hooves	1073	100	1			1		1	67	ulb	Wyrmhide Boots		5	5000								ac%		100	125	dex		35	35	balance3		40	40	move3		40	40	rep-dur	60			dmg-max		20	20	crush		15	15	deadly		20	25																		0
-Thoqqua's Slipper	1074	100	1			2		19	19	uvb	scarabshell boots		5	5000				invboot11				ac		75	120	mag%		40	80	res-all		10	15	hp		35	50	move3		50	50																														0
-Hollowed Ground	1075	100	1			1		37	37	umb	boneweave boots		5	5000				invboot29				pal		1	1	ac%		150	200	balance2		25	25	dmg-undead		125	125	rip		1	1	aura	119	2	5	dex		15	25																						0
-Stairway to Heaven	1076	100	1			2		1	74	utb	mirrored boots		5	5000				invboot9				ac%		125	160	mag%		20	30	res-fire		40	70	res-cold		40	70	res-ltng		40	70	res-pois		40	70	half-freeze		1	1	res-pois-len		50	50																		0
-Lustwander	1077	100	1			1		1	81	utb	Mirrored Boots		5	5000				invboot24				ac		100	150	oskill	teleport	2	5	gold%		150	250	mag%		75	75	res-all		25	25	allskills		1	1																										0
-Wild Horses	1078	100	1			1		34	34	uhb	myrmidon greaves		5	5000				invboot14				ac%		125	200	kick		10	15	move3		40	40	balance3		40	40	str		25	25	dex		25	25	deadly		10	20																						0
-Bloodrune	1079	100	1			1		1	8	lbl	sash		5	5000	dred	dred						ac		15	25	regen		3	5	res-fire		40	45	res-cold		40	45	res-pois		40	45	res-ltng		40	45																										0
-Ivywrap	1080	100	1			3		1	5	lbl	sash		5	5000	lyel	lyel						ac		10	20	dmg-pois	75	77	77	res-pois		35	35	res-pois-len		25	50	slow		10	10	mag%		10	15																										0
-Ratman's Rope	1081	100	1			1		1	15	vbl	light belt		5	5000	oran	oran		invbelt12				ac		10	20	dmg-demon		100	100	res-ltng		20	30	mana		35	35	cast1		10	10	dex		5	5																										0
-Spiritseeker	1082	100	1			3		1	12	vbl	light belt		5	5000				invbelt6				ac		15	25	dmg-undead		50	50	addxp		3	5	cheap		5	5	mana		20	30	regen-mana		50	50																										0
-Belt of Evil	1083	100	1			1		1	25	mbl	belt		5	5000				invbelt1				ac		20	30	regen		-1	-1	addxp		-2	-2	gold%		75	75	mag%		75	75	hp		55	75																										0
-Wreath of Suffering	1084	100	1			3		1	21	mbl	belt		5	5000				invbelt15				ac%		100	125	dmg-max		5	15	manasteal		2	5	crush		5	10	regen		-2	-2	str		10	10	vit		10	10																						0
-Crocodile Wrap	1085	100	1			1		1	30	tbl	heavy belt		5	5000								ac%		75	100	red-dmg%		10	10	move2		20	20	red-mag		3	5	res-all		10	10	str		10	10	vit		10	10																						0
-Pirate's Faith	1086	100	1			3		1	28	tbl	heavy belt		5	5000	oran	oran						mag%		25	25	gold%		100	100	move2		20	20	ac%		120	145	dex		15	15	red-dmg%		5	10	fade		1	1																						0
-Pandemonium	1087	100	1			1		1	32	hbl	girdle		5	5000	dred	dred						ac/lvl	10			str/lvl	4			hp/lvl	8			dmg/lvl	2			res-cold/lvl	4			res-fire/lvl	4																												0
-Leash of Cerebus	1088	100	1			3		1	30	hbl	girdle		5	5000				invbelt11				ac%		125	150	all-stats		10	10	regen		3	3	skilltab	15	1	3	skill	227	1	3	skill	237	1	3	balance1		15	15	res-ltng		35	45																		0
-Warriv's Coin	1089	100	1			1		1	39	zlb	demonhide sash		5	5000				invbelt16				ac%		100	120	gold%		200	200	cheap		5	15	mag%		25	25	manasteal		5	5	mana/lvl	6																												0
-Xenophobe	1090	100	1			3		1	36	zlb	demonhide sash		5	5000				invbelt14				ac%		100	150	ac/lvl	6			hit-skill	77	10	3	skilltab	6	1	1	skill	77	3	3	dmg%		15	20	dmg-to-mana		5	10																						0
-Megladon Wrap	1091	100	1			1		1	41	zvb	sharkskin belt		5	5000				invbelt3				ac/lvl	10			heal-kill		6	10	lifesteal		4	7	crush		15	15	dmg-max		10	15	res-ltng/lvl	6			dex		10	10																						0
-Wave Whipper	1092	100	1			3		1	37	zvb	sharkskin belt		5	5000				invbelt8				ac%		110	160	res-cold		25	35	crush		5	10	deadly		5	10	oskill	increased stamina	1	1	move2		20	20																										0
-Meshif's Coil	1093	100	1			1		1	45	zmb	mesh belt		5	5000				invbelt2				ac%		130	160	move3		30	30	balance1		15	15	gethit-skill	76	4	14	regen-mana		30	30	res-cold-max		10	10	res-cold/lvl	7																								0
-Weakling's Whimper	1094	100	1			3		1	40	zmb	mesh belt		5	5000				invbelt13				ac%		125	165	gethit-skill	72	20	1	charged	72	15	25	str		20	20	res-pois		10	25	res-fire		35	35																										0
-Assassin Vine	1095	100	1			1		1	48	ztb	battle belt		5	5000	cred	cred						ass		1	1	dex		20	30	str		20	30	balance2		20	20	kick		5	5	knock		2	2	res-ltng		20	40																						0
-Fortune's Fool	1096	100	1			3		1	46	ztb	battle belt		5	5000	dgld	dgld						ac%		75	100	ac		50	75	gold%/lvl	16			mag%/lvl	6			enr		-5	-5	vit		-5	-5	oskill	find item	1	1																						0
-The Art of War	1097	100	1			1		1	54	zhb	war belt		5	5000				invbelt4				ac%		150	180	str		35	35	dmg/lvl	4			swing1		15	15	bar		1	1	vit/lvl	4			res-ltng		35	35																						0
-Shattered Dreams	1098	100	1			3	1	1	50	zhb	war belt		5	5000	blac	blac						ac%		135	175	dmg-max		5	15	stupidity		1	1	swing1		10	10	regen		5	5	deadly		10	10	oskill	sword mastery	1	1																						0
-Duskwreath	1099	100	1			1		1	60	ulc	spiderweb sash		5	5000				invbelt10				ac		100	150	fade		1	1	res-all		35	35	balance2		20	20	cast1		15	15	enr		30	30																										0
-Dreadfury	1100	100	1			1		1	64	uvc	vampirefang belt		5	5000				invbelt7				ac%		120	150	dru		1	1	swing1		10	10	howl		33	33	skill-rand	2	221	250	extra-fire		10	15																										0
-Kashya's Ward	1101	100	1			1		1	73	umc	mithril coil		5	5000				invbelt9				ac%		100	150	red-dmg%		15	15	res-mag		15	15	abs-fire/lvl	3			abs-ltng/lvl	3			abs-cold/lvl	3			regen-mana		50	50																						0
-Wisdom's Wrap	1102	100	1			1		1	78	utc	troll belt		5	5000								ac%		150	200	addxp		3	3	enr/lvl	5			allskills		1	1	rep-dur	30			dmg-to-mana		15	15	res-all		15	20																						0
-Ecstacy of Ishtar	1103	100	1			2		1	71	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		25	25	mana%		25	25	red-dmg		25	30	red-mag		25	30	pierce		50	50																										0
-Lachdonnan's Wrap	1104	100	1			1		1	85	uhc	colossus girdle		5	5000								ac		200	300	ease		20	20	lifesteal		8	8	manasteal		8	8	res-all		30	40	block2		20	20	allskills		1	1	dmg%		20	25																		0
-Ogre's Embrace	1105	100	1			2		1	80	uhc	Colossus Girdle		5	5000	dgrn	dgrn						ac%		175	200	ac		75	125	red-dmg%		10	15	str/lvl	8			vit/lvl	8			res-pois		100	100	rep-dur	25			oskill	iron skin	1	1																		0
-Damsel of Destruction	1106	100	1			1		26	26	am1	stag bow		5	5000	blac	blac		invam1				dmg%		80	120	dmg-norm		20	40	skilltab	0	1	3	swing1		15	15	dmg-elem	200	10	25	mana-kill		5	5	balance2		20	20																						0
-Bleeding Branch	1107	100	1			3		1	18	am1	stag bow		5	5000	cred	cred		invam1				dmg%		120	160	dmg-norm		10	20	lifesteal		5	8	noheal		1	1	openwounds		57	57	bloody		1	1	sock		2	2																						0
-Angelsong	1108	100	1			5		1	12	am1	Stag Bow		5	5000	dgld	dgld		invam1				dmg%		75	110	dmg-norm		5	10	swing1		10	10	aura	defiance	1	3	pierce-fire		45	45	pierce-cold		45	45	dmg-demon		200	200																						0
-Kashya's Retort	1109	100	1			1		33	39	am2	reflex bow		5	5000	oran	oran		invam2				dmg%		80	120	dmg-norm		25	50	skilltab	0	1	3	ama		1	1	gethit-skill	47	17	4	light		2	4	mana		35	35	manasteal		5	5																		0
-Elvenbrand	1110	100	1			3		1	32	am2	reflex bow		5	5000	dgrn	dgrn		invam2				dmg%		125	175	ama		1	1	skilltab	0	1	3	swing2		20	20	dex		20	20	ignore-ac		1	1	pierce		20	20	dmg-norm		10	20																		0
-Ragnarok Sliver	1111	100	1			5		1	24	am2	Reflex Bow		5	5000	whit	whit		invam2				dmg%		100	150	crush		25	25	deadly/lvl	12			dex		15	15	ease		-50	-50	ama		1	1	allskills		1	1	dmg-norm		10	25																		0
-Brightmangler	1112	100	1			1		55	51	am6	ashwood bow		5	5000				invbow15				dmg%		100	100	dmg-min		25	35	dmg-max		50	100	skilltab	1	1	3	deadly		35	35	openwounds		50	50	res-ltng		35	35	res-pois		20	30																		0
-Abyssal Torment	1113	100	1			3		1	41	am6	ashwood bow		5	5000	lgry	lgry		invam1				dmg%		200	250	skilltab	0	3	3	dmg/lvl	8			res-fire		35	50	extra-fire		15	15	oskill	amplify damage	1	1	rip		1	1																						0
-Adamantine Leaf	1114	100	1			5		1	33	am6	Ashwood Bow		5	5000	lgrn	lgrn		invam1				dmg%		125	190	skilltab	0	1	3	swing2		20	20	res-all		35	50	pierce		25	25	move2		25	25	magicarrow		1	1	att%		25	25	skill	32	7	7	dmg-norm		20	40										0
-Distance Strike	1115	100	1			1		55	60	am7	ceremonial bow		5	5000	dyel	dyel		invam2				dmg%		100	100	dmg-min		25	50	dmg-max		90	140	swing3		30	30	allskills		1	1	dex		15	15	move2		25	25	att		250	250	knock		2	2														0
-The Four Winds	1116	100	1			3		1	50	am7	ceremonial bow		5	5000	dred	dred		invam2				dmg%		220	270	dmg-norm		15	30	dmg-ltng		1	200	oskill	teleport	1	1	move3		50	50	ama		1	2	skilltab	1	1	3																						0
-Laurana's Elven Bow	1117	100	1			1		1	73	amb	matriachal bow		5	5000	dblu	dgld		invbow14				dmg%		260	325	dmg-norm		25	50	dmg%/lvl	14			swing3		50	50	pierce		40	40	balance2		30	30	sock		1	1																						0
-Wintershock	1118	100	1			1		1	87	amc	grand matron bow		5	5000	lgld	lgld		invam2				dmg%		300	350	dmg-norm		40	80	dmg-cold	600	25	50	dmg-ltng		1	444	res-ltng		65	65	res-cold		65	65	extra-cold		10	15	pierce-cold		10	15																		0
-Quicksilver	1119	100	1			4		1	80	amc	Grand Matron Bow		5	5000	whit			invam2				dmg%		200	300	dmg/lvl	16			dmg-norm		40	100	swing3		50	50	skilltab	0	3	3	ama		2	2	addxp		10	10	res-all		15	50																		0
-Shieldmaiden's Toss	1120	100	1			1		40	50	am5	maiden javelin		5	5000	cgrn	cgrn						dmg%		75	100	dmg-norm		30	50	skilltab	2	1	3	stack		80	80	rep-quant	25			pierce		25	25	dex		15	15	deadly		15	15																		0
-Hastemaster	1121	100	1			3		1	27	am5	maiden javelin		5	5000	dyel	dyel						dmg%		120	160	dmg-throw		15	15	rep-quant	25			stack		55	55	swing3		40	40	block2		30	30																										0
-Raptorshaft	1122	100	1			5		1	20	am5	Maiden Javelin		5	5000								dmg%		75	115	ama		1	1	skilltab	2	1	1	dmg-throw		10	20	stack		50	50	rep-quant	75			noheal		1	1	addxp		15	15																		0
-Lady in Waiting	1123	100	1			1		55	65	ama	ceremonial javelin		5	5000	cred	cred						dmg%		100	125	dmg-norm		30	60	dmg/lvl	6			stack		100	100	rep-quant	90			skilltab	2	1	3	allskills		1	1	rip		1	1																		0
-Sister of the Sun	1124	100	1			3		1	49	ama	ceremonial javelin		5	5000	oran	oran						dmg%		215	270	ama		2	2	dmg-fire		75	100	res-cold		35	35	res-fire		50	50	skilltab	2	1	3	rep-quant	25			stack		155	155																		0
-Pegasus Wing	1125	100	1			1		1	80	amf	matriarchal javelin		5	5000	dyel	dyel						dmg%		275	350	stack		100	100	rep-quant	25			skilltab	2	1	3	allskills		2	2	addxp		3	5	oskill	teleport	3	3	balance3		40	40	block3		40	40														0
-Wrathshifter	1126	100	1			2		1	15	am3	maiden spear		5	5000								dmg-min		15	30	dmg-max		50	70	skilltab	2	1	1	swing1		15	15	oskill	68	2	2	gethit-skill	54	7	1																										0
-Hawkfire	1127	100	1			5		1	8	am3	Maiden Spear		5	5000	lred	lred						dmg%		80	120	dmg-fire		5	18	res-fire		35	35	ama		1	1	hp		35	35	swing1		25	25																										0
-Stygian Harlot	1128	100	1			2		1	25	am4	maiden pike		5	5000								dmg-min		30	55	dmg-norm		80	120	swing2		20	20	skilltab	2	1	3	hp		40	50	lifesteal		6	8	sock		2	2																						0
-Sepia Shard	1129	100	1			5		1	19	am4	Maiden Pike		5	5000	cblu	cblu						dmg%		100	125	dmg-cold	200	10	15	res-cold		20	40	skilltab	2	2	2	mana		35	50	att		100	200	manasteal		6	9																						0
-Vile Temptress	1130	100	1			2		1	40	am8	ceremonial spear		5	5000	blac	blac						dmg%		175	225	dmg/lvl	12			ama		1	1	skilltab	1	2	2	hit-skill	53	8	3	addxp		3	5	dex		25	25	ease		-20	-20																		0
-Silverdawn	1131	100	1			5		1	33	am8	Ceremonial Spear		5	5000	whit							dmg%		140	200	ama		1	1	skilltab	1	2	4	dmg-ltng		1	200	res-ltng		50	65	light		4	7	dmg-demon		100	200	hp/lvl	9			dmg-norm		20	60														0
-Murder's Mistress	1132	100	1			2	1	1	50	am9	ceremonial pike		5	5000	dgry	dgry						dmg%		190	250	dmg%/lvl	12			ama		1	1	swing3		50	50	deadly		18	28	oskill	sword mastery	3	5	rep-dur	10			heal-kill		10	15	mag%		35	70														0
-Valkyrie's Calling	1133	100	1			1		1	73	amd	matriarchal spear		5	5000	whit	whit						dmg%		250	300	dmg-norm		40	80	skill	32	4	7	charged	258	10	15	skilltab	2	3	3	allskills		1	1	res-all		30	30	mana		75	75																		0
-Amanda's Point	1134	100	1			1		1	80	ame	matriarchal pike		5	5000								dmg%		275	325	dmg/lvl	16			skilltab	2	2	2	sock		4	6	ama		2	2																														0
-Manticore's Retort	1135	100	1			2		1	70	ame	Matriarchal Pike		5	5000	oran	lred						dmg%		200	300	dmg-norm		50	100	swing3		35	35	dmg-pois	100	999	999	skilltab	2	1	3	res-pois-max		15	15	res-pois		50	50	res-pois-len		75	75																		0
-Queasespreader	1136	100	1			1		1	11	ob1	eagle orb		5	5000								dmg-norm		8	16	swing2		25	25	sor		1	1	dmg-ltng		1	30	res-ltng		35	50	mana		25	25																										0
-Sparrow's Trill	1137	100	1			3		1	6	ob1	Eagle Orb		5	5000	oran	oran						dmg-norm		3	8	skilltab	5	1	1	mana		25	35	ac		15	25	move1		20	20																														0
-Cyanstrike	1138	100	1			1		1	16	ob2	sacred orb		5	5000	dyel	dyel						dmg-min		6	12	dmg-max		20	25	hit-skill	45	8	3	res-pois		25	25	extra-cold		10	10	heal-kill		5	5																										0
-Flicker Cinch	1139	100	1			3		1	12	ob2	Sacred Globe		5	5000								dmg%		80	120	block		20	30	block2		20	20	hp		25	25	mana		35	35	mag%		20	30																										0
-Revoker	1140	100	1			1		1	23	ob3	smoked sphere		5	5000	dred	dred						allskills		1	1	mag%		20	20	cast2		25	25	extra-ltng		10	15	res-all		20	20	hp		35	50	charged	138	60	8																						0
-Soul Stinger	1141	100	1			3		1	18	ob3	Smoked Sphere		5	5000	dgry	dgry						sor		1	1	rip		1	1	oskill	weaken	2	2	hit-skill	66	75	5	dmg-norm		10	20	manasteal		35	35																										0
-Zapcaster	1142	100	1			1		1	27	ob4	clasped orb		5	5000	lgry	lgry						skilltab	4	2	2	pierce-ltng		10	15	abs-ltng		8	12	hit-skill	49	6	5	dmg-min		10	10	dmg-max		25	35	swing2		20	20																						0
-Thought Splinter	1143	100	1			3		1	22	ob4	Clasped Orb		5	5000								enr/lvl	8			skilltab	4	1	2	skilltab	3	1	2	skilltab	5	1	2	heal-kill		5	5	addxp		5	5																										0
-Unseeing Eye	1144	100	1			5		1	26	ob5	dragon stone		5	5000								allskills		1	1	addxp		10	10	cast2		20	20	mana		45	45	ac		70	100	dmg-to-mana		10	15	mana-kill		4	6																						0
-Eternity Cable	1145	100	1			1		1	32	ob5	Dragon Stone		5	5000	blac	blac						sor		2	2	skill-rand	3	36	60	skill-rand	3	36	60	skill-rand	3	36	60	res-all		25	40	str		25	25	dex		15	15																						0
-Terminus Rod	1146	100	1			1		1	36	ob6	glowing orb		5	5000								sor		2	2	extra-fire		10	15	pierce-fire		10	15	abs-fire%		15	20	res-fire		75	75	dex		15	15	enr		15	15																						0
-Dreamsplitter	1147	100	1			3		1	29	ob6	Glowing Orb		5	5000	cgrn	cgrn						allskills		1	1	skill-rand	7	36	60	all-stats		15	25	mag%		15	25	gold%		50	100	sock		2	2	regen		10	15																						0
-Drehya's Globe	1148	100	1			1		1	40	ob7	crystalline globe		5	5000								sor		2	2	extra-cold		10	15	pierce-cold		10	15	abs-cold%		15	20	res-cold		75	75	str		15	15	vit		15	15																						0
-Murdering Shard	1149	100	1			3		1	33	ob7	Crystalline Globe		5	5000	lpur	lpur						dmg-norm		15	30	dmg%		100	150	swing2		40	40	manasteal		100	100	slow		35	35	sor		2	2	heal-kill		10	15																						0
-Starbreaker	1150	100	1			1		1	43	ob8	cloudy sphere		5	5000	blac	blac						sor		2	2	extra-ltng		10	15	pierce-ltng		10	15	abs-ltng%		15	20	res-ltng		75	75	str		15	15	dex		15	15																						0
-Dawn Shadow	1151	100	1			3		1	35	ob8	Cloudy Sphere		5	5000								mana%		25	25	hp%		20	20	allskills		2	2	cast2		25	25	regen-mana		200	200	balance2		30	30	block		25	25																						0
-Manna from Heaven	1152	100	1			1		1	48	ob9	sparkling ball		5	5000	cblu	cblu						sor		1	2	res-all-max		5	15	res-all		50	50	mana/lvl	20			gethit-skill	58	10	12	balance1		15	15	abs-mag		10	20	res-pois-len		50	90																		0
-Desecration Sigil	1153	100	1			3		1	50	ob9	Sparkling Ball		5	5000	whit							oskill	skeleton mastery	5	12	oskill	revive	1	3	oskill	raise skeletal mage	6	10	cast3		40	40	cheap		10	10	mana/lvl	8			sor		2	2	oskill	grim ward	1	1																		0
-Quandry of the Queen	1154	100	1			3		1	39	oba	swirling crystal		5	5000	dgld	dgld						allskills		1	2	vit/lvl	4			enr/lvl	4			str/lvl	3			dex/lvl	3			cast3		30	30	red-dmg%		10	15	regen		8	10	regen-mana		75	75														0
-Star of Bethlehem	1155	100	1			1		1	59	obb	heavenly stone		5	5000	lyel	lyel						aura	99	1	1	aura	120	1	1	aura	123	1	1	allskills		1	1	charged	117	100	5	charged	155	5	25	addxp		5	10																						0
-Haven of Light	1156	100	1			3		1	50	obb	Heavenly Stone		5	5000	whit							sor		2	2	pierce-ltng		30	50	pierce-fire		30	50	pierce-cold		30	50	skill	65	3	3	skill	63	3	3	skill	61	3	3	mana-kill		4	7																		0
-Utterance of Power	1157	100	1			1		1	65	obc	eldritch orb		5	5000	cgrn	cgrn						extra-fire		35	50	extra-cold		35	50	extra-ltng		35	50	charged	154	200	7	charged	91	20	5																														0
-Star of David	1158	100	1			1		1	72	obd	demon heart		5	5000								allskills		2	2	dex		25	25	enr		25	25	ac%		25	25	heal-kill		15	25	res-mag		65	65	move2		20	20	sock		1	1																		0
-Soul Of The Tanar'Ri	1159	100	1			3		1	68	obd	Demon Heart		5	5000	blac	blac						allskills		1	1	red-dmg%		20	20	abs-fire%		15	20	abs-cold%		15	20	abs-ltng%		15	20	fade		1	1	move3		30	30	mana%		40	40																		0
-Unity of Mind	1160	100	1			3		1	73	obe	vortex orb		5	5000	oran	oran						sor		2	2	mana/lvl	24			dmg-to-mana		25	25	regen-mana		100	100	skill	58	7	7	cast3		50	50	res-all		40	40	addxp		5	5																		0
-Athena's Tirade	1161	100	1			1		1	78	obe	Vortex Orb		5	5000								sor		3	3	aura	conviction	5	5	ac		200	200	dmg-to-mana		25	25	all-stats		35	35	regen		25	25	regen-mana		150	150	mag%		50	75	gold%		100	200														0
-Oracle's Riddle	1162	100	1			1		1	84	obf	dimensional shard		5	5000								dmg-min		25	50	dmg-max		175	225	swing3		50	50	manasteal		20	20	ignore-ac		1	1	oskill	valkyrie	7	7	block		25	35	block3		50	50	balance3		40	40	allskills		1	3										0
-Blanched Death	1163	100	1			1		1	8	ne1	preserved head		5	5000				invnec7				ac/lvl	8			skill	69	1	3	skill-rand	2	66	76	res-cold		25	35	gethit-skill	67	8	4	nec		1	1																										0
-Goblin Grin	1164	100	1			3		1	4	ne1	Preserved Head		5	5000	lgrn	lgrn						ac%		40	60	block		15	20	block1		20	20	skill	69	1	2	skill	70	1	2	cast1		15	15																										0
-Paingiver	1165	100	1			1		1	12	ne2	zombie head		5	5000				invnec8				ac		25	40	skilltab	6	1	3	skill	66	1	3	mana		25	25	block		15	25	block1		15	15																										0
-Death's Witness	1166	100	1			3		1	9	ne2	Zombie Head		5	5000	dgry	dgry						ac%		45	65	block		10	20	move2		25	25	nec		1	1	ac		15	25	res-pois		35	35	cast1		15	15																						0
-Death Mauler	1167	100	1			1		1	19	ne3	unraveller head		5	5000								ac%		75	100	skilltab	7	1	3	charged	126	100	10	att		200	200	dmg-norm		5	10	block2		20	20	balance2		25	25																						0
-Scalphunter	1168	100	1			3		1	15	ne3	Unraveller Head		5	5000	lyel	lyel						ac%		50	70	block		20	30	block2		25	25	skilltab	6	1	3	red-dmg		8	10	demon-heal		15	15	cast2		20	20																						0
-Steel Weevil	1169	100	1			1		1	24	ne4	gargoyle head		5	5000	whit							ac%		80	110	skilltab	8	1	3	skill-rand	2	66	89	skill-rand	3	66	89	red-dmg%		10	15	block3		30	30	res-all		20	30																						0
-Sinister Smile	1170	100	1			3		1	20	ne4	Gargoyle Head		5	5000				invnec1				ac%		55	75	balance2		25	25	block2		25	25	nec		1	1	res-ltng		25	40	res-fire		35	50	hp		50	50																						0
-Undead Beholder	1171	100	1			1		1	30	ne5	demon head		5	5000	dyel	dyel						ac		45	60	allskills		1	1	block		25	25	balance2		15	15	move2		20	20	rep-dur	20			heal-kill		8	10	mana-kill		5	7																		0
-Chiaroscuro Visage	1172	100	1			3		1	26	ne5	Demon Head		5	5000	lred	lred						ac%		60	80	block		25	35	swing2		20	20	skilltab	7	1	3	dmg-norm		10	20	crush		35	35	dmg-pois	175	100	100	cast2		25	25																		0
-King Tut	1173	100	1			1		1	35	ne6	mummified trophy		5	5000								ac%		110	140	nec		1	2	gold%		100	100	mag%/lvl	8			block		20	40	block2		25	25	skill-rand	2	66	95	skill-rand	3	66	95																		0
-Janus' Face	1174	100	1			3		1	29	ne6	Mummified Trophy		5	5000				invnec2				ac%		90	110	balance3		25	25	block2		20	20	skilltab	8	1	3	mana-kill		3	5	pierce-pois		25	25	dmg-to-mana		10	15	cast2		20	20																		0
-Mystery of Life	1175	100	1			1		1	39	ne7	fetish trophy		5	5000								ac		75	125	skill	69	4	6	skill	70	3	5	skill	80	2	4	skill	95	1	3	hp%		20	20	hp/lvl	8			heal-kill		10	10	addxp		3	5														0
-Carrion Comfort	1176	100	1			3		1	33	ne7	Fetish Trophy		5	5000	lpur	lpur						ac%		100	140	block		15	40	balance2		25	25	skill-rand	3	66	95	skill-rand	2	76	95	skill-rand	1	88	95	abs-mag		8	12	cast2		25	25																		0
-Fallen Hero's Disgrace	1177	100	1			1		1	43	ne8	sextan trophy		5	5000	dgry	dgry						ac/lvl	16	140		nec		2	2	dex		30	30	str		30	30	block		25	50	red-dmg		10	15	red-mag		10	15	death-skill	59	100	37																		0
-Rictus of the Joker	1178	100	1			3		1	36	ne8	Sexton Trophy		5	5000				invnec6				ac%		100	150	block		25	50	block2		30	30	skilltab	6	1	3	nec		2	2	sock		2	2																										0
-Vow of Revenge	1179	100	1			1		1	47	ne9	cantor trophy		5	5000								ac%		120	170	skilltab	7			nec		2	2	block		25	50	death-skill	chain lightning	100	51	dex		20	20	res-fire		50	50	res-ltng		50	50	res-pois-len		50	95														0
-Dreamsender	1180	100	1			3		1	40	ne9	Cantor Trophy		5	5000	blac	blac						ac%		120	170	balance3		25	25	move2		25	25	nec		2	2	mag%		50	50	str		20	20	dex		20	20	rep-dur	10			dur		100	100														0
-Putrid Defiler	1181	100	1			1		1	52	nea	heirophant trophy		5	5000				invnec3				ac		135	170	skilltab	8			nec		2	2	block		35	35	levelup-skill	nova	100	60	vit		20	20	res-pois		50	50	res-cold		50	50	nofreeze		1	1														0
-Venomlord's Visage	1182	100	1			1		1	55	neb	minion skull		5	5000	dgrn	dgrn						ac%		150	200	oskill	inferno	15	20	res-fire		75	100	allskills		1	1	demon-heal		35	50	skill-rand	3	66	95	skill-rand	3	66	95	addxp		3	5																		0
-Reaper's Trophy	1183	100	1			3		1	49	neb	Minion Skull		5	5000								ac%		130	180	block		20	40	block2		30	30	allskills		2	2	hp/lvl	9			mana/lvl	9			res-cold		45	45	rip		1	1																		0
-Devil's Advocate	1184	100	1			1		1	63	neg	hellspawn skull		5	5000				invnec10				ac		150	200	block		25	35	balance3		40	40	mana-kill		10	10	regen-mana		50	50	oskill	warmth	1	1	skill	95	4	7	sock		2	2																		0
-Dreadmother	1185	100	1			3		1	57	neg	Hellspawn Skull		5	5000	oran	oran						ac%		160	200	balance2		25	25	move2		25	25	skilltab	7	1	3	oskill	poison javelin	5	8	oskill	plague javelin	5	8	pierce-pois		20	20	extra-pois		20	20	skill	92	5	5														0
-Nihlathak's Spirit	1186	100	1			1		1	71	ned	overseer skull		5	5000				invnec4				ac/lvl	12			skill	74	8	15	skill	95	1	3	move2		20	20	oskill	teleport	3	3	mana/lvl	12			red-dmg		15	15	res-all		25	35																		0
-Basilisk's Kiss	1187	100	1			3		1	66	ned	Overseer Skull		5	5000								ac%		200	300	block		50	60	block3		45	45	red-dmg%		20	30	sock		2	2	dmg-to-mana		10	15	cast2		30	30																						0
-Prayer for the Dying	1188	100	1			1		22	22	nee	succubae skull		5	5000				invnec9				ac%		150	200	rip		1	1	addxp		10	10	nec		3	3	block		50	50	sock		2	2																										0
-Ravings of the Mad	1189	100	1			1	1	1	86	nef	bloodlord skull		5	5000				invnec5				ac		200	300	mag%		65	65	gold%		150	150	all-stats		25	25	cast3		40	40	pierce		100	100	oskill	sword mastery	8	12	swing2		20	20	dmg-norm		10	30	nec		1	2										0
-Validator	1190	100	1			1		1	8	pa1	targe		5	5000				invshld25				ac		20	25	block		15	25	block1		15	15	res-all		15	20	dmg%		15	20	dmg-max		4	9	swing1		10	10																						0
-Seafarer's Security	1191	100	1			3		1	5	pa1	Targe		5	5000	lblu							ac		10	15	dmg%		15	25	block		20	25	sock		2	2																																		0
-Swiftfoot Slash	1192	100	1			1		1	17	pa2	rondache		5	5000								ac%		75	100	block		20	30	block1		15	15	dmg%		20	30	swing2		20	20	move2		20	20	balance2		25	25																						0
-Grip of the Gorgon	1193	100	1			3		1	10	pa2	Rondache		5	5000	cgrn	cgrn						ac%		50	80	block		15	30	str		25	25	skilltab	10	1	3	slow		15	25	howl		75	75																										0
-Felix's Brace	1194	100	1			1		1	22	pa3	heraldic shield		5	5000	oran	oran						ac%		75	100	block		25	35	block2		20	20	dex		15	15	res-all		15	25	red-dmg		10	15	balance3		40	40																						0
-Secret of Steel	1195	100	1			3		1	15	pa3	Heraldic Shield		5	5000								ac%		75	100	ac		20	40	red-dmg%		10	20	ease		-15	-15	block		15	15	block2		25	25	balance2		25	25																						0
-Bastion of Hope	1196	100	1			3		1	20	pa4	aerin shield		5	5000	cgrn	cgrn						ac%		90	130	block		25	35	block2		20	20	str		20	20	vit		15	15	addxp		3	5	pal		1	1	res-all		15	25																		0
-Hellchatter	1197	100	1			1		1	27	pa4	Aerin Shield		5	5000	dred	dred						ac		40	50	pal		1	1	res-all		60	70	dmg-fire		16	24	hit-skill	76	10	7	rep-dur	7			dur		45	45																						0
-King's Guard	1198	100	1			3		1	25	pa5	crown shield		5	5000	cred	cred						ac		75	120	block		30	40	block2		20	20	dmg%		20	30	red-dmg%		15	15	res-mag		15	15	lifesteal		5	5	cheap		10	15																		0
-Devourer of Worlds	1199	100	1			1		1	32	pa5	Crown Shield		5	5000	blac	blac						ac%		75	100	dmg%		25	50	sock		2	4	pal		1	2																																		0
-Death to the Soul	1200	100	1			1		1	37	pa6	akaran targe		5	5000	blac	blac						ac%		120	150	block		30	45	balance2		25	25	allskills		1	1	res-all		40	60	rip		1	1	sock		1	1	charged	258	5	12																		0
-Twilight Presence	1201	100	1			3		1	30	pa6	Akaran Targe		5	5000	lgry	lgry						ac%		100	140	stupidity		3	3	att%		25	25	dmg-demon		100	100	move2		30	30	block		25	25	balance2		25	25																						0
-Knight's Holy Sigil	1202	100	1			1		1	41	pa7	akaran rondache		5	5000	whit	whit						ac/lvl	16			block		35	45	block2		30	30	dmg-demon		200	200	dmg-undead		200	200	dmg%		30	40	att%		25	25	pal		1	2	skill	117	2	3														0
-Voice of the Prophet	1203	100	1			3		1	34	pa7	Akaran Rondache		5	5000								charged	138	1	30	charged	149	1	30	charged	155	1	30	res-all		40	40	allskills		2	2	hp%		15	15	rip		1	1																						0
-Defender of Innocence	1204	100	1			1		1	45	pa8	protector shield		5	5000								ac%		120	160	ac		35	50	block		25	30	balance2		35	35	aura	104	5	8	gethit-skill	40	17	1	res-mag		15	15																						0
-Black Rain	1205	100	1			3		1	39	pa8	Protector Shield		5	5000	blac	blac						ac%		100	150	res-fire		50	50	res-cold		35	35	dmg-ltng		10	100	stupidity		2	2	kill-skill	Static Field	100	3	aura	118	5	8																						0
-Crusader's Will	1206	100	1			1		1	50	pa9	guilded shield		5	5000	oran	oran						ac%		125	175	block		35	35	balance2		20	20	cast3		40	40	mana		70	125	mana-kill		6	10	all-stats		10	10	pal		2	2																		0
-Wisdom of Thoth	1207	100	1			3		1	46	paa	royal shield		5	5000	dpur	dpur						ac		100	150	allskills		2	2	skilltab	10	1	3	enr		25	25	addxp		3	5	res-all		30	60	sock		2	2																						0
-Grand Inquisitor	1208	100	1			1		1	54	paa	Royal Shield		5	5000								ac%		125	200	block		35	35	block3		50	50	balance3		50	50	addxp		10	15	dmg%		50	50	pal		3	3	res-all-max		10	10																		0
-Ancients' Epiphany	1209	100	1			3		1	55	pab	sacred targe		5	5000	dgld	dgld						ac		125	225	block		50	60	block3		30	30	dmg%		60	60	dmg/lvl	2			charged	138	25	7	charged	149	25	7	charged	155	25	7																		0
-Cleric's Rebuke	1210	100	1			1		1	72	pab	Sacred Targe		5	5000				invshld32				ac		150	200	aura	thorns	15	20	gethit-skill	82	15	5	res-all		75	75	pal		2	2	gold%		200	200	mag%/lvl	8			regen		10	15																		0
-Dawn Blesser	1211	100	1			1		1	68	pac	sacred rondache		5	5000	lyel	lyel						ac%		150	200	dmg%		35	50	res-all		35	50	red-dmg%		15	25	abs-fire%		10	15	abs-ltng%		15	15	abs-cold%		15	20	res-pois-len		50	50	pal		2	2														0
-Faith's Promise	1212	100	1			3		1	70	pad	ancient shield		5	5000	dyel	dyel						ac		150	200	block		35	35	balance2		30	30	aura	108	5	7	skill-rand	8	96	125	rep-dur	12			demon-heal		10	15																						0
-Dawnfall	1213	100	1			1		1	77	pad	Ancient Shield		5	5000								gethit-skill	62	3	30	ac%		140	200	red-dmg%		35	35	res-all		50	75	skill-rand	3	96	125	move2		25	25	swing3		30	30																						0
-God's Word	1214	100	1			1		1	81	pae	zakarum shield		5	5000	cblu	cblu						ac/lvl	24			dmg%		50	50	dmg-norm		15	40	sock		4	4	pal		1	3																														0
-Valorsong	1215	100	1			2		1	12	paf	vortex shield		5	5000	oran	oran						allskills		2	2	ac/lvl	19			res-all		60	100	gethit-skill	149	5	4	gethit-skill	138	5	4	openwounds		88	88	dmg-to-mana		15	20	oskill	warmth	1	1																		0
-Fortress of Morpheus	1216	100	1			1		1	88	paf	Vortex Shield		5	5000								pal		4	4	ac%		175	175	red-dmg%		10	15	res-all		30	50	sock		4	4																														0
-Madman's Bluster	1217	100	1			1		1	12	ba1	jawbone cap		5	5000								ac%		75	100	res-all		10	20	skill	130	1	3	dmg-max		4	6	dmg-min		1	2	swing1		10	10	balance2		20	20	enr		-5	-5																		0
-Chaos Kin	1218	100	1			3		1	6	ba1	Jawbone Cap		5	5000		oran						ac		10	15	bar		1	1	red-dmg		3	5	dmg-max		8	12	res-ltng		15	25	howl		66	66																										0
-Pitykiller	1219	100	1			3		1	11	ba2	fanged helm		5	5000								ac		20	40	dmg%		15	15	levelup-skill	frozen armor	100	25	res-fire		20	30	res-cold		25	25	nofreeze		1	1																										0
-Darkhunger	1220	100	1			1		1	18	ba2	Fanged Helm		5	5000		cred						ac		10	20	stupidity		2	2	res-all		10	15	lifesteal		5	8	heal-kill		3	5	skilltab	12	1	3																										0
-Kygragond	1221	100	1			1		1	23	ba3	horned helm		5	5000				invhelm34				ac%		90	120	skilltab	12	1	3	block		15	15	block1		15	15	move1		10	10	manasteal		3	3	mana-kill		2	4																						0
-Dragonkin	1222	100	1			3		1	17	ba3	Horned Helm		5	5000		dgrn						ac%		50	75	dur		25	25	rep-dur	20			att		125	125	dmg-fire		10	20	block		15	15	red-dmg%		5	10																						0
-Invader's Glee	1223	100	1			1		1	27	ba4	assault helm		5	5000								ac%		100	125	lifesteal		3	5	gold%		75	75	mag%		25	25	rep-dur	15			dur		25	25	openwounds		44	44	skilltab	13	1	3																		0
-Blood Dancer	1224	100	1			3		1	22	ba4	Assault Helmet		5	5000		dred						ac		25	50	bloody		1	1	noheal		1	1	move3		25	25	dex		15	15	hp		25	25	res-cold		25	25	res-fire		20	35																		0
-Warsummoner	1225	100	1			1		1	31	ba5	avenger guard		5	5000								ac%		100	125	skilltab	14	1	3	oskill	revive	2	2	addxp		3	5	res-pois		35	35	abs-fire		8	10	abs-ltng		8	10	str		15	20																		0
-Chimera's Chaos	1226	100	1			3		1	26	ba5	Avenger Guard		5	5000		lyel						ac%		100	140	dmg%		25	25	red-dmg%		10	10	res-all		15	15	oskill	inferno	6	10	str		20	20																										0
-Helms Deep	1227	100	1			1		1	35	ba6	jawbone visor		5	5000	dgrn	dgrn						ac		100	120	dmg%		30	50	red-dmg%		15	15	res-mag		15	15	indestruct		1	1	all-stats		10	15	hp		50	75																						0
-Deadgaze	1228	100	1			3		1	30	ba6	Jawbone Visor		5	5000	dgry	blac						ac%		100	150	rip		1	1	howl		99	99	manasteal		8	8	mana		35	50	res-ltng		25	25	block		15	15																						0
-Malefactor's Reward	1229	100	1			1		1	40	ba7	lion helm		5	5000	lyel							ac%		110	135	bar		2	2	oskill	bone armor	3	3	oskill	life tap	1	1	regen		3	5	res-pois-len		50	50	half-freeze		1	1	balance2		20	20																		0
-Gambler's Glory	1230	100	1			3		1	33	ba7	Lion Helm		5	5000	dgld	lpur						ac		50	100	gold%		100	100	mag%/lvl	8			bar		1	1	skilltab	12	1	3	balance2		20	20	swing1		15	15																						0
-Primal Lust	1231	100	1			1		1	43	ba8	rage mask		5	5000				invhelm31				ac%		150	170	dmg-max		15	20	dmg-min		3	5	balance3		30	30	swing1		15	15	block2		20	20	vit		15	15	str		10	10																		0
-Slayer's Glee	1232	100	1			3		1	36	ba8	Rage Mask		5	5000	whit							ac%		125	150	skill	147	5	5	skill	152	2	2	bar		1	1	kill-skill	decrepify	50	1	gethit-skill	77	25	2	regen		10	10																						0
-Hanabal's Crown	1233	100	1			1		1	46	ba9	savage helm		5	5000	cgrn	cgrn						ac%		150	200	dur		75	75	allskills		2	2	skilltab	13	1	1	cheap		15	15	hp%		10	10	skill-rand	3	126	155	skill-rand	2	126	155																		0
-Hellraiser's Casque	1234	100	1			3		1	39	ba9	Savage Helmet		5	5000	lred							ac%/lvl	16			rep-dur	9			bar		2	2	heal-kill		10	10	addxp		5	5	sock		2	3																										0
-Vanguard	1235	100	1			1		1	51	baa	slayer guard		5	5000		blac						ac		150	190	bar		1	1	skill-rand	5	126	155	skill-rand	4	126	155	skill-rand	3	126	155	red-dmg		20	30	res-mag		20	30	abs-fire		10	20	block		25	25														0
-Conqueror's Feast	1236	100	1			3		1	50	bab	carnage helm		5	5000	lred	lred						ac/lvl	14			ac		75	100	heal-kill		10	15	regen		10	15	mana		50	50	move2		20	20	sock		2	2	res-all		25	25																		0
-Foul Embrace	1237	100	1			1		1	57	bab	Carnage Helm		5	5000	dgrn	dgrn						ac%		150	200	allskills		3	3	dmg-pois	200	1200	1200	res-all		55	75	regen		-12	-12	dmg-to-mana		10	10	manasteal		6	8	regen-mana		100	100																		0
-Death Knight's Mask	1238	100	1			1		1	66	bac	fury visor		5	5000				invhelm35				ac		200	240	skilltab	12	2	4	skilltab	13	2	4	skilltab	14	2	4	lifesteal		10	10	manasteal		8	8	howl		50	50	freeze		3	3																		0
-Wasteland Visage	1239	100	1			1		1	74	bad	destroyer helm		5	5000								ac%		150	200	regen		-2	-2	bar		2	2	dmg-norm		10	15	hp		60	60	res-cold		50	50	res-fire		40	50	res-ltng		31	40	crush/lvl	4																0
-Insight of the Ancients	1240	100	1			1		1	82	bae	conqueror helm		5	5000	dgld	dgld						ac%		100	140	ethereal		1	1	rep-dur	50			enr		40	40	addxp		20	20	bar		2	2																										0
-Archon's Ache	1241	100	1			3		1	81	baf	guardian crown		5	5000	cblu	cblu						ac%		180	210	dmg%		35	35	swing2		20	20	crush		33	33	deadly		50	50	wounds/lvl	12			dmg/lvl	4			charged	87	33	15																		0
-Conscience of the King	1242	100	1			1		1	87	baf	Guardian Crown		5	5000								ac		200	300	res-all		25	25	red-dmg%		15	15	allskills		1	3	mag%		50	50	addxp		5	10	block		20	30	all-stats		20	30	slow		20	30														0
-Morning After	1243	100	1			1		1	12	dr1	wolf head		5	5000								ac%		100	120	regen		8	12	skilltab	15	1	2	dmg%		20	20	mana-kill		5	5	sock		1	1																										0
-Blood Brother	1244	100	1			3		1	4	dr1	Wolf Head		5	5000	lred	lred						ac%		50	75	lifesteal		5	8	hp		25	25	mana		20	20	skill	223	1	3	skill	224	1	3																										0
-Swift Slaughter	1245	100	1			1		1	16	dr2	hawk helm		5	5000								ac%		105	125	dmg-max		6	10	swing2		20	20	lifesteal		5	5	skilltab	16	1	2	att		75	75																										0
-Copperbite	1246	100	1			3		1	8	dr2	Hawk Helm		5	5000	lgld	lgld						ac%		55	75	ac		10	15	rep-dur	7			res-pois		55	55	dmg-pois	100	100	100	dru		1	1																										0
-Yamanda's Token	1247	100	1			1		1	21	dr3	antlers		5	5000								ac%		110	130	dru		1	1	block		15	25	extra-fire		10	10	skill	226	1	3	rep-dur	15			dmg-to-mana		5	10																						0
-Silverskin	1248	100	1			3		1	14	dr3	Antlers		5	5000	whit	whit						ac		35	45	red-dmg		8	10	move2		25	25	skilltab	16	1	3	deadly		15	25	dmg-cold		10	15	freeze		2	2																						0
-Voltar's Feather	1249	100	1			1		1	24	dr4	falcon mask		5	5000	dgry	dgry						ac%		115	135	res-mag		15	15	dmg-ltng		1	75	res-ltng		25	25	enr		25	25	move2		15	15																										0
-Eye of Heaven	1250	100	1			3		1	19	dr4	Falcon Mask		5	5000								ac%		65	100	half-freeze		1	1	enr		15	15	vit		15	15					cast2		25	25																										0
-Lion's Pride	1251	100	1			1		1	30	dr5	spirit mask		5	5000	dyel	dyel						ac%		120	140	str		20	20	deadly		20	20	dmg-min		5	5	balance2		20	20	str/lvl	6			mag%		30	30																						0
-Wraith Whisper	1252	100	1			3		1	25	dr5	Spirit Mask		5	5000	dgry	dgry						ac%		80	110	dru		1	1	skilltab	17	1	2	light		3	5	ethereal		1	1	rep-dur	15			res-cold/lvl	8																								0
-Moonshadow	1253	100	1			3		1	29	dr6	alpha helm		5	5000	blac	blac						ac%		150	180	fade		1	1	res-ltng		15	30	hp		20	40	heal-kill		10	10	ac/lvl	8			charged	267	15	3																						0
-The King's Heart	1254	100	1			1		1	34	dr6	Alpha Helm		5	5000								ac%		100	125	allskills		1	1	res-all		25	25	dmg%		25	25	skill	238	7	7	hp%		20	25																										0
-Gathering of Hawks	1255	100	1			1		1	38	dr7	griffon headress		5	5000	lred	lred						ac		75	100	skill	221	4	4	skill-rand	1	221	250	skill-rand	2	221	250	skill-rand	3	221	250	res-cold/lvl	8			hp/lvl	4			res-fire/lvl	4																				0
-Creeper's Canopy	1256	100	1			3		1	33	dr7	Griffon Headress		5	5000				invhelm14				ac%		100	135	skill	223	5	7	skill	232	5	7	skill	242	5	7	howl		75	75	balance2		25	25	regen-mana		50	50																						0
-Centaur's Sight	1257	100	1			3		1	37	dr8	hunters guise		5	5000	oran	oran						ac%		155	185	skill-rand	2	221	250	skill-rand	3	221	250	skilltab	17	2	2	balance2		20	20	ignore-ac		1	1	stamdrain		35	35	dmg-undead		75	75																		0
-Night Prowler	1258	100	1			1		1	43	dr8	Hunter's Guise		5	5000	blac	blac						ac%		120	150	dru		2	2	skilltab	15	1	2	move3		50	50	balance2		25	25	swing2		15	15	block3		40	40																						0
-Phoenix Fall	1259	100	1			1		1	46	dr9	sacred feathers		5	5000	cred	cred						ac%		160	190	dmg-fire		35	100	dru		1	1	extra-fire		10	15	res-all		25	25	light		1	3	sock		1	1																						0
-Falcon Sharp	1260	100	1			3		1	40	dr9	Sacred Feathers		5	5000								ac%		125	150	dmg%		50	50	res-all		20	20	dmg-ltng		15	250	dmg-fire		25	60	oskill	inner sight	2	4	all-stats		15	15	skilltab	16	1	2																		0
+Weeping at the Gate	805	100	1			3	1	33	43	9pi	great pilum		5	5000	lgrn	lgrn						dmg%		200	250	rep-quant	25			stack		65	65	mana		65	65	dmg-to-mana		25	25	regen-mana		150	150	red-dmg%		10	15																						0
+Trump of Jericho	806	100	1			5	1	18	35	9pi	Great Pilum		5	5000	lyel	lyel						dmg%		150	200	rep-quant	30			mag%		35	50	ac/lvl	10			swing2		25	25	str		25	25	dex		25	25																						0
+Artimus's Spiculum	807	100	1			1	1	55	61	9s9	simbilan		5	5000	oran	oran						dmg%		100	125	dmg-norm		40	80	dmg/lvl	6			stack		75	75	mag%		35	35	pierce-ltng		25	25	extra-ltng		10	15																						0
+Cursed One	808	100	1			3	1	37	47	9s9	simbilan		5	5000	blac	blac						dmg%		200	250	rep-quant	25			stack		70	70	gethit-skill	81	12	7	regen		-1	-1	dmg/lvl	6			str		15	25																						0
+Hatemonger	809	100	1			5	1	26	38	9s9	Simbilan		5	5000				invjav7				dmg%		140	225	ac-hth		200	300	regen		10	15	manasteal		7	7	lifesteal		7	7	dmg-throw		20	40	oskill	attract	5	5																						0
+Confusion Flight	810	100	1			1	1	55	65	9gl	spiculum		5	5000	cred	cred						dmg%		110	140	dmg-norm		45	90	dmg/lvl	7			stack		100	100	rep-quant	40			stupidity		2	2	swing2		20	20	red-dmg		15	20	red-mag		25	25														0
+Blessed One	811	100	1			3	1	40	50	9gl	spiculum		5	5000	whit	whit						dmg%		215	265	rep-quant	25			stack		75	75	aura	99	5	15	block		25	25	ac		70	100	all-stats		10	10	allskills		1	1																		0
+Warbreeder	812	100	1			5	1	20	41	9gl	Spiculum		5	5000	blac	blac						dmg%		175	235	rep-quant	35			res-all		40	50	hp		75	75	oskill	charged strike	6	6	pierce-ltng		35	35	slow		15	15	dmg-ltng		1	250																		0
+Silver-Tipped Harpoons	813	100	1			1	1	55	69	9ts	harpoon		5	5000	whit	whit						dmg%		120	150	dmg-norm		40	80	dmg/lvl	8			stack		45	45	allskills		2	2	res-all		20	30	dmg-undead		200	200	thorns		20	30	dmg-ltng		15	150														0
+Blessings of Osiris	814	100	1			3	1	44	54	9ts	harpoon		5	5000	oran	oran						dmg%		225	270	rep-quant	25			stack		80	80	oskill	lightning fury	3	5	pierce-ltng		10	10	res-ltng		35	60	abs-ltng%		15	15	hp%		10	15																		0
+Bowel Twister	815	100	1			5	1	32	45	9ts	Harpoon		5	5000				invjav8				dmg%		180	240	rep-quant	35			stack		100	100	aura	118	9	15	res-ltng		65	65	abs-ltng%		35	35	noheal		1	1																						0
+Jaguar's Claw	816	100	1			1	1	62	70	7ja	hyperion javelin		5	5000	dyel	dyel						dmg%		225	275	rep-quant	40			stack		40	40	reduce-ac		15	20	bloody		1	1	deadly/lvl	8			lifesteal		7	7																						0
+Arc of the Rainbow	817	100	1			2	1	45	55	7ja	Hyperion Javelin		5	5000								dmg%		180	250	ac-miss		200	300	dmg-fire		75	200	dmg-ltng		10	300	dmg-cold	200	100	140	swing3		40	40	addxp		5	10	gold%		200	200																		0
+Woundripper	818	100	1			2	1	52	61	7pi	stygian pilum		5	5000				invjav10				dmg%		225	275	rep-quant	20			stack		65	65	heal-kill		10	10	noheal		1	1	openwounds		88	88	oskill	plague javelin	5	5	block2		25	25																		0
+Summerstrike	819	100	1			1	1	23	23	7pi	Stygian Pilum		5	5000	cred	cred						dmg%		200	250	rep-quant	30			dmg-fire		300	500	abs-fire%		40	50	ethereal		1	1	stack		75	75																										0
+Clockwork Horror	820	100	1			1	1	69	77	7s7	balrog spear		5	5000				invjav4				dmg%		230	280	rep-quant	25			stack		50	50	crush		22	33	howl		41	41	move2		25	25	str/lvl	5			dex/lvl	5																				0
+Invisible Stalker	821	100	1			1	1	1	81	7gl	ghost glaive		5	5000								dmg%		250	300	stack		300	300	dmg/lvl	8			allskills		1	1	fade		1	1	oskill	quickness	3	3	move3		60	60																						0
+Spectral Slayer	822	100	1			1	1	20	20	tax	throwing axe		5	5000	dgry	dgry						dmg%		80	80	dmg-norm		20	40	stack		50	50	rep-quant	15			bar		1	1	fade		1	1	ethereal		1	1																						0
+Tonguecutter	823	100	1			3	1	1	10	tax	throwing axe		5	5000				invaxe17				dmg%		100	150	rep-quant	20			stack		75	75	bloody		1	1	lifesteal		5	7	manasteal		5	7	bar		1	1																						0
+Solstice Edge	824	100	1			5	1	1	6	tax	Throwing Axe		5	5000	oran	oran						dmg-throw		4	12	stack		60	60	rep-quant	45			dmg-fire		3	9	mag%		20	30	knock		1	1																										0
+Oakplume	825	100	1			1	1	28	35	bal	balanced axe		5	5000								dmg%		80	120	dmg-norm		30	60	stack		75	75	rep-quant	50			skill	140	3	3	swing2		20	20	balance2		20	20	res-pois		35	35	lifesteal		6	6														0
+Timbersplitter	826	100	1			3	1	10	27	bal	balanced axe		5	5000	lgrn	lgrn						dmg%		175	200	rep-quant	20			stack		75	75	pierce		25	25	oskill	critical strike	1	1	openwounds		35	35	res-ltng		15	15	abs-ltng%		5	5																		0
+Spleen Feaster	827	100	1			5	1	8	22	bal	Balanced Axe		5	5000	dgrn	dgrn						dmg-norm		10	20	stack		60	60	dmg-pois	150	122	122	noheal		1	1	dex		15	15	att%		30	30	deadly		20	40																						0
+Banshee's Cry	828	100	1			1	1	55	50	9ta	francisca		5	5000								dmg%		120	140	dmg-norm		25	50	dmg-throw		25	40	skilltab	13	2	2	howl		122	122	hit-skill	48	4	5	slow		25	25	knock		2	2																		0
+Despicable Behavior	829	100	1			3	1	32	43	9ta	francisca		5	5000	dblu	dblu						dmg%		200	250	rep-quant	25			stack		60	60	bar		2	2	att%		25	25	swing2		20	20	block3		30	30	hit-skill	59	5	7																		0
+Axes of Jahadra	830	100	1			1	1	55	60	9b8	hurlbat		5	5000	lpur	lpur						dmg%		125	150	dmg-norm		30	60	dmg-throw		30	50	allskills		1	1	mag%		25	35	hit-skill	51	3	1	thorns		25	35	red-mag		10	15																		0
+Instigator	831	100	1			3	1	45	54	9b8	hurlbat		5	5000	dgld	dgld						dmg%		225	270	rep-quant	25			stack		60	60	bar		2	2	manasteal		6	6	swing2		25	25	balance3		30	30	gethit-skill	42	7	4																		0
+Brainraver	832	100	1			5	1	36	47	9b8	Hurlbat		5	5000								dmg%		165	225	rep-quant	30			stack		45	45	swing3		40	40	allskills		1	1	stupidity		2	2	slow		50	50																						0
+Winged Serpent	833	100	1			1	1	72	77	7ta	flying axe		5	5000	cgrn	cgrn						dmg%		250	300	rep-quant	15			stack		70	70	bar		1	2	dmg-pois	200	1250	1250	res-all		25	30	charged	54	255	1	str		20	20																		0
+Golden Wyndlass	834	100	1			1	1	80	85	7b8	winged axe		5	5000	dgld	dgld						dmg%		250	300	rep-quant	50			skilltab	14	1	3	ignore-ac		1	1	swing2		20	20	stupidity		2	2	mana		50	50	oskill	redemption	3	3	move2		20	20														0
+Sheera's Knives	835	100	1			1	1	25	22	tkf	throwing knife		5	5000	dred	dred						dmg%		60	80	dmg-norm		20	40	stack		50	50	rep-quant	20			ac-hth		100	100	pierce		20	20	red-dmg		6	10	res-all		15	15																		0
+Subtle Slice	836	100	1			3	1	1	7	tkf	throwing knife		5	5000	lyel	lyel						dmg%		100	150	rep-quant	20			stack		75	75	dmg-norm		4	8	deadly		35	35	dmg-pois	125	55	55	gethit-skill	36	14	3	dex		10	10																		0
+Splinterbeam	837	100	1			5	1	1	4	tkf	Throwing Knife		5	5000	lgld	dgrn						dmg%		65	100	rep-quant	25			swing2		25	25	manasteal		3	6	res-cold		25	35	res-ltng		25	35	reduce-ac		10	15																						0
+Deadly Needle	838	100	1			1	1	32	38	bkf	balanced knife		5	5000								dmg%		85	105	dmg-norm		25	50	stack		90	90	rep-quant	25			str		15	15	deadly/lvl	9			res-fire		20	30	res-ltng		20	30																		0
+Initiator	839	100	1			3	1	8	22	bkf	balanced knife		5	5000	oran							dmg%		170	200	rep-quant	25			stack		75	75	dmg-throw		8	20	swing2		25	25	slow		20	20	aura	108	4	4	str		15	15	ease		-15	-15														0
+Dead Scoffer	840	100	1			5	1	6	19	bkf	Balanced Knife		5	5000	blac							dmg-throw		10	20	dmg%		75	110	stack		100	100	heal-kill		8	10	oskill	raise skeleton	3	5	dmg-undead		350	350																										0
+Swarming Blades	841	100	1			1	1	55	57	9tk	battle dart		5	5000		cblu						dmg%		100	100	dmg/lvl	12			swing3		60	60	stack		100	100	rep-quant		20	20	hp		50	60	res-pois		25	35	reduce-ac		15	15																		0
+Silt Runner	842	100	1			3	1	32	42	9tk	battle dart		5	5000	dgry	dgry						dmg%		200	250	rep-quant	20			stack		55	55	stupidity		2	2	lifesteal		8	8	move3		35	35	all-stats		20	20	hp		50	65																		0
+Darts of Evermeet	843	100	1			1	1	55	69	9bk	war dart		5	5000								dmg%		120	150	rep-quant	10			stack		60	60	dmg-norm		40	80	allskills		1	1	extra-fire		15	25	dmg-fire		60	120	ac%		20	20	dex		15	20														0
+Ravenstar	844	100	1			3	1	42	52	9bk	war dart		5	5000	lblu							dmg%		220	270	rep-quant	15			stack		75	75	slow		25	25	manasteal		8	8	cast3		30	30	allskills		1	1	mana		30	50																		0
+Pain Harvester	845	100	1			5	1	35	45	9bk	War Dart		5	5000	lpur							dmg%		160	200	stack		75	75	att%		50	50	dex		20	20	str		20	20	bar		2	2	nofreeze		1	1																						0
+Fallen Glory	846	100	1			1	1	20	20	7tk	flying knife		5	5000		dred						dmg%		260	325	stack		65	65	rep-quant	15			allskills		2	2	skilltab	12	1	3	swing2		20	20	oskill	56	2	2	oskill	61	2	2																		0
+Shard of the North Star	847	100	1			2	1	56	64	7tk	Flying Knife		5	5000	lgld	lgld						dmg%		200	300	rep-quant	35			res-all		25	40	lifesteal		5	10	dmg-elem	300	50	100	freeze		3	3	hit-skill	56	12	8																						0
+Frostbite Shard	848	100	1			1	1	75	80	7bk	winged knife		5	5000								dmg%		275	325	rep-quant	20			stack		65	65	dmg-cold		250	300	freeze		6	6	dmg/lvl	6			res-cold		35	50	mana		65	65																		0
+Hungerpang	849	100	1			1	1	1	11	qui	quilted armor		5	5000				invbody20				ac		30	50	regen		-1	-1	hp		65	65	lifesteal		4	6	regen-mana		40	40																														0
+Ashenwrath	850	100	1			3	1	1	6	qui	quilted armor		5	5000				invbody5				ac		20	30	nec		1	1	fireskill		1	1	res-fire		35	35	sock		1	2																														0
+Ogden's Shroud	851	100	1			1	1	1	13	lea	leather armor		5	5000				invbody46				ac		45	65	res-ltng		25	25	balance2		20	20	addxp		2	3	gold%		100	100																														0
+JuJu Flame	852	100	1			3	1	1	8	lea	leather armor		5	5000				invbody49				ac		30	40	sor		1	1	kill-skill	teeth	25	4	charged	36	200	17																																		0
+Armor of Gloom	853	100	1			1	1	1	15	hla	hard leather		5	5000				invbody72				ac		70	85	stupidity		1	1	gethit-skill	71	7	2	res-pois		25	35	vit		10	10	sock		1	1																										0
+Stinkshroud	854	100	1			3	1	1	10	hla	hard leather		5	5000				invbody50				ac		50	65	gethit-skill	72	5	9	ass		1	1	skill-rand	2	252	257	res-pois		35	35																														0
+Scarab of Protection	855	100	1			1	1	2	17	stu	studded leather		5	5000				invbody4				ac		100	115	red-dmg		8	12	res-mag		10	10	res-all		10	20	hp		35	45	block2		15	15																										0
+Gemini Coat	856	100	1			3	1	1	12	stu	studded leather		5	5000				invbody27				ac%		80	100	ac		25	40	ama		1	1	aura	might	1	1	dur%		25	25	dmg-throw		5	10																										0
+The Shadowed One	857	100	1			1	1	4	19	rng	ring mail		5	5000	blac	blac						ac		115	130	light		-3	-3	ass		1	1	move2		20	20	ignore-ac		1	1	mana		25	35																										0
+Steelflesh	858	100	1			3	1	1	14	rng	ring mail		5	5000				invbody2				ac%		125	200	bar		1	1	dmg%		20	25	red-dmg%		10	15	oskill	sacrifice	3	5																														0
+Red Dragon Scails	859	100	1			1	1	6	21	scl	scale mail		5	5000	dred	dred		invbody25				ac		130	150	red-dmg%		10	15	res-fire		45	65	abs-fire%		10	15	pierce-fire		10	15	extra-fire		10	15																										0
+Mandrake's Bloom	860	100	1			3	1	1	16	scl	scale mail		5	5000								ac%		125	170	pal		1	1	gethit-skill	68	5	8	block		10	15	dmg-fire		10	20																														0
+Ghosly Chainmail	861	100	1			1	1	8	23	chn	chain mail		5	5000		whit						ac		155	175	ethereal		1	1	rep-dur	25			res-cold		30	50	pierce-cold		10	15	extra-cold		10	15																										0
+Xanadu Dreams	862	100	1			3	1	3	18	chn	chain mail		5	5000				invbody8				ac%		100	200	dru		1	1	dur%		100	100	hit-skill	71	5	2	res-all		15	25	lifesteal		3	3																										0
+Breastplate of Gond	863	100	1			1	1	10	25	brs	breast plate		5	5000	dgrn			invbody70				ac		180	200	pierce-ltng		10	15	abs-ltng%		10	15	extra-ltng		10	15	res-ltng		40	60	dmg-ltng		1	75																										0
+Shattering Blow	864	100	1			3	1	9	21	brs	breast plate		5	5000				invbody68				ac%		120	150	crush/lvl	8			deadly/lvl	8			dmg-norm		5	10	swing1		15	15																														0
+Starsong	865	100	1			1	1	12	26	spl	splint mail		5	5000	lgry	lgry						ac		205	220	hp		25	50	mana		25	55	mana-kill		3	5	heal-kill		8	12	res-pois		30	50																										0
+Russetfire	866	100	1			3	1	8	22	spl	splint mail		5	5000				invbody35				ac		100	150	mag%		35	50	res-fire		40	50	abs-fire%		20	20	aura	holy fire	3	5	sock		1	2																										0
+Armor of Warmth	867	100	1			1	1	12	28	plt	plate mail		5	5000	dred	cred		invbody71				ac		225	250	oskill	warmth	3	5	att		75	75	dex		15	15	enr		15	15																														0
+Celestial Revelation	868	100	1			3	1	10	25	plt	plate mail		5	5000				invbody21				extra-fire		15	20	extra-cold		15	20	extra-pois		15	20	extra-ltng		15	20	cast1		20	20	ac%		125	150																										0
+Dreamscape	869	100	1			1	1	13	29	fld	field plate		5	5000	blac	blac						ac		260	300	stupidity		2	2	vit		20	20	block		15	15	block2		30	30	sock		1	2																										0
+Ion Storm	870	100	1			3	1	12	26	fld	field plate		5	5000	dgrn	dgrn		invbody43				dmg-elem	200	1	65	ac		150	190	addxp		4	7	sock		3	4																																		0
+A Knight's Tale	871	100	1			1	1	16	30	gth	gothic plate		5	5000	lgry	lgry						ac		300	350	allskills		1	1	sock		4	4																																						0
+Golem's Gain 	872	100	1			3	1	12	26	gth	gothic plate		5	5000				invbody66				ac%		120	200	str		25	25	oskill	golem mastery	8	8	oskill	bloodgolem	2	5	charged	75	5	30	res-all		25	25																										0
+Kaz's Battle Armor	873	100	1			1	1	18	32	ful	full plate mail		5	5000				invbody67				ac		355	400	dmg-norm		5	10	swing1		15	15	balance2		20	20	gethit-skill	58	6	3	mana		35	35																										0
+Halcyon Shroud	874	100	1			3	1	13	28	ful	full plate mail		5	5000				invful				allskills		1	1	res-fire		25	40	res-cold		25	40	res-ltng		25	40	red-dmg		10	20	regen		8	12	ac%		100	200																						0
+Greyhawk Dragon	875	100	1			1	1	19	34	aar	ancient armor		5	5000	dgry	dgry						ac		400	500	balance3		40	40	heal-kill		5	5	addxp		2	3	sock		2	2	res-all		35	35																										0
+Killing Blow	876	100	1			3	1	15	30	aar	ancient armor		5	5000	oran	oran						ac%		150	200	dmg-max		25	25	noheal		1	1	bloody		1	1	deadly		33	33	oskill	attract	2	4	knock		1	1																						0
+Weightless Grace	877	100	1			1	1	17	36	ltp	light plate		5	5000				invbody53				ac		300	400	ease		-50	-50	dex		25	25	allskills		1	1	gold%		50	50	mag%		35	50	hp		50	60																						0
+Madness of Chthulu	878	100	1			3	1	16	30	ltp	light plate		5	5000				invbody19				ac		200	250	ease		25	25	all-stats		20	20	rip		1	1	ignore-ac		1	1	death-skill	poison nova	100	15																										0
+Rainbow Cloak	879	100	1			3	1	18	32	xui	ghost armor		5	5000				invbody23				ac%		100	150	res-all		15	25	allskills		1	1	res-all-max		5	5																																		0
+Gillian's Brazier	880	100	1			1	1	25	41	xui	ghost armor		5	5000				invbody42				ac%		90	125	ama		1	2	ass		1	2	sor		1	2	dex		35	35	str		25	25	cast2		25	25																						0
+Anaconda Skin	881	100	1			1	1	26	42	xea	serpentskin armor		5	5000				invbody13				ac%		110	160	crush		20	40	move2		25	25	res-pois		25	35	str		15	15	red-dmg		10	20	red-mag		10	15																						0
+Scavanger's Carapace	882	100	1			3	1	20	34	xea	serpentskin armor		5	5000				invbody38				ac%		95	130	rep-dur	20			red-dmg%		10	20	res-cold		35	50	res-cold-max		10	10	ac/lvl	10			dmg-und/lvl	24																								0
+Torn Flesh of Souls	883	100	1			1	1	27	43	xla	demonhide armor		5	5000	dgry	dgry						ac%		120	170	dmg-demon		75	75	nec		1	1	skill-rand	3	66	95	skill-rand	3	66	95	cast2		20	20	mana/lvl	6																								0
+The Defiler's Flesh	884	100	1			3	1	17	36	xla	demonhide armor		5	5000				invbody24				ac%		100	150	heal-kill		5	8	mag%		40	40	balance2		25	25	lifesteal		4	6	hp		40	40	skill	83	1	3	skill	89	1	3																		0
+Lilt of the Dryad	885	100	1			1	1	28	44	xtu	trellised armor		5	5000				invbody16				ac%		130	180	swing3		20	20	ama		1	1	skilltab	1	1	2	res-fire		20	40	res-ltng		20	40	slow		15	15																						0
+Cold Comfort	886	100	1			3	1	24	38	xtu	trellised armor		5	5000	dblu	dblu		invbody57				ac%		110	150	ac		200	250	gethit-skill	60	15	8	res-cold		50	50	pierce-cold		15	15	abs-cold%		10	10	extra-cold		5	10	nofreeze		1	1																		0
+Heartbane	887	100	1			3	1	28	41	xng	linked mail		5	5000				invbody17				ac%		135	185	dex		15	15	enr		15	15	heal-kill		5	9	addxp		1	3	red-mag		10	15	red-dmg%		10	15	noheal		1	1																		0
+Adamantine Mail	888	100	1			1	1	12	26	xng	linked mail		5	5000	whit	whit		invrng				ac/lvl	48			ac		150	200	red-dmg%		25	35	sock		3	3	allskills		1	1																														0
+Weakest Link	889	100	1			1	1	32	47	xcl	tigulated mail		5	5000				invbody36				ac%		140	190	rep-dur	15			dmg%		20	30	balance2		20	20	manasteal		6	8	dmg-to-mana		8	8	allskills		1	1																						0
+Panic of Thousands	890	100	1			3	1	30	43	xcl	tigulated mail		5	5000	cblu	cblu		invscl				ac%		125	150	gethit-skill	77	33	3	oskill	enchant	4	4	res-fire		35	50	res-ltng		35	50	dex/lvl	4			dur		100	100																						0
+Drow Chainmail	891	100	1			3	1	31	44	xhn	mesh armor		5	5000	blac	blac						ac%		150	200	ease		-25	-25	extra-fire		10	15	res-all		20	30	all-stats		10	10	hp/lvl	8			mana		40	60																						0
+Disparate Paths	892	100	1			1	1	37	49	xhn	mesh armor		5	5000	oran	oran		invchn				ac%		125	150	dru		1	1	skill-rand	3	221	250	skill-rand	3	221	250	skill-rand	3	221	250	swing1		10	10	res-all		20	30																						0
+Tesla's Cuirass	893	100	1			3	1	35	47	xrs	cuirass		5	5000	dgry	dgry		invbody39				ac%		160	210	dmg/lvl	2			reduce-ac		10	15	move1		15	15	lifesteal		4	4	sock		2	2																										0
+Mother's Milk	894	100	1			1	1	41	51	xrs	cuirass		5	5000	lgry	lgry		invbody58				ac%		125	150	ama		1	1	swing2		25	25	skill-rand	5	6	35	ease		-25	-25	balance2		20	20	aura	113	1	6																						0
+Brimstone Hearth	895	100	1			3	1	40	50	xpl	russet armor		5	5000	dred	dred						ac%		170	220	res-fire		30	50	pierce-fire		20	20	dmg-fire		25	100	nofreeze		1	1	fireskill		2	2	dur		30	30																						0
+Scars of the Forefathers	896	100	1			1	1	45	55	xpl	russet armor		5	5000	lblu	dblu		invbody28				ac%		125	150	ac/lvl	20			bar		1	1	red-dmg%		15	30	skill-rand	3	126	155	dmg%		40	60	block2		20	20	att-skill	82	3	12																		0
+Demonspike Coat	897	100	1			1	1	48	57	xlt	templar coat		5	5000				invbody63				ac%		180	230	dmg-demon		75	75	demon-heal		25	25	lifesteal		6	6	regen		1	4	thorns/lvl	16																												0
+Succulent Sin	898	100	1			3	1	42	52	xlt	templar coat		5	5000		dpur		invbody41				ac%		140	165	ass		1	1	skill-rand	4	251	280	skill-rand	3	251	280	oskill	zeal	1	1	deadly		15	15	vit/lvl	4																								0
+Bloodlust Frenzy	899	100	1			1	1	50	59	xld	sharktooth armor		5	5000	lgrn	lgrn		invbody56				ac		185	235	swing2		20	20	allskills		1	1	skilltab	13	1	1	skill	147	1	4	lifesteal		6	8	hp%		10	20																						0
+Seaflame	900	100	1			3	1	46	55	xld	sharktooth armor		5	5000	oran			invbody59				ac%		150	175	res-all		50	60	red-mag		12	15	heal-kill		8	12	regen		10	12	regen-mana		50	50	mag%		60	60	dur		200	200																		0
+Royal Plate	901	100	1			1	1	51	60	xth	embossed plate		5	5000				invbody33				ac%		190	240	red-dmg%		15	25	res-mag		10	15	res-all		15	30	cheap		5	10	ease		-15	-15	rep-dur	20																								0
+Nightcrawler	902	100	1			3	1	46	56	xth	embossed plate		5	5000	blac	blac		invgth				ac		300	500	oskill	fade	2	4	rip		1	1	sock		4	4	ease		-35	-35																														0
+Shambling Mound	903	100	1			1	1	53	61	xul	chaos armor		5	5000				invbody65				ac/lvl	40			ac%		50	75	res-pois		40	70	dmg-pois	200	400	400	extra-pois		15	15	move1		10	10	sock		2	2																						0
+Evening Sky	904	100	1			3	1	47	57	xul	chaos armor		5	5000		oran		invbody61				ac%		175	210	dmg-fire		75	150	res-fire		75	75	move3		30	30	cast2		20	20	mana		50	50	hp		50	50																						0
+Adamantine Plate	905	100	1			1	1	53	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		30	30	res-all		50	75	rep-dur	20																																				0
+Iceskin	906	100	1			3	1	48	58	xar	ornate armor		5	5000	cblu	cblu		invaar				ac%		180	215	gethit-skill	60	50	8	gethit-skill	64	5	5	res-cold		100	100	extra-cold		15	20	allskills		1	1	block2		25	25																						0
+Plate of Fistindantalas	907	100	1			1	1	55	63	xtp	mage plate		5	5000				invbody54				ac		400	600	ac%		50	75	allskills		1	1	mana/lvl	8			hp/lvl	8			addxp		1	3	sock		2	3																						0
+Serendipity	908	100	1			3	1	50	59	xtp	mage plate		5	5000				invbody47				ac%		185	225	ac/lvl	16			allskills		1	1	cast3		30	30	mana		75	75	mag%		30	30	light		1	3	addxp		5	5																		0
+Blanket of Stars	909	100	1			1	1	58	65	uui	dusk shroud		5	5000				invbody3				ac%		100	200	regen		4	8	regen-mana		50	50	enr		25	25	vit		25	25	block2		25	25	balance3		30	30																						0
+Ancient Dragon	910	100	1			1	1	59	67	uea	wyrmhide		5	5000				invbody14				ac%		100	200	allskills		1	1	mana%		15	25	hp/lvl	16			stupidity		1	1	knock		2	2	sock		1	1																						0
+Crescent of Secrets	911	100	1			2	1	47	57	uea	Wyrmhide		5	5000				invbody11				ac%		75	100	allskills		1	1	gold%		75	75	all-stats		50	50	mag%		50	50	sock		2	2																										0
+Zaratan Hide	912	100	1			1	1	62	69	ula	scarab husk		5	5000				invbody1				ac%		160	200	move3		30	30	red-dmg		35	50	red-mag		20	25	res-cold		75	75	half-freeze		1	1	gold%		100	100																						0
+Aprhodite's Girdle	913	100	1			2	1	52	60	ula	Scarab Husk		5	5000				invbody64				ac		300	500	ama		2	2	sor		2	2	ass		2	2	move3		30	30	enr		35	35	mana		75	75	cast2		20	20																		0
+Wyrmbane	914	100	1			1	1	66	73	utu	wire fleece		5	5000				invbody15				ac%		120	200	allskills		1	1	red-dmg%		10	15	balance2		25	25	dmg-demon		65	65	dex		25	25	ac		150	250																						0
+Adamantine Links	915	100	1			1	1	66	73	ung	diamond mail		5	5000				invbody6				ac%		150	200	red-dmg%		25	35	allskills		1	1	all-stats		10	10	res-fire		35	55	res-ltng		35	55	mag%		40	60																						0
+Feathering Mithril	916	100	1			2	1	57	65	ung	Diamond Mail		5	5000				invbody9				ac%		100	200	ease		-75	-75	red-dmg%		15	20	move3		40	40	rep-dur	30			nofreeze		1	1	hp%		20	20																						0
+Will-O'-Wisp	917	100	1			1	1	68	74	ucl	loricated mail		5	5000	whit	oran						ac%		100	200	allskills		1	2	move3		40	40	oskill	teleport	7	7	ethereal		1	1	rep-dur	25			fade		1	1	oskill	evade	1	1																		0
+Golden Lotus	918	100	1			2	1	60	67	ucl	Loricated Mail		5	5000	dgld	dgld		invbody18				ac%		100	150	gold%		300	300	mag%/lvl	12			res-all-max		5	5	att%		20	25	allskills		1	1																										0
+Chains of the Abyss	919	100	1			2	1	61	68	uhn	boneweave		5	5000	lred	lred						ac%		100	200	red-dmg		20	30	abs-ltng%		20	25	swing1		-5	-5	move1		-5	-5	cast2		25	25	mana		80	120	abs-fire%		20	30																		0
+Tarrasque Hide	920	100	1			1	1	80	86	uhn	Boneweave		5	5000	blac	blac						ac%		200	300	ac		300	500	red-dmg%		30	50	red-mag		35	50	res-fire		50	60	res-ltng		70	80	res-cold		30	50	res-pois		45	80																		0
+Celestial Unicorn	921	100	1			2	1	64	70	urs	great hauberk		5	5000				invbody48				ac%		100	120	allskills		2	2	regen		12	15	aura	109	4	7	mag%		40	50	gold%/lvl	21																												0
+Gray God's Mantle	922	100	1			1	1	72	77	urs	Great Hauberk		5	5000	blac	blac		invbody30				ac%		125	150	allskills		4	4	sock		3	3																																						0
+Diablo's Scale	923	100	1			1	1	73	78	upl	balrog skin		5	5000	oran	lgry		invbody74				ac%		150	200	allskills		1	1	block		25	40	block3		35	35	move2		30	30	res-all		35	65	red-dmg%		20	30																						0
+Hellshifter	924	100	1			1	1	76	80	ult	hellforged plate		5	5000	dred	dred		invbody22				ac%		100	200	pal		2	2	skill-rand	1	96	125	skill-rand	3	96	125	skill-rand	2	96	125	dmg%		30	50	balance2		30	30																						0
+Lunatic Fringe	925	100	1			2	1	66	73	ult	Hellforged Plate		5	5000	dgld	dgld		invbody32				ac%		130	165	block		25	35	block2		25	25	howl		88	88	stupidity		3	3	hp%		15	15																										0
+Ocean's Embrace	926	100	1			1	1	77	82	uld	kraken shell		5	5000	lblu	dblu		invbody69				ac%		100	200	regen		3	5	regen-mana		200	200	cast2		20	20	abs-cold		20	30	res-fire		60	80	extra-cold		15	20																						0
+Lachdonnan's Heart	927	100	1			1	1	78	83	uth	lacquered plate		5	5000	lred	lred		invbody45				ac%		160	200	ease		20	20	dmg%		140	160	swing3		60	60	dmg-max		25	25	allskills		1	1																										0
+Pride of the Barony	928	100	1			2	1	68	75	uth	Lacquered Plate		5	5000	cblu	cblu						ac%		120	150	ac		200	300	swing2		25	25	dmg%		50	50	dmg-norm		15	30	balance2		30	30	addxp		25	25																						0
+Shadowtrick	929	100	1			1	1	80	84	uul	shadow plate		5	5000								ac%		130	200	oskill	fade	3	4	oskill	quickness	3	4	oskill	teleport	3	4	oskill	shout	3	4	oskill	battle orders	3	4	allskills		2	2	aura	123	3	4																		0
+Heaven's Treasure	930	100	1			1	1	82	87	utp	archon plate		5	5000	dyel	dyel		invbody55				ac%		100	200	allskills		2	2	mag%		200	350	sock		2	4																																		0
+Legacy of the Eternals	931	100	1			2	1	74	79	utp	Archon Plate		5	5000	oran	oran						ac%		75	100	allskills		1	2	cast2		30	30	mana%		25	25	abs-cold%		25	35	abs-fire%		25	35	abs-ltng%		25	35	res-all-max		10	10	block		20	20														0
+Nameweaver	932	100	1			1	1	1	8	cap	cap		5	5000				invhelm41				ac		20	30	dex		10	10	dmg-max		5	10	regen-mana		45	45	res-ltng		35	35																														0
+Trickster's Guise	933	100	1			3	1	1	5	cap	cap		5	5000				invcap				ac		15	25	enr		15	15	red-dmg%		8	8	gethit-skill	38	27	3	res-all		6	13	sock		1	1																										0
+Liespreader	934	100	1			1	1	2	16	skp	skull cap		5	5000				invhelm42				ac		30	40	cheap		15	15	skilltab	1	1	1	hp		25	25	mana		25	25	sock		1	1																										0
+Devourer of Dreams	935	100	1			3	1	1	13	skp	skull cap		5	5000	lgld	lgld						ac		15	25	cast1		15	15	oskill	warmth	1	1	regen		3	5	knock		1	1																														0
+Barbazu's Smile	936	100	1			1	1	4	20	hlm	helm		5	5000				invhelm16				ac		25	40	skilltab	3	1	1	mana%		15	15	regen-mana		40	40	mana-kill		3	5	cast1		15	15																										0
+Freedom's Facade	937	100	1			3	1	2	16	hlm	helm		5	5000	cred			invhelm24				ac		18	30	swing1		10	10	move1		10	10	dex		20	20	regen		-1	-1	dmg-to-mana		10	10																										0
+Harpy's Call	938	100	1			1	1	5	23	fhl	full helm		5	5000				invhelm27				ac		30	40	skilltab	6	1	1	res-all		20	20	addxp		3	3	aura	99	1	1	gethit-skill	77	7	3																										0
+Equinox Visor	939	100	1			3	1	4	20	fhl	full helm		5	5000				invhelm22				ac		20	33	hp		35	35	res-ltng		20	25	skill	224	1	3	oskill	summon spirit wolf	3	3	mana-kill		3	5																										0
+Satyr's Speech	940	100	1			1	1	8	27	bhm	bone helm		5	5000	lred	lred						ac		40	50	skilltab	10	1	1	rep-dur	20			att		125	125	freeze		1	2	howl		77	77	res-all		15	15																						0
+Hindsight	941	100	1			3	1	6	24	bhm	bone helm		5	5000				invbhm				ac		25	35	cast1		15	15	balance2		20	20	mag%		20	30	oskill	meditation	2	2	pal		1	1	res-mag		5	8	gethit-skill	82	10	3																		0
+Fool's Crest	942	100	1			1	1	14	30	ghm	great helm		5	5000				invhelm30				ac		40	50	skilltab	12	1	1	dmg%		25	25	hp		50	50	lifesteal		4	6	mag%		30	40	res-cold		25	25																						0
+Morning's Tears	943	100	1			3	1	12	28	ghm	great helm		5	5000	dblu			invhelm11				ac		32	40	regen		5	5	hp%		10	10	mana%		10	10	allskills		1	1	gold%		50	50	res-pois-max		75	75	res-pois		40	60																		0
+Gaiden's Loss	944	100	1			3	1	14	30	crn	crown		5	5000	dyel	dyel						ac		45	55	skilltab	16	1	1	mana		25	25	manasteal		3	5	ignore-ac		1	1	gold%		50	50	dmg-undead		100	100																						0
+Crown of Thorns	945	100	1			1	1	16	32	crn	crown		5	5000								ac		37	50	gethit-skill	235	15	5	gethit-skill	40	10	3	mana		20	30	bar		1	1	res-fire		30	30	res-cold		30	30	red-dmg		8	10	aura	103	1	2														0
+Blindman's Bluff	946	100	1			1	1	12	28	msk	mask		5	5000								ac		50	65	skilltab	19	1	1	fade		1	1	res-all		20	20	dex		15	15	str		15	15	rep-dur	25																								0
+Treachery's Allure	947	100	1			3	1	5	23	msk	mask		5	5000								ac%		80	120	slow		15	15	manasteal		3	5	cheap		15	15	all-stats		10	10	sock		2	2																										0
+Pepin's Blessing	948	100	1			1	1	20	36	xap	war hat		5	5000				invhelm08				ac%		100	125	regen		5	8	regen-mana		75	75	addxp		3	3	allskills		1	1	mana-kill		4	4	manasteal		5	5																						0
+Hushmaker	949	100	1			3	1	18	33	xap	war hat		5	5000	lyel	lyel		invhelm40				ac%		80	120	red-dmg		8	12	red-mag		6	8	balance2		20	20	slow		10	15	sock		1	1	oskill	resist lightning	1	1																						0
+Drunken Fury	950	100	1			3	1	20	36	xkp	sallet		5	5000	dgry	dgry						ac%		100	125	oskill	lightning fury	14	14	dex		-10	-10	dmg%		25	25	dmg-max		20	30	swing1		-10	-10	balance2		-10	-10																						0
+Neonate's Sallet	951	100	1			1	1	25	40	xkp	sallet		5	5000	cblu	cblu		invskp				ac%		80	120	sor		1	2	skill-rand	2	36	65	skill-rand	2	36	65	mana		75	75	cast2		20	20	res-mag		15	15	dmg-to-mana		15	20																		0
+Helm of Ra	952	100	1			3	1	24	39	xlm	casque		5	5000				invhelm26				ac%		110	135	allskills		1	1	str		15	15	extra-fire		15	15	res-fire		25	25	res-fire-max		10	10	move1		10	10																						0
+Troubled Thoughts	953	100	1			1	1	30	43	xlm	casque		5	5000				invhelm25				ac%		80	120	nec		1	2	skill-rand	2	66	95	skill-rand	2	66	95	rep-dur	10			heal-kill		15	20	mana-kill		8	12	str		15	15																		0
+Knight's Crest	954	100	1			3	1	30	43	xhl	basinet		5	5000				invhelm13				ac%		120	140	pal		1	2	block		10	10	skill-rand	2	96	125	heal-kill		10	15	cast2		20	20	slow		15	15																						0
+Wraithwatch	955	100	1			1	1	35	46	xhl	basinet		5	5000				invhelm12				ac%		80	120	ass		1	2	skill-rand	2	251	280	skill-rand	2	251	280	move2		25	25	swing1		10	10	sock		2	2	ease		-30	-30																		0
+Gotterdamerung	956	100	1			3	1	40	50	xhm	winged helm		5	5000				invhelm10				ac%		90	130	res-all		35	35	red-dmg%		15	15	abs-fire		8	12	balance2		25	25	hit-skill	67	4	7	wounds/lvl	8																								0
+Embracing Solitude	957	100	1			1	1	43	53	xhm	winged helm		5	5000				invhelm20				ac%		80	120	dru		1	2	skill-rand	2	221	250	skill-rand	2	221	250	swing1		15	15	lifesteal		6	6	cast1		15	15	res-all		15	25																		0
+Usurper's Ambition	958	100	1			3	1	43	53	xrn	grand crown		5	5000				invhelm36				ac%		130	150	allskills		2	2	sock		3	3	addxp		3	3	mag%		25	25																														0
+Reign of Deceit	959	100	1			1	1	47	56	xrn	grand crown		5	5000	oran	oran		invcrn				ac%		80	120	bar		1	2	skill-rand	2	126	155	skill-rand	2	126	155	dmg%		20	25	dmg-norm		5	10	block2		20	20	hp		25	50																		0
+Wraithshadow	960	100	1			3	1	34	44	xsk	death mask		5	5000	dred	dred		invhelm15				ac%		135	155	fade		1	1	move2		20	20	swing2		20	20	gold%		35	35	mag%		20	20	vit		20	20																						0
+Archnemesis	961	100	1			1	1	38	48	xsk	death mask		5	5000				invhelm1				ac%		80	120	ama		1	2	skill-rand	2	6	35	skill-rand	2	6	35	swing1		15	15	move1		15	15	dmg-cold	100	25	50	mag%		20	30																		0
+Ghoulslayer	962	100	1			3	1	36	46	xh9	grim helm		5	5000	cblu	cblu						ac%		140	165	rip		1	1	allskills		1	1	dmg-undead		100	100	str		15	25	vit		15	25	red-dmg%		5	10	sock		1	1																		0
+Skull of Fistindantalas	963	100	1			1	1	39	49	xh9	grim helm		5	5000	dgrn	dgrn						ac%		80	120	pal		1	2	skill-rand	2	96	125	skill-rand	2	96	125	rip		1	1	cast1		15	15	mana		50	50	dex		15	15																		0
+Bane's Dark Wisdom	964	100	1			1	1	45	55	uap	shako		5	5000				invhelm38				ac		100	125	allskills		1	1	addxp		50	50																																						0
+Overlord's Helm	965	100	1			1	1	59	67	ukp	hydraskull		5	5000	lblu	lblu						allskills		4	4	sock		2	2	ac%		100	120	cast3		30	30	mana/lvl	8																																0
+Slaver's Price	966	100	1			2	1	49	58	ukp	Hydraskull		5	5000				invhelm09				ac		80	120	regen		-15	-15	dmg%		50	50	dmg-max		15	15	swing2		20	20	rip		1	1																										0
+Conch of Dismay	967	100	1			1	1	68	74	uhl	giant conch		5	5000				invhelm21				hp		300	350	mana		125	150	mag%		50	50	ac/lvl	16			allskills		1	1	half-freeze		1	1	res-pois-len		60	70																						0
+Judas Kiss	968	100	1			2	1	57	66	uhl	Giant Conch		5	5000	blac	blac		invhelm19				ac		200	300	heal-kill		15	15	ignore-ac		1	1	res-pois-len		50	50	nofreeze		1	1	move2		20	20	res-all		15	25																						0
+King Conan's Rule	969	100	1			1	1	80	84	urn	corona		5	5000								ac%		150	200	allskills		2	2	addxp		2	4	gold%		200	200	dmg-norm		10	30	res-all		25	25	str/lvl	8			dex		35	35																		0
+Lolith's Crest	970	100	1			1	1	70	77	usk	demonhead		5	5000				invhelm18				allskills		1	1	ac%		150	200	heal-kill		10	15	block		15	20	balance2		30	30	cast2		20	20	dmg-to-mana		15	15																						0
+Kiss of the Vampire	971	100	1			1	1	77	81	uh9	bone visage		5	5000	dred	dred						ac		200	300	allskills		1	1	hp		50	75	mana		50	75	regen		10	15	regen-mana		75	75	manasteal		8	10	lifesteal		8	10	mana-kill		5	7	heal-kill		10	15										0
+Fairweather	972	100	1			1	1	18	32	ci0	circlet		5	5000	cblu	cblu						ac%		140	175	abs-fire		10	15	abs-ltng		10	15	abs-cold		10	15	res-pois-len		65	90	half-freeze		1	1	sock		1	1	allskills		1	1																		0
+Muddled Thoughts	973	100	1			3	1	10	25	ci0	circlet		5	5000	cred	cred		invhelm03				ac%		100	120	cast2		25	25	enr		15	15	sor		1	1	res-all		15	25	hp		35	50	dmg-to-mana		10	15																						0
+Charon's Token	974	100	1			5	1	6	18	ci0	Circlet		5	5000				invhelm06				ac		20	30	move1		15	15	block1		15	15	balance1		15	15	cast1		15	15	swing1		15	15	all-stats		15	15	res-all		15	15																		0
+Gainsayer	975	100	1			1	1	19	19	ci1	coronet		5	5000	dpur	dpur						ac%		140	175	addxp		4	7	cheap		5	10	all-stats		15	20	res-all		20	30	balance2		25	25	skilltab	14	1	3	skilltab	6	1	3																		0
+Threatspeaker	976	100	1			3	1	1	12	ci1	coronet		5	5000	cblu	cblu						ac		50	75	dmg-min		5	10	dmg-max		20	25	swing1		10	10	oskill	war cry	10	10	oskill	conversion	1	6	res-all		15	20																						0
+Sorcerer's Cache	977	100	1			5	1	25	39	ci1	Coronet		5	5000				invhelm02				ac%		100	135	allskills		1	1	cast2		30	30	mana		50	50	extra-fire		10	15	extra-cold		10	15	extra-ltng		10	15																						0
+Gillian's Hairpin	978	100	1			1	1	30	30	ci2	tiara		5	5000								ac		75	150	block		15	25	block2		20	20	slow		25	25	oskill	teleport	2	4	regen		8	8																										0
+Mystic Angel	979	100	1			3	1	60	68	ci2	tiara		5	5000								ac%		100	140	oskill	valkyrie	1	1	mana%		20	20	res-ltng		20	35	res-fire		25	35	red-dmg%		10	15																										0
+Blindsight	980	100	1			1	1	82	86	ci3	diadam		5	5000								ac/lvl	20			allskills		2	2	stupidity		3	3	att%		35	35	dex		20	20	res-ltng		65	65	gethit-skill	28	12	5																						0
+Royal Circlet	981	100	1			3	1	80	83	ci3	diadam		5	5000				invhelm32				ac%		130	175	ac/lvl	10			allskills		1	1	gold%		250	300	str		25	25	dex		15	15	gethit-skill	53	7	4																						0
+Lightreaper	982	100	1			1	1	1	8	buc	buckler		5	5000				invshld2				ac		20	35	block		15	25	dmg-ltng		10	20	balance2		25	25	cast2		20	20	vit		5	5																										0
+Traitor's Mark	983	100	1			3	1	1	5	buc	buckler		5	5000				invshld3				ac		15	30	block		10	20	block2		15	15	lifesteal		3	4	swing1		10	10	dmg%		25	25																										0
+Golgomere's Shield	984	100	1			1	1	1	14	sml	small shield		5	5000				invshld35				ac%		100	120	block2		20	20	heal-kill		5	8	regen-mana		50	50	extra-cold		10	10	res-cold		25	25	hp		20	20																						0
+Skein of Deceit	985	100	1			3	1	1	11	sml	small shield		5	5000	cred	cred		invshld34				ac		25	35	block		15	20	block2		20	20	skill	36	1	3	skill	38	1	3	skill	39	1	3	mana		25	25																						0
+Crest of the Horned Society	986	100	1			1	1	2	19	lrg	large shield		5	5000				invshld11				ac%		80	120	block		20	30	swing2		15	15	thorns		8	12	noheal		1	1	manasteal		4	4																										0
+Lepertouch	987	100	1			3	1	1	16	lrg	large shield		5	5000	cgrn	cgrn		invlrg				ac%		100	125	block		15	25	block2		20	20	res-pois-len		50	50	res-pois		75	75	dmg-pois	100	100	100	oskill	poison dagger	1	1																						0
+Doomhedge	988	100	1			1	1	6	28	bsh	bone shield		5	5000				invshld22				ac		25	50	block2		30	30	balance2		15	15	dmg-max		8	8	gethit-skill	66	13	1	deadly		10	10	res-all		15	15																						0
+Cacophony	989	100	1			3	1	4	24	bsh	bone shield		5	5000	dyel	dyel		invbsh				ac%		100	125	block		20	25	block2		20	20	gethit-skill	77	20	2	howl		35	35	res-all		10	15	sock		1	2																						0
+Fanged Shield	990	100	1			1	1	2	22	spk	spiked shield		5	5000				invshld38				ac%		100	125	thorns/lvl	8			block2		20	20	allskills		1	1	ignore-ac		1	1	mana		25	35	openwounds		30	80																						0
+Debtfinisher	991	100	1			3	1	1	18	spk	spiked shield		5	5000	lyel	lyel		invspk				ac%		110	135	block		20	30	block2		25	25	oskill	zeal	1	5	pal		1	1	skill	96	1	3	skill	104	1	3	ac		30	40																		0
+Crest of Avalon	992	100	1			1	1	4	24	kit	kite shield		5	5000				invshld1				ac%		120	140	block		60	70	block3		40	40	red-dmg%		50	50																																		0
+Killhunger	993	100	1			3	1	3	21	kit	kite shield		5	5000				invshld7				ac%		115	140	block		25	30	block2		30	30	lifesteal		3	5	heal-kill		6	6	nec		1	1	skill	69	1	3	skill	80	1	3																		0
+Bigby's Crushing Fist	994	100	1			3	1	5	25	tow	tower shield		5	5000				invshld8				ac		40	70	crush/lvl	5			dmg%		20	30	allskills		1	1	sock		2	3																														0
+Knight's Dawn	995	100	1			1	1	8	29	tow	tower shield		5	5000								ac%		120	150	block		25	35	block2		30	30	bar		1	1	oskill	holy shield	1	1	oskill	vengeance	1	3	oskill	concentration	1	2	sock		2	3																		0
+Pathfinder	996	100	1			1	1	10	31	gts	gothic shield		5	5000				invshld15				ac%		100	125	ac/lvl	8			str/lvl	3			dex/lvl	3			vit/lvl	3			enr/lvl	3			move3		30	30																						0
+Shield of Osirus	997	100	1			3	1	8	29	gts	gothic shield		5	5000	oran	oran		invshld27				ac%		125	150	block		30	40	block3		40	40	allskills		1	1	res-all		25	25	balance2		30	30	aura	109	6	6	regen-mana		35	35	regen		2	5														0
+Yemista's Defender	998	100	1			1	1	14	37	xuc	defender		5	5000		blac		invshld29				ac		70	100	nec		1	1	cast1		15	15	hp		100	100	regen		3	5	mana-kill		3	5																										0
+Mongolian Trust	999	100	1			3	1	12	34	xuc	defender		5	5000	oran	oran		invbuc				ac%		80	130	ass		1	1	skill-rand	2	251	280	skill-rand	2	251	280	block		15	30	lifesteal		3	5	stupidity		1	1	reduce-ac		10	10																		0
+Doom's Mirror	1000	100	1			1	1	15	39	xml	round shield		5	5000				invshld30				block		30	40	block2		25	25	ac/lvl	12			abs-fire		15	15	abs-ltng		15	15	abs-cold		15	15	stupidity		2	2	sock		2	2																		0
+Undead Buckler	1001	100	1			3	1	12	35	xml	round shield		5	5000	dgry	dgry		invsml				ac%		80	130	dru		1	1	skill-rand	2	221	250	skill-rand	2	221	250	block		15	30	oskill	skeleton mastery	5	5	oskill	revive	1	1	dmg-to-mana		10	10																		0
+Savant Sin	1002	100	1			1	1	25	42	xrg	scutum		5	5000				invshld16				ac%		120	150	pal		1	1	oskill	holy shield	1	1	balance2		20	20	dmg-norm		5	15	swing1		10	10	res-ltng		35	35																						0
+Spellbreaker	1003	100	1			3	1	21	39	xrg	scutum		5	5000				invshld9				ac%		80	130	sor		1	1	skill-rand	2	36	65	skill-rand	2	36	65	block		15	30	cast1		15	15	mana-kill		4	7	mana%		10	10																		0
+Under Dragon's Wing	1004	100	1			1	1	30	48	xit	dragon shield		5	5000		blac		invshld17				dmg%		50	50	ac		75	100	block2		50	50	red-dmg%		10	15	res-mag		10	15	res-all		35	35	dmg-fire		10	77																						0
+Wishgranter	1005	100	1			3	1	28	44	xit	dragon shield		5	5000				invshld18				ac%		80	130	bar		1	1	skill-rand	2	126	155	skill-rand	2	126	155	block		15	30	dmg-max		10	15	hp%		10	10	att		200	200																		0
+Adamantine Shield	1006	100	1			1	1	43	53	xow	pavise		5	5000				invshld21				ac/lvl	20			red-dmg%		20	20	indestruct		1	1	allskills		1	1	red-mag		25	25	str		15	15	ease		10	10	sock		1	1																		0
+Shieldmaiden's Shield	1007	100	1			3	1	39	49	xow	pavise		5	5000				invshld19				ac%		80	130	ama		1	1	skill-rand	2	6	35	skill-rand	2	6	35	block		15	30	oskill	sword mastery	1	1	red-dmg%		10	15	manasteal		5	5																		0
+Dreadwall	1008	100	1			3	1	45	55	xts	ancient sheild		5	5000				invshld36				ac%		140	170	block		25	35	gethit-skill	77	100	1	thorns/lvl	8			mag%		25	25	mana-kill		2	4	addxp		3	5																						0
+Crusader's Wall	1009	100	1			1	1	50	59	xts	ancient shield		5	5000				invshld24				ac%		80	130	pal		1	1	skill-rand	2	96	125	skill-rand	2	96	125	block		15	30	res-all		25	35	red-dmg%		10	10	block2		20	20																		0
+Ghoulspawner	1010	100	1			1	1	38	48	xsh	grim shield		5	5000				invshld41				ac%		100	125	reanimate	10	10	15	charged	95	10	10	dmg-undead		75	75	att%		20	20	lifesteal		6	6	res-all		30	40	rep-dur	12																				0
+Lichward	1011	100	1			3	1	35	45	xsh	grim shield		5	5000	blac	blac		invbsh				ac%		80	130	nec		1	1	skill-rand	2	66	95	skill-rand	2	66	95	block		15	30	mana		35	35	aura	119	1	4	pierce-pois		15	15																		0
+Raptarfang	1012	100	1			1	1	36	46	xpk	barbed shield		5	5000								ac/lvl	10			balance2		25	25	block		20	40	gold%		100	100	dmg-max		15	30	red-dmg		15	20	sock		1	1																						0
+Razorbite Deflecter	1013	100	1			3	1	29	41	xpk	barbed sheild		5	5000	oran	oran		invspk				ac%		80	130	allskills		1	1	openwounds		33	33	dmg-norm		5	15	dmg%		25	40	red-dmg		10	15	red-mag		10	15	block		25	45																		0
+Chill of Winter	1014	100	1			1	1	48	58	uuc	heater		5	5000				invshld39				ac%		150	200	dmg-cold		100	200	freeze		4	4	extra-cold		15	25	abs-cold%		15	15	res-cold		75	100	pierce-cold		60	60																						0
+Sun Tormenter	1015	100	1			2	1	43	53	uuc	Heater		5	5000				invshld23				ac/lvl	20			res-fire		50	50	abs-fire%		25	25	dmg-fire		75	200	pierce-fire		25	25	extra-fire		20	25	res-fire-max		20	20	block		20	30	block2		30	30														0
+Solar Eclipse	1016	100	1			1	1	59	67	uml	luna		5	5000				invshld28				ac%		100	150	lifesteal		8	8	stupidity		2	2	slow		10	10	block		30	30	allskills		1	1	res-all		20	20	regen-mana		25	25																		0
+Shield of Myth	1017	100	1			1	1	62	70	urg	hyperion		5	5000				invshld31				ac%		150	200	block		25	35	block2		20	20	balance3		40	40	hp		150	150	mag%		75	75																										0
+Safewarden	1018	100	1			2	1	56	65	urg	Hyperion		5	5000				invshld33				ac%		100	200	red-dmg%		15	20	abs-mag%		25	25	res-all		20	30	block		75	75	block3		60	60																										0
+Fortress of Solitude	1019	100	1			1	1	72	78	uit	monarch		5	5000	dgrn	dgrn		invshld4				ac%		200	225	block		35	50	balance2		35	35	enr		40	40	addxp		3	5	red-dmg%		15	25	res-mag		15	25	sock		1	2																		0
+Lachdonnan's Guard	1020	100	1			1	1	76	82	uow	aegis		5	5000				invshld12				ac%		100	120	ac/lvl	16			allskills		3	3	ease		50	50	block		50	75	balance1		15	15	abs-fire%		30	30																						0
+Medusa's Gaze1	1021	100	1			2	1	69	76	uow	aegis		3	5000	lred	lred						ac%		150	180	slow		20	20	gethit-skill	Lower Resist	10	7	lifesteal		5	9	death-skill	Nova	100	44	res-cold		40	80																										0
+Braced for Battle	1022	100	1			1	1	82	86	uts	ward		5	5000				invshld10				ac%		100	150	ease		-70	-70	block2		30	30	balance3		60	60	swing2		20	20	sock		2	2																										0
+Cry of the Wretched	1023	100	1			1	1	76	80	ush	troll nest		5	5000	lgrn	lgrn		invbsh				gethit-skill	91	15	3	ac%		200	240	block		25	35	cast2		25	25	nec		1	2	mana		50	50	manasteal		5	5																						0
+Baal's Wing	1024	100	1			1	1	52	52	upk	blade barrier		5	5000								ac		200	300	block		35	50	block1		15	15	move2		20	20	oskill	bone wall	5	5	hit-skill	53	33	8	noheal		1	1	openwounds		77	77																		0
+Blisterpain	1025	100	1			1	1	1	11	lgl	gloves		5	5000				invglov5				ac		30	40	dmg-max		5	5	dmg-fire		12	18	res-fire		45	45	swing1		15	15	noheal		1	1																										0
+Goblin Touch	1026	100	1			3	1	1	8	lgl	gloves		5	5000	lgrn	lgrn		invglov10				ac		10	20	res-pois		15	25	dmg-demon		100	100	rep-dur	10			att		75	75	demon-heal		10	15																										0
+Healing Touch	1027	100	1			1	1	4	18	vgl	heavy gloves		5	5000								ac		35	45	lifesteal		6	8	regen		3	5	heal-kill		4	7	mana-kill		4	6	regen-mana		35	35																										0
+Fiendfeast	1028	100	1			3	1	1	14	vgl	heavy gloves		5	5000				invglov21				ac		20	25	dmg-demon		50	50	dmg-undead		50	50	manasteal		4	6	mag%		15	15	gold%		25	25	red-dmg%		5	10																						0
+Horseman's Gloves	1029	100	1			3	1	6	20	mgl	bracers		5	5000								ac		40	50	red-dmg%		7	10	swing1		10	10	skilltab	10	1	3	res-pois		15	25	hp		30	30																										0
+Green God's Bracers	1030	100	1			1	1	8	25	mgl	bracers		5	5000	dgrn	dgrn						ac%		100	115	swing1		15	15	skilltab	1	1	3	dmg-ltng		1	35	res-all		10	20	hp		25	35																										0
+Prismatic Gauntlets	1031	100	1			1	1	16	30	tgl	light gauntlets		5	5000	oran	oran		invglov2				ac		45	55	res-all		20	30	dmg-elem	150	15	30	swing2		20	20	dmg-min		3	5	all-stats		5	5																										0
+Skein of Pain	1032	100	1			3	1	14	27	tgl	light gauntlets		5	5000				invglov11				ac%		120	140	dmg-norm		3	12	swing1		10	10	mana		20	20	res-fire		15	25	res-ltng		20	40	skilltab	13	1	3																						0
+Viridian Gloves	1033	100	1			1	1	17	33	hgl	gauntlets		5	5000				invglov20				ac		50	60	ease		-25	-25	dex		15	15	att		75	75	slow		15	15	res-fire		25	25	cast1		10	10																						0
+Firesign	1034	100	1			3	1	16	31	hgl	gauntlets		5	5000	dred	dred						ac%		125	150	dmg-fire		20	35	res-fire		35	45	res-fire-max		5	5	abs-fire%		5	5	half-freeze		1	1	light		2	4	fireskill		1	1																		0
+Devil's Invocation	1035	100	1			1	1	20	37	xlg	demonhide gloves		5	5000				invglov17				ac%		100	125	cast2		20	20	mana		30	50	dmg-to-mana		10	15	regen-mana		50	50	mana-kill		3	5	manasteal		5	5																						0
+Marauder's Claw	1036	100	1			3	1	16	34	xlg	demonhide gloves		5	5000				invglov4				ac%		100	125	dmg-min		6	10	reduce-ac		5	5	crush		5	5	gold%		100	100	res-cold		20	30	res-fire		20	30																						0
+Lady of the Lake	1037	100	1			1	1	23	43	xvg	sharkskin gloves		5	5000	dblu	dblu						ac%		120	140	sor		1	1	ama		1	1	ass		1	1	mana		40	50	cast2		15	15	swing1		15	15																						0
+Conspiracy of Thieves	1038	100	1			3	1	20	39	xvg	sharkskin gloves		5	5000				invglov1				ac%		125	160	dex		25	25	mag%		20	30	abs-fire		10	15	abs-cold		10	15	abs-ltng		10	15	ac		20	40																						0
+Spikefiend Bracers	1039	100	1			1	1	34	48	xmg	heavy bracers		5	5000	dgry	dgry						ac%		140	160	bar		1	1	pal		1	1	dmg%		20	20	hp		25	35	lifesteal		5	5																										0
+Rapturous Blessings	1040	100	1			3	1	30	44	xmg	heavy bracers		5	5000				invglov15				ac		75	125	oskill	salvation	1	1	cast1		10	10	res-all-max		5	5	res-all		10	15	enr		15	15	vit		15	15																						0
+Warlock's Touch	1041	100	1			1	1	44	54	xtg	battle gauntlets		5	5000				invglov7				ac%		125	150	nec		1	1	dru		1	1	cast2		20	20	mana-kill		5	5	mana		25	40	regen-mana		50	50																						0
+Gryphon's Claw	1042	100	1			3	1	40	50	xtg	battle gauntlets		5	5000				invglov12				ac%		130	160	dmg-max		6	10	swing1		10	10	skilltab	15	1	3	heal-kill		5	5	res-pois		25	25	res-cold		20	30																						0
+Burning Soul	1043	100	1			1	1	51	60	xhg	war gauntlets		5	5000				invglov16				ac		100	150	dmg-fire		77	122	res-fire		35	35	abs-fire%		10	15	extra-fire		10	15	pierce-fire		10	15																										0
+Threat of Retribution	1044	100	1			3	1	45	55	xhg	war gauntlets		5	5000	lgrn	lgrn						ac/lvl	16			ac%		50	75	charged	8	77	10	gethit-skill	42	3	1	hit-skill	39	3	10	balance1		15	15	move1		15	15																						0
+Mephisto's Claw	1045	100	1			1	1	55	64	ulg	bramble mitts		5	5000	oran	oran						ac%		125	150	aura	114	4	6	dmg-cold		70	100	freeze		2	2	mag%		35	50																														0
+Griefspawn	1046	100	1			2	1	47	57	ulg	Bramble Mitts		5	5000				invglov18				ac%		75	100	dmg-norm		10	20	swing3		40	40	rip		1	1	hp%		10	10																														0
+Bloodyearn	1047	100	1			1	1	20	36	uvg	vampirebone gloves		5	5000	cred	cred		invglov6				ac%		120	150	hp%		25	25	hp/lvl	6			lifesteal		6	6	swing2		20	20	skilltab	13	1	3																										0
+Lachdonnan's Bracers	1048	100	1			1	1	74	80	umg	vambraces		5	5000								ac%		160	200	ease		40	40	skilltab	9	1	3	dmg-norm		10	20	dmg-demon		100	100	res-fire		25	35	mag%		35	50																						0
+Paladin's Quest	1049	100	1			1	1	80	84	utg	crusader gauntlets		5	5000				invglov9				allskills		1	1	addxp		1	1	skill	117	1	3	skill	122	1	3	block		20	20	block2		20	20																										0
+Hellhunger	1050	100	1			2	1	20	34	utg	Crusader Gauntlets		5	5000				invglov3				ac		75	125	allskills		1	1	oskill	lower resist	1	5	cast1		10	10	mag%		20	25																														0
+Black Lotus	1051	100	1			1	1	83	87	uhg	ogre gauntlets		5	5000				invglov22				ac/lvl	24			swing3		30	30	dex		25	25	deadly		25	25	pierce		20	20	res-all		15	20																										0
+Cheetah Speed	1052	100	1			1	1	1	10	lbt	leather boots		5	5000				invboot19				ac		20	30	move1		30	30	balance2		30	30	res-all		10	15	heal-kill		5	5																														0
+Marathon Slipper	1053	100	1			3	1	1	7	lbt	leather boots		5	5000				invboot25				ac		15	25	move2		25	25	balance2		20	20	dex		15	15	res-ltng		20	30	gold%		35	35																										0
+Gillian's Boots	1054	100	1			1	1	23	43	vbt	heavy boots		5	5000				invboot4				ac		25	35	move2		15	15	kick		3	3	gold%		50	50	skilltab	19	1	1	str		10	10																										0
+Angel's Tread	1055	100	1			3	1	1	13	vbt	heavy boots		5	5000	whit	whit						ac		25	35	skilltab	11	1	3	skill	99	1	3	balance2		25	25	res-all		15	20	mag%		15	25	res-fire		25	35																						0
+Pepin's Grace	1056	100	1			1	1	6	23	mbt	chain boots		5	5000				invboot23				ac		30	40	move2		20	20	regen		2	5	oskill	dodge	1	1	thorns		6	9	dex		10	15																										0
+Bonemesh	1057	100	1			3	1	5	19	mbt	chain boots		5	5000				invboot3				ac%		100	125	skilltab	8	1	2	oskill	skeleton mastery	5	5	oskill	raise skeleton	1	1	dmg-undead		75	75	regen		3	3																										0
+Dawn Scion	1058	100	1			1	1	10	30	tbt	light plated boots		5	5000				invboot21				ac		35	45	skilltab	11	1	2	str		5	15	addxp		1	2	balance2		15	15	mag%		20	30	light		1	3																						0
+Lilith's Heels	1059	100	1			3	1	8	26	tbt	light plate boots		5	5000				invboot5				ac%		115	140	dmg-to-mana		5	10	skill	54	1	2	skill	37	1	1	mana		25	25	move2		20	20	res-cold		25	40																						0
+Dark Familiar	1060	100	1			1	1	12	34	hbt	plate boots		5	5000	lgry	lgry						ac		40	50	kick		3	5	skilltab	6	1	1	lifesteal		3	4	mana		25	35	red-mag		10	15																										0
+Grimleaper	1061	100	1			3	1	28	46	hbt	plate boots		5	5000				invboot15				ac%		125	150	dmg%		20	30	skill	143	1	2	heal-kill		2	3	aura	prayer	1	6	gethit-skill	68	5	8	res-pois		25	35	hp%		5	5																		0
+Hooves of Satan	1062	100	1			1	1	20	40	xlb	demonhide boots		5	5000				invboot10				ac%		90	140	cast3		30	30	rep-dur	15			slow		10	15	dex		-5	-5	res-fire		45	60	extra-fire		10	10	kick		3	5																		0
+Deepwander	1063	100	1			3	1	18	35	xlb	demonhide boots		5	5000				invboot6				ac		50	80	move2		25	25					light		1	7	nofreeze		1	1	hp		25	25	mana		25	25																						0
+Asheara's Slippers	1064	100	1			1	1	26	45	xvb	sharkskin boots		5	5000				invboot12				ac%		110	150	ac		25	40	res-pois		25	35	res-cold		30	40	move3		25	25	balance2		20	20	extra-cold		10	15																						0
+Road to Perdition1	1065	100	1			3	1	28	38	xvb	sharkskin boots		5	5000	lgry	lgry		invboot1				ac%		120	160	move1		15	15	balance2		25	25	dex		20	20	rep-dur	8			addxp		4	7	charged	96	250	20																						0
+Whirling Dervish	1066	100	1			1	1	38	48	xmb	mesh boots		5	5000				invboot2				ac%		130	170	oskill	whirlwind	7	12	skilltab	12	1	1	dmg%		10	15	swing1		10	10	ease		25	25	move2		20	20																						0
+Zebrastride	1067	100	1			3	1	32	43	xmb	mesh boots		5	5000				invboot28				ac%		125	165	move3		40	40	dex/lvl	5			crush		10	10	kick		5	10	res-all		15	15	regen-mana		25	25																						0
+Halbu's Gift	1068	100	1			1	1	46	56	xtb	battle boots		5	5000				invboot20				ac%		125	160	ac/lvl	6			addxp		2	4	cheap		5	5	red-dmg		10	15	res-all		15	25	dex		15	25																						0
+Zero Effect	1069	100	1			3	1	39	49	xtb	battle boots		5	5000	dred	dred		invboot7				ac%		130	170	red-dmg%		15	20	abs-cold%		10	15	abs-fire%		10	15	abs-ltng%		10	15	res-pois-len		50	50	nofreeze		1	1																						0
+River Stalker	1070	100	1			1	1	51	60	xhb	war boots		5	5000				invboot17				ac		100	140	balance2		30	30	oskill	avoid	1	1	oskill	dodge	1	1	oskill	evade	1	1	mana		30	50	regen-mana		35	35	mana-kill		3	5																		0
+Doubtraiser	1071	100	1			3	1	45	55	xhb	war boots		5	5000				invboot13				ac/lvl	12			str		20	20	move1		15	15	addxp		-3	-3	heal-kill		12	12	res-all		25	25	kick		5	5	mag%		25	25																		0
+Dance of the Cobra	1072	100	1			2	1	46	56	ulb	wyrmhide boots		5	5000				invboot8				ac%		100	150	stupidity		1	1	move1		15	15	res-pois		75	75	res-pois-len		25	80	dmg-pois	100	777	777	noheal		1	1																						0
+Stallion Hooves	1073	100	1			1	1	53	67	ulb	Wyrmhide Boots		5	5000								ac%		100	125	dex		35	35	balance3		40	40	move3		40	40	rep-dur	60			dmg-max		20	20	crush		15	15	deadly		20	25																		0
+Thoqqua's Slipper	1074	100	1			2	1	4	19	uvb	scarabshell boots		5	5000				invboot11				ac		75	120	mag%		40	80	res-all		10	15	hp		35	50	move3		50	50																														0
+Hollowed Ground	1075	100	1			1	1	18	37	umb	boneweave boots		5	5000				invboot29				pal		1	1	ac%		150	200	balance2		25	25	dmg-undead		125	125	rip		1	1	aura	119	2	5	dex		15	25																						0
+Stairway to Heaven	1076	100	1			2	1	66	74	utb	mirrored boots		5	5000				invboot9				ac%		125	160	mag%		20	30	res-fire		40	70	res-cold		40	70	res-ltng		40	70	res-pois		40	70	half-freeze		1	1	res-pois-len		50	50																		0
+Lustwander	1077	100	1			1	1	74	81	utb	Mirrored Boots		5	5000				invboot24				ac		100	150	oskill	teleport	2	5	gold%		150	250	mag%		75	75	res-all		25	25	allskills		1	1																										0
+Wild Horses	1078	100	1			1	1	34	34	uhb	myrmidon greaves		5	5000				invboot14				ac%		125	200	kick		10	15	move3		40	40	balance3		40	40	str		25	25	dex		25	25	deadly		10	20																						0
+Bloodrune	1079	100	1			1	1	1	8	lbl	sash		5	5000	dred	dred						ac		15	25	regen		3	5	res-fire		40	45	res-cold		40	45	res-pois		40	45	res-ltng		40	45																										0
+Ivywrap	1080	100	1			3	1	1	5	lbl	sash		5	5000	lyel	lyel						ac		10	20	dmg-pois	75	77	77	res-pois		35	35	res-pois-len		25	50	slow		10	10	mag%		10	15																										0
+Ratman's Rope	1081	100	1			1	1	1	15	vbl	light belt		5	5000	oran	oran		invbelt12				ac		10	20	dmg-demon		100	100	res-ltng		20	30	mana		35	35	cast1		10	10	dex		5	5																										0
+Spiritseeker	1082	100	1			3	1	1	12	vbl	light belt		5	5000				invbelt6				ac		15	25	dmg-undead		50	50	addxp		3	5	cheap		5	5	mana		20	30	regen-mana		50	50																										0
+Belt of Evil	1083	100	1			1	1	5	25	mbl	belt		5	5000				invbelt1				ac		20	30	regen		-1	-1	addxp		-2	-2	gold%		75	75	mag%		75	75	hp		55	75																										0
+Wreath of Suffering	1084	100	1			3	1	1	21	mbl	belt		5	5000				invbelt15				ac%		100	125	dmg-max		5	15	manasteal		2	5	crush		5	10	regen		-2	-2	str		10	10	vit		10	10																						0
+Crocodile Wrap	1085	100	1			1	1	10	30	tbl	heavy belt		5	5000								ac%		75	100	red-dmg%		10	10	move2		20	20	red-mag		3	5	res-all		10	10	str		10	10	vit		10	10																						0
+Pirate's Faith	1086	100	1			3	1	8	28	tbl	heavy belt		5	5000	oran	oran						mag%		25	25	gold%		100	100	move2		20	20	ac%		120	145	dex		15	15	red-dmg%		5	10	fade		1	1																						0
+Pandemonium	1087	100	1			1	1	12	32	hbl	girdle		5	5000	dred	dred						ac/lvl	10			str/lvl	4			hp/lvl	8			dmg/lvl	2			res-cold/lvl	4			res-fire/lvl	4																												0
+Leash of Cerebus	1088	100	1			3	1	10	30	hbl	girdle		5	5000				invbelt11				ac%		125	150	all-stats		10	10	regen		3	3	skilltab	15	1	3	skill	227	1	3	skill	237	1	3	balance1		15	15	res-ltng		35	45																		0
+Warriv's Coin	1089	100	1			1	1	21	39	zlb	demonhide sash		5	5000				invbelt16				ac%		100	120	gold%		200	200	cheap		5	15	mag%		25	25	manasteal		5	5	mana/lvl	6																												0
+Xenophobe	1090	100	1			3	1	16	36	zlb	demonhide sash		5	5000				invbelt14				ac%		100	150	ac/lvl	6			hit-skill	77	10	3	skilltab	6	1	1	skill	77	3	3	dmg%		15	20	dmg-to-mana		5	10																						0
+Megladon Wrap	1091	100	1			1	1	21	41	zvb	sharkskin belt		5	5000				invbelt3				ac/lvl	10			heal-kill		6	10	lifesteal		4	7	crush		15	15	dmg-max		10	15	res-ltng/lvl	6			dex		10	10																						0
+Wave Whipper	1092	100	1			3	1	17	37	zvb	sharkskin belt		5	5000				invbelt8				ac%		110	160	res-cold		25	35	crush		5	10	deadly		5	10	oskill	increased stamina	1	1	move2		20	20																										0
+Meshif's Coil	1093	100	1			1	1	22	45	zmb	mesh belt		5	5000				invbelt2				ac%		130	160	move3		30	30	balance1		15	15	gethit-skill	76	4	14	regen-mana		30	30	res-cold-max		10	10	res-cold/lvl	7																								0
+Weakling's Whimper	1094	100	1			3	1	20	40	zmb	mesh belt		5	5000				invbelt13				ac%		125	165	gethit-skill	72	20	1	charged	72	15	25	str		20	20	res-pois		10	25	res-fire		35	35																										0
+Assassin Vine	1095	100	1			1	1	30	48	ztb	battle belt		5	5000	cred	cred						ass		1	1	dex		20	30	str		20	30	balance2		20	20	kick		5	5	knock		2	2	res-ltng		20	40																						0
+Fortune's Fool	1096	100	1			3	1	36	46	ztb	battle belt		5	5000	dgld	dgld						ac%		75	100	ac		50	75	gold%/lvl	16			mag%/lvl	6			enr		-5	-5	vit		-5	-5	oskill	find item	1	1																						0
+The Art of War	1097	100	1			1	1	44	54	zhb	war belt		5	5000				invbelt4				ac%		150	180	str		35	35	dmg/lvl	4			swing1		15	15	bar		1	1	vit/lvl	4			res-ltng		35	35																						0
+Shattered Dreams	1098	100	1			3	1	40	50	zhb	war belt		5	5000	blac	blac						ac%		135	175	dmg-max		5	15	stupidity		1	1	swing1		10	10	regen		5	5	deadly		10	10	oskill	sword mastery	1	1																						0
+Duskwreath	1099	100	1			1	1	52	60	ulc	spiderweb sash		5	5000				invbelt10				ac		100	150	fade		1	1	res-all		35	35	balance2		20	20	cast1		15	15	enr		30	30																										0
+Dreadfury	1100	100	1			1	1	56	64	uvc	vampirefang belt		5	5000				invbelt7				ac%		120	150	dru		1	1	swing1		10	10	howl		33	33	skill-rand	2	221	250	extra-fire		10	15																										0
+Kashya's Ward	1101	100	1			1	1	68	73	umc	mithril coil		5	5000				invbelt9				ac%		100	150	red-dmg%		15	15	res-mag		15	15	abs-fire/lvl	3			abs-ltng/lvl	3			abs-cold/lvl	3			regen-mana		50	50																						0
+Wisdom's Wrap	1102	100	1			1	1	72	78	utc	troll belt		5	5000								ac%		150	200	addxp		3	3	enr/lvl	5			allskills		1	1	rep-dur	30			dmg-to-mana		15	15	res-all		15	20																						0
+Ecstacy of Ishtar	1103	100	1			2	1	65	71	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		25	25	mana%		25	25	red-dmg		25	30	red-mag		25	30	pierce		50	50																										0
+Lachdonnan's Wrap	1104	100	1			1	1	80	85	uhc	colossus girdle		5	5000								ac		200	300	ease		20	20	lifesteal		8	8	manasteal		8	8	res-all		30	40	block2		20	20	allskills		1	1	dmg%		20	25																		0
+Ogre's Embrace	1105	100	1			2	1	76	80	uhc	Colossus Girdle		5	5000	dgrn	dgrn						ac%		175	200	ac		75	125	red-dmg%		10	15	str/lvl	8			vit/lvl	8			res-pois		100	100	rep-dur	25			oskill	iron skin	1	1																		0
+Damsel of Destruction	1106	100	1			1	1	6	26	am1	stag bow		5	5000	blac	blac		invam1				dmg%		80	120	dmg-norm		20	40	skilltab	0	1	3	swing1		15	15	dmg-elem	200	10	25	mana-kill		5	5	balance2		20	20																						0
+Bleeding Branch	1107	100	1			3	1	1	18	am1	stag bow		5	5000	cred	cred		invam1				dmg%		120	160	dmg-norm		10	20	lifesteal		5	8	noheal		1	1	openwounds		57	57	bloody		1	1	sock		2	2																						0
+Angelsong	1108	100	1			5	1	1	12	am1	Stag Bow		5	5000	dgld	dgld		invam1				dmg%		75	110	dmg-norm		5	10	swing1		10	10	aura	defiance	1	3	pierce-fire		45	45	pierce-cold		45	45	dmg-demon		200	200																						0
+Kashya's Retort	1109	100	1			1	1	19	39	am2	reflex bow		5	5000	oran	oran		invam2				dmg%		80	120	dmg-norm		25	50	skilltab	0	1	3	ama		1	1	gethit-skill	47	17	4	light		2	4	mana		35	35	manasteal		5	5																		0
+Elvenbrand	1110	100	1			3	1	12	32	am2	reflex bow		5	5000	dgrn	dgrn		invam2				dmg%		125	175	ama		1	1	skilltab	0	1	3	swing2		20	20	dex		20	20	ignore-ac		1	1	pierce		20	20	dmg-norm		10	20																		0
+Ragnarok Sliver	1111	100	1			5	1	4	24	am2	Reflex Bow		5	5000	whit	whit		invam2				dmg%		100	150	crush		25	25	deadly/lvl	12			dex		15	15	ease		-50	-50	ama		1	1	allskills		1	1	dmg-norm		10	25																		0
+Brightmangler	1112	100	1			1	1	55	51	am6	ashwood bow		5	5000				invbow15				dmg%		100	100	dmg-min		25	35	dmg-max		50	100	skilltab	1	1	3	deadly		35	35	openwounds		50	50	res-ltng		35	35	res-pois		20	30																		0
+Abyssal Torment	1113	100	1			3	1	21	41	am6	ashwood bow		5	5000	lgry	lgry		invam1				dmg%		200	250	skilltab	0	3	3	dmg/lvl	8			res-fire		35	50	extra-fire		15	15	oskill	amplify damage	1	1	rip		1	1																						0
+Adamantine Leaf	1114	100	1			5	1	13	33	am6	Ashwood Bow		5	5000	lgrn	lgrn		invam1				dmg%		125	190	skilltab	0	1	3	swing2		20	20	res-all		35	50	pierce		25	25	move2		25	25	magicarrow		1	1	att%		25	25	skill	32	7	7	dmg-norm		20	40										0
+Distance Strike	1115	100	1			1	1	55	60	am7	ceremonial bow		5	5000	dyel	dyel		invam2				dmg%		100	100	dmg-min		25	50	dmg-max		90	140	swing3		30	30	allskills		1	1	dex		15	15	move2		25	25	att		250	250	knock		2	2														0
+The Four Winds	1116	100	1			3	1	40	50	am7	ceremonial bow		5	5000	dred	dred		invam2				dmg%		220	270	dmg-norm		15	30	dmg-ltng		1	200	oskill	teleport	1	1	move3		50	50	ama		1	2	skilltab	1	1	3																						0
+Laurana's Elven Bow	1117	100	1			1	1	60	73	amb	matriachal bow		5	5000	dblu	dgld		invbow14				dmg%		260	325	dmg-norm		25	50	dmg%/lvl	14			swing3		50	50	pierce		40	40	balance2		30	30	sock		1	1																						0
+Wintershock	1118	100	1			1	1	84	87	amc	grand matron bow		5	5000	lgld	lgld		invam2				dmg%		300	350	dmg-norm		40	80	dmg-cold	600	25	50	dmg-ltng		1	444	res-ltng		65	65	res-cold		65	65	extra-cold		10	15	pierce-cold		10	15																		0
+Quicksilver	1119	100	1			4	1	74	80	amc	Grand Matron Bow		5	5000	whit			invam2				dmg%		200	300	dmg/lvl	16			dmg-norm		40	100	swing3		50	50	skilltab	0	3	3	ama		2	2	addxp		10	10	res-all		15	50																		0
+Shieldmaiden's Toss	1120	100	1			1	1	40	50	am5	maiden javelin		5	5000	cgrn	cgrn						dmg%		75	100	dmg-norm		30	50	skilltab	2	1	3	stack		80	80	rep-quant	25			pierce		25	25	dex		15	15	deadly		15	15																		0
+Hastemaster	1121	100	1			3	1	7	27	am5	maiden javelin		5	5000	dyel	dyel						dmg%		120	160	dmg-throw		15	15	rep-quant	25			stack		55	55	swing3		40	40	block2		30	30																										0
+Raptorshaft	1122	100	1			5	1	4	20	am5	Maiden Javelin		5	5000								dmg%		75	115	ama		1	1	skilltab	2	1	1	dmg-throw		10	20	stack		50	50	rep-quant	75			noheal		1	1	addxp		15	15																		0
+Lady in Waiting	1123	100	1			1	1	55	65	ama	ceremonial javelin		5	5000	cred	cred						dmg%		100	125	dmg-norm		30	60	dmg/lvl	6			stack		100	100	rep-quant	90			skilltab	2	1	3	allskills		1	1	rip		1	1																		0
+Sister of the Sun	1124	100	1			3	1	39	49	ama	ceremonial javelin		5	5000	oran	oran						dmg%		215	270	ama		2	2	dmg-fire		75	100	res-cold		35	35	res-fire		50	50	skilltab	2	1	3	rep-quant	25			stack		155	155																		0
+Pegasus Wing	1125	100	1			1	1	74	80	amf	matriarchal javelin		5	5000	dyel	dyel						dmg%		275	350	stack		100	100	rep-quant	25			skilltab	2	1	3	allskills		2	2	addxp		3	5	oskill	teleport	3	3	balance3		40	40	block3		40	40														0
+Wrathshifter	1126	100	1			2	1	1	15	am3	maiden spear		5	5000								dmg-min		15	30	dmg-max		50	70	skilltab	2	1	1	swing1		15	15	oskill	68	2	2	gethit-skill	54	7	1																										0
+Hawkfire	1127	100	1			5	1	1	8	am3	Maiden Spear		5	5000	lred	lred						dmg%		80	120	dmg-fire		5	18	res-fire		35	35	ama		1	1	hp		35	35	swing1		25	25																										0
+Stygian Harlot	1128	100	1			2	1	5	25	am4	maiden pike		5	5000								dmg-min		30	55	dmg-norm		80	120	swing2		20	20	skilltab	2	1	3	hp		40	50	lifesteal		6	8	sock		2	2																						0
+Sepia Shard	1129	100	1			5	1	1	19	am4	Maiden Pike		5	5000	cblu	cblu						dmg%		100	125	dmg-cold	200	10	15	res-cold		20	40	skilltab	2	2	2	mana		35	50	att		100	200	manasteal		6	9																						0
+Vile Temptress	1130	100	1			2	1	24	40	am8	ceremonial spear		5	5000	blac	blac						dmg%		175	225	dmg/lvl	12			ama		1	1	skilltab	1	2	2	hit-skill	53	8	3	addxp		3	5	dex		25	25	ease		-20	-20																		0
+Silverdawn	1131	100	1			5	1	13	33	am8	Ceremonial Spear		5	5000	whit							dmg%		140	200	ama		1	1	skilltab	1	2	4	dmg-ltng		1	200	res-ltng		50	65	light		4	7	dmg-demon		100	200	hp/lvl	9			dmg-norm		20	60														0
+Murder's Mistress	1132	100	1			2	1	40	50	am9	ceremonial pike		5	5000	dgry	dgry						dmg%		190	250	dmg%/lvl	12			ama		1	1	swing3		50	50	deadly		18	28	oskill	sword mastery	3	5	rep-dur	10			heal-kill		10	15	mag%		35	70														0
+Valkyrie's Calling	1133	100	1			1	1	64	73	amd	matriarchal spear		5	5000	whit	whit						dmg%		250	300	dmg-norm		40	80	skill	32	4	7	charged	258	10	15	skilltab	2	3	3	allskills		1	1	res-all		30	30	mana		75	75																		0
+Amanda's Point	1134	100	1			1	1	74	80	ame	matriarchal pike		5	5000								dmg%		275	325	dmg/lvl	16			skilltab	2	2	2	sock		4	6	ama		2	2																														0
+Manticore's Retort	1135	100	1			2	1	64	70	ame	Matriarchal Pike		5	5000	oran	lred						dmg%		200	300	dmg-norm		50	100	swing3		35	35	dmg-pois	100	999	999	skilltab	2	1	3	res-pois-max		15	15	res-pois		50	50	res-pois-len		75	75																		0
+Queasespreader	1136	100	1			1	1	1	11	ob1	eagle orb		5	5000								dmg-norm		8	16	swing2		25	25	sor		1	1	dmg-ltng		1	30	res-ltng		35	50	mana		25	25																										0
+Sparrow's Trill	1137	100	1			3	1	1	6	ob1	Eagle Orb		5	5000	oran	oran						dmg-norm		3	8	skilltab	5	1	1	mana		25	35	ac		15	25	move1		20	20																														0
+Cyanstrike	1138	100	1			1	1	1	16	ob2	sacred orb		5	5000	dyel	dyel						dmg-min		6	12	dmg-max		20	25	hit-skill	45	8	3	res-pois		25	25	extra-cold		10	10	heal-kill		5	5																										0
+Flicker Cinch	1139	100	1			3	1	1	12	ob2	Sacred Globe		5	5000								dmg%		80	120	block		20	30	block2		20	20	hp		25	25	mana		35	35	mag%		20	30																										0
+Revoker	1140	100	1			1	1	3	23	ob3	smoked sphere		5	5000	dred	dred						allskills		1	1	mag%		20	20	cast2		25	25	extra-ltng		10	15	res-all		20	20	hp		35	50	charged	138	60	8																						0
+Soul Stinger	1141	100	1			3	1	1	18	ob3	Smoked Sphere		5	5000	dgry	dgry						sor		1	1	rip		1	1	oskill	weaken	2	2	hit-skill	66	75	5	dmg-norm		10	20	manasteal		35	35																										0
+Zapcaster	1142	100	1			1	1	7	27	ob4	clasped orb		5	5000	lgry	lgry						skilltab	4	2	2	pierce-ltng		10	15	abs-ltng		8	12	hit-skill	49	6	5	dmg-min		10	10	dmg-max		25	35	swing2		20	20																						0
+Thought Splinter	1143	100	1			3	1	2	22	ob4	Clasped Orb		5	5000								enr/lvl	8			skilltab	4	1	2	skilltab	3	1	2	skilltab	5	1	2	heal-kill		5	5	addxp		5	5																										0
+Unseeing Eye	1144	100	1			5	1	6	26	ob5	dragon stone		5	5000								allskills		1	1	addxp		10	10	cast2		20	20	mana		45	45	ac		70	100	dmg-to-mana		10	15	mana-kill		4	6																						0
+Eternity Cable	1145	100	1			1	1	12	32	ob5	Dragon Stone		5	5000	blac	blac						sor		2	2	skill-rand	3	36	60	skill-rand	3	36	60	skill-rand	3	36	60	res-all		25	40	str		25	25	dex		15	15																						0
+Terminus Rod	1146	100	1			1	1	16	36	ob6	glowing orb		5	5000								sor		2	2	extra-fire		10	15	pierce-fire		10	15	abs-fire%		15	20	res-fire		75	75	dex		15	15	enr		15	15																						0
+Dreamsplitter	1147	100	1			3	1	9	29	ob6	Glowing Orb		5	5000	cgrn	cgrn						allskills		1	1	skill-rand	7	36	60	all-stats		15	25	mag%		15	25	gold%		50	100	sock		2	2	regen		10	15																						0
+Drehya's Globe	1148	100	1			1	1	24	40	ob7	crystalline globe		5	5000								sor		2	2	extra-cold		10	15	pierce-cold		10	15	abs-cold%		15	20	res-cold		75	75	str		15	15	vit		15	15																						0
+Murdering Shard	1149	100	1			3	1	13	33	ob7	Crystalline Globe		5	5000	lpur	lpur						dmg-norm		15	30	dmg%		100	150	swing2		40	40	manasteal		100	100	slow		35	35	sor		2	2	heal-kill		10	15																						0
+Starbreaker	1150	100	1			1	1	28	43	ob8	cloudy sphere		5	5000	blac	blac						sor		2	2	extra-ltng		10	15	pierce-ltng		10	15	abs-ltng%		15	20	res-ltng		75	75	str		15	15	dex		15	15																						0
+Dawn Shadow	1151	100	1			3	1	15	35	ob8	Cloudy Sphere		5	5000								mana%		25	25	hp%		20	20	allskills		2	2	cast2		25	25	regen-mana		200	200	balance2		30	30	block		25	25																						0
+Manna from Heaven	1152	100	1			1	1	38	48	ob9	sparkling ball		5	5000	cblu	cblu						sor		1	2	res-all-max		5	15	res-all		50	50	mana/lvl	20			gethit-skill	58	10	12	balance1		15	15	abs-mag		10	20	res-pois-len		50	90																		0
+Desecration Sigil	1153	100	1			3	1	40	50	ob9	Sparkling Ball		5	5000	whit							oskill	skeleton mastery	5	12	oskill	revive	1	3	oskill	raise skeletal mage	6	10	cast3		40	40	cheap		10	10	mana/lvl	8			sor		2	2	oskill	grim ward	1	1																		0
+Quandry of the Queen	1154	100	1			3	1	19	39	oba	swirling crystal		5	5000	dgld	dgld						allskills		1	2	vit/lvl	4			enr/lvl	4			str/lvl	3			dex/lvl	3			cast3		30	30	red-dmg%		10	15	regen		8	10	regen-mana		75	75														0
+Star of Bethlehem	1155	100	1			1	1	49	59	obb	heavenly stone		5	5000	lyel	lyel						aura	99	1	1	aura	120	1	1	aura	123	1	1	allskills		1	1	charged	117	100	5	charged	155	5	25	addxp		5	10																						0
+Haven of Light	1156	100	1			3	1	40	50	obb	Heavenly Stone		5	5000	whit							sor		2	2	pierce-ltng		30	50	pierce-fire		30	50	pierce-cold		30	50	skill	65	3	3	skill	63	3	3	skill	61	3	3	mana-kill		4	7																		0
+Utterance of Power	1157	100	1			1	1	56	65	obc	eldritch orb		5	5000	cgrn	cgrn						extra-fire		35	50	extra-cold		35	50	extra-ltng		35	50	charged	154	200	7	charged	91	20	5																														0
+Star of David	1158	100	1			1	1	63	72	obd	demon heart		5	5000								allskills		2	2	dex		25	25	enr		25	25	ac%		25	25	heal-kill		15	25	res-mag		65	65	move2		20	20	sock		1	1																		0
+Soul Of The Tanar'Ri	1159	100	1			3	1	60	68	obd	Demon Heart		5	5000	blac	blac						allskills		1	1	red-dmg%		20	20	abs-fire%		15	20	abs-cold%		15	20	abs-ltng%		15	20	fade		1	1	move3		30	30	mana%		40	40																		0
+Unity of Mind	1160	100	1			3	1	65	73	obe	vortex orb		5	5000	oran	oran						sor		2	2	mana/lvl	24			dmg-to-mana		25	25	regen-mana		100	100	skill	58	7	7	cast3		50	50	res-all		40	40	addxp		5	5																		0
+Athena's Tirade	1161	100	1			1	1	72	78	obe	Vortex Orb		5	5000								sor		3	3	aura	conviction	5	5	ac		200	200	dmg-to-mana		25	25	all-stats		35	35	regen		25	25	regen-mana		150	150	mag%		50	75	gold%		100	200														0
+Oracle's Riddle	1162	100	1			1	1	80	84	obf	dimensional shard		5	5000								dmg-min		25	50	dmg-max		175	225	swing3		50	50	manasteal		20	20	ignore-ac		1	1	oskill	valkyrie	7	7	block		25	35	block3		50	50	balance3		40	40	allskills		1	3										0
+Blanched Death	1163	100	1			1	1	1	8	ne1	preserved head		5	5000				invnec7				ac/lvl	8			skill	69	1	3	skill-rand	2	66	76	res-cold		25	35	gethit-skill	67	8	4	nec		1	1																										0
+Goblin Grin	1164	100	1			3	1	1	4	ne1	Preserved Head		5	5000	lgrn	lgrn						ac%		40	60	block		15	20	block1		20	20	skill	69	1	2	skill	70	1	2	cast1		15	15																										0
+Paingiver	1165	100	1			1	1	1	12	ne2	zombie head		5	5000				invnec8				ac		25	40	skilltab	6	1	3	skill	66	1	3	mana		25	25	block		15	25	block1		15	15																										0
+Death's Witness	1166	100	1			3	1	1	9	ne2	Zombie Head		5	5000	dgry	dgry						ac%		45	65	block		10	20	move2		25	25	nec		1	1	ac		15	25	res-pois		35	35	cast1		15	15																						0
+Death Mauler	1167	100	1			1	1	1	19	ne3	unraveller head		5	5000								ac%		75	100	skilltab	7	1	3	charged	126	100	10	att		200	200	dmg-norm		5	10	block2		20	20	balance2		25	25																						0
+Scalphunter	1168	100	1			3	1	1	15	ne3	Unraveller Head		5	5000	lyel	lyel						ac%		50	70	block		20	30	block2		25	25	skilltab	6	1	3	red-dmg		8	10	demon-heal		15	15	cast2		20	20																						0
+Steel Weevil	1169	100	1			1	1	4	24	ne4	gargoyle head		5	5000	whit							ac%		80	110	skilltab	8	1	3	skill-rand	2	66	89	skill-rand	3	66	89	red-dmg%		10	15	block3		30	30	res-all		20	30																						0
+Sinister Smile	1170	100	1			3	1	1	20	ne4	Gargoyle Head		5	5000				invnec1				ac%		55	75	balance2		25	25	block2		25	25	nec		1	1	res-ltng		25	40	res-fire		35	50	hp		50	50																						0
+Undead Beholder	1171	100	1			1	1	10	30	ne5	demon head		5	5000	dyel	dyel						ac		45	60	allskills		1	1	block		25	25	balance2		15	15	move2		20	20	rep-dur	20			heal-kill		8	10	mana-kill		5	7																		0
+Chiaroscuro Visage	1172	100	1			3	1	6	26	ne5	Demon Head		5	5000	lred	lred						ac%		60	80	block		25	35	swing2		20	20	skilltab	7	1	3	dmg-norm		10	20	crush		35	35	dmg-pois	175	100	100	cast2		25	25																		0
+King Tut	1173	100	1			1	1	15	35	ne6	mummified trophy		5	5000								ac%		110	140	nec		1	2	gold%		100	100	mag%/lvl	8			block		20	40	block2		25	25	skill-rand	2	66	95	skill-rand	3	66	95																		0
+Janus' Face	1174	100	1			3	1	9	29	ne6	Mummified Trophy		5	5000				invnec2				ac%		90	110	balance3		25	25	block2		20	20	skilltab	8	1	3	mana-kill		3	5	pierce-pois		25	25	dmg-to-mana		10	15	cast2		20	20																		0
+Mystery of Life	1175	100	1			1	1	21	39	ne7	fetish trophy		5	5000								ac		75	125	skill	69	4	6	skill	70	3	5	skill	80	2	4	skill	95	1	3	hp%		20	20	hp/lvl	8			heal-kill		10	10	addxp		3	5														0
+Carrion Comfort	1176	100	1			3	1	13	33	ne7	Fetish Trophy		5	5000	lpur	lpur						ac%		100	140	block		15	40	balance2		25	25	skill-rand	3	66	95	skill-rand	2	76	95	skill-rand	1	88	95	abs-mag		8	12	cast2		25	25																		0
+Fallen Hero's Disgrace	1177	100	1			1	1	26	43	ne8	sextan trophy		5	5000	dgry	dgry						ac/lvl	16	140		nec		2	2	dex		30	30	str		30	30	block		25	50	red-dmg		10	15	red-mag		10	15	death-skill	59	100	37																		0
+Rictus of the Joker	1178	100	1			3	1	16	36	ne8	Sexton Trophy		5	5000				invnec6				ac%		100	150	block		25	50	block2		30	30	skilltab	6	1	3	nec		2	2	sock		2	2																										0
+Vow of Revenge	1179	100	1			1	1	35	47	ne9	cantor trophy		5	5000								ac%		120	170	skilltab	7			nec		2	2	block		25	50	death-skill	chain lightning	100	51	dex		20	20	res-fire		50	50	res-ltng		50	50	res-pois-len		50	95														0
+Dreamsender	1180	100	1			3	1	21	40	ne9	Cantor Trophy		5	5000	blac	blac						ac%		120	170	balance3		25	25	move2		25	25	nec		2	2	mag%		50	50	str		20	20	dex		20	20	rep-dur	10			dur		100	100														0
+Putrid Defiler	1181	100	1			1	1	42	52	nea	heirophant trophy		5	5000				invnec3				ac		135	170	skilltab	8			nec		2	2	block		35	35	levelup-skill	nova	100	60	vit		20	20	res-pois		50	50	res-cold		50	50	nofreeze		1	1														0
+Venomlord's Visage	1182	100	1			1	1	45	55	neb	minion skull		5	5000	dgrn	dgrn						ac%		150	200	oskill	inferno	15	20	res-fire		75	100	allskills		1	1	demon-heal		35	50	skill-rand	3	66	95	skill-rand	3	66	95	addxp		3	5																		0
+Reaper's Trophy	1183	100	1			3	1	39	49	neb	Minion Skull		5	5000								ac%		130	180	block		20	40	block2		30	30	allskills		2	2	hp/lvl	9			mana/lvl	9			res-cold		45	45	rip		1	1																		0
+Devil's Advocate	1184	100	1			1	1	54	63	neg	hellspawn skull		5	5000				invnec10				ac		150	200	block		25	35	balance3		40	40	mana-kill		10	10	regen-mana		50	50	oskill	warmth	1	1	skill	95	4	7	sock		2	2																		0
+Dreadmother	1185	100	1			3	1	47	57	neg	Hellspawn Skull		5	5000	oran	oran						ac%		160	200	balance2		25	25	move2		25	25	skilltab	7	1	3	oskill	poison javelin	5	8	oskill	plague javelin	5	8	pierce-pois		20	20	extra-pois		20	20	skill	92	5	5														0
+Nihlathak's Spirit	1186	100	1			1	1	62	71	ned	overseer skull		5	5000				invnec4				ac/lvl	12			skill	74	8	15	skill	95	1	3	move2		20	20	oskill	teleport	3	3	mana/lvl	12			red-dmg		15	15	res-all		25	35																		0
+Basilisk's Kiss	1187	100	1			3	1	58	66	ned	Overseer Skull		5	5000								ac%		200	300	block		50	60	block3		45	45	red-dmg%		20	30	sock		2	2	dmg-to-mana		10	15	cast2		30	30																						0
+Prayer for the Dying	1188	100	1			1	1	22	22	nee	succubae skull		5	5000				invnec9				ac%		150	200	rip		1	1	addxp		10	10	nec		3	3	block		50	50	sock		2	2																										0
+Ravings of the Mad	1189	100	1			1	1	82	86	nef	bloodlord skull		5	5000				invnec5				ac		200	300	mag%		65	65	gold%		150	150	all-stats		25	25	cast3		40	40	pierce		100	100	oskill	sword mastery	8	12	swing2		20	20	dmg-norm		10	30	nec		1	2										0
+Validator	1190	100	1			1	1	1	8	pa1	targe		5	5000				invshld25				ac		20	25	block		15	25	block1		15	15	res-all		15	20	dmg%		15	20	dmg-max		4	9	swing1		10	10																						0
+Seafarer's Security	1191	100	1			3	1	1	5	pa1	Targe		5	5000	lblu							ac		10	15	dmg%		15	25	block		20	25	sock		2	2																																		0
+Swiftfoot Slash	1192	100	1			1	1	1	17	pa2	rondache		5	5000								ac%		75	100	block		20	30	block1		15	15	dmg%		20	30	swing2		20	20	move2		20	20	balance2		25	25																						0
+Grip of the Gorgon	1193	100	1			3	1	1	10	pa2	Rondache		5	5000	cgrn	cgrn						ac%		50	80	block		15	30	str		25	25	skilltab	10	1	3	slow		15	25	howl		75	75																										0
+Felix's Brace	1194	100	1			1	1	2	22	pa3	heraldic shield		5	5000	oran	oran						ac%		75	100	block		25	35	block2		20	20	dex		15	15	res-all		15	25	red-dmg		10	15	balance3		40	40																						0
+Secret of Steel	1195	100	1			3	1	1	15	pa3	Heraldic Shield		5	5000								ac%		75	100	ac		20	40	red-dmg%		10	20	ease		-15	-15	block		15	15	block2		25	25	balance2		25	25																						0
+Bastion of Hope	1196	100	1			3	1	1	20	pa4	aerin shield		5	5000	cgrn	cgrn						ac%		90	130	block		25	35	block2		20	20	str		20	20	vit		15	15	addxp		3	5	pal		1	1	res-all		15	25																		0
+Hellchatter	1197	100	1			1	1	7	27	pa4	Aerin Shield		5	5000	dred	dred						ac		40	50	pal		1	1	res-all		60	70	dmg-fire		16	24	hit-skill	76	10	7	rep-dur	7			dur		45	45																						0
+King's Guard	1198	100	1			3	1	5	25	pa5	crown shield		5	5000	cred	cred						ac		75	120	block		30	40	block2		20	20	dmg%		20	30	red-dmg%		15	15	res-mag		15	15	lifesteal		5	5	cheap		10	15																		0
+Devourer of Worlds	1199	100	1			1	1	12	32	pa5	Crown Shield		5	5000	blac	blac						ac%		75	100	dmg%		25	50	sock		2	4	pal		1	2																																		0
+Death to the Soul	1200	100	1			1	1	20	37	pa6	akaran targe		5	5000	blac	blac						ac%		120	150	block		30	45	balance2		25	25	allskills		1	1	res-all		40	60	rip		1	1	sock		1	1	charged	258	5	12																		0
+Twilight Presence	1201	100	1			3	1	10	30	pa6	Akaran Targe		5	5000	lgry	lgry						ac%		100	140	stupidity		3	3	att%		25	25	dmg-demon		100	100	move2		30	30	block		25	25	balance2		25	25																						0
+Knight's Holy Sigil	1202	100	1			1	1	25	41	pa7	akaran rondache		5	5000	whit	whit						ac/lvl	16			block		35	45	block2		30	30	dmg-demon		200	200	dmg-undead		200	200	dmg%		30	40	att%		25	25	pal		1	2	skill	117	2	3														0
+Voice of the Prophet	1203	100	1			3	1	14	34	pa7	Akaran Rondache		5	5000								charged	138	1	30	charged	149	1	30	charged	155	1	30	res-all		40	40	allskills		2	2	hp%		15	15	rip		1	1																						0
+Defender of Innocence	1204	100	1			1	1	29	45	pa8	protector shield		5	5000								ac%		120	160	ac		35	50	block		25	30	balance2		35	35	aura	104	5	8	gethit-skill	40	17	1	res-mag		15	15																						0
+Black Rain	1205	100	1			3	1	21	39	pa8	Protector Shield		5	5000	blac	blac						ac%		100	150	res-fire		50	50	res-cold		35	35	dmg-ltng		10	100	stupidity		2	2	kill-skill	Static Field	100	3	aura	118	5	8																						0
+Crusader's Will	1206	100	1			1	1	40	50	pa9	guilded shield		5	5000	oran	oran						ac%		125	175	block		35	35	balance2		20	20	cast3		40	40	mana		70	125	mana-kill		6	10	all-stats		10	10	pal		2	2																		0
+Wisdom of Thoth	1207	100	1			3	1	36	46	paa	royal shield		5	5000	dpur	dpur						ac		100	150	allskills		2	2	skilltab	10	1	3	enr		25	25	addxp		3	5	res-all		30	60	sock		2	2																						0
+Grand Inquisitor	1208	100	1			1	1	44	54	paa	Royal Shield		5	5000								ac%		125	200	block		35	35	block3		50	50	balance3		50	50	addxp		10	15	dmg%		50	50	pal		3	3	res-all-max		10	10																		0
+Ancients' Epiphany	1209	100	1			3	1	45	55	pab	sacred targe		5	5000	dgld	dgld						ac		125	225	block		50	60	block3		30	30	dmg%		60	60	dmg/lvl	2			charged	138	25	7	charged	149	25	7	charged	155	25	7																		0
+Cleric's Rebuke	1210	100	1			1	1	64	72	pab	Sacred Targe		5	5000				invshld32				ac		150	200	aura	thorns	15	20	gethit-skill	82	15	5	res-all		75	75	pal		2	2	gold%		200	200	mag%/lvl	8			regen		10	15																		0
+Dawn Blesser	1211	100	1			1	1	60	68	pac	sacred rondache		5	5000	lyel	lyel						ac%		150	200	dmg%		35	50	res-all		35	50	red-dmg%		15	25	abs-fire%		10	15	abs-ltng%		15	15	abs-cold%		15	20	res-pois-len		50	50	pal		2	2														0
+Faith's Promise	1212	100	1			3	1	62	70	pad	ancient shield		5	5000	dyel	dyel						ac		150	200	block		35	35	balance2		30	30	aura	108	5	7	skill-rand	8	96	125	rep-dur	12			demon-heal		10	15																						0
+Dawnfall	1213	100	1			1	1	70	77	pad	Ancient Shield		5	5000								gethit-skill	62	3	30	ac%		140	200	red-dmg%		35	35	res-all		50	75	skill-rand	3	96	125	move2		25	25	swing3		30	30																						0
+God's Word	1214	100	1			1	1	75	81	pae	zakarum shield		5	5000	cblu	cblu						ac/lvl	24			dmg%		50	50	dmg-norm		15	40	sock		4	4	pal		1	3																														0
+Valorsong	1215	100	1			2	1	1	12	paf	vortex shield		5	5000	oran	oran						allskills		2	2	ac/lvl	19			res-all		60	100	gethit-skill	149	5	4	gethit-skill	138	5	4	openwounds		88	88	dmg-to-mana		15	20	oskill	warmth	1	1																		0
+Fortress of Morpheus	1216	100	1			1	1	84	88	paf	Vortex Shield		5	5000								pal		4	4	ac%		175	175	red-dmg%		10	15	res-all		30	50	sock		4	4																														0
+Madman's Bluster	1217	100	1			1	1	1	12	ba1	jawbone cap		5	5000								ac%		75	100	res-all		10	20	skill	130	1	3	dmg-max		4	6	dmg-min		1	2	swing1		10	10	balance2		20	20	enr		-5	-5																		0
+Chaos Kin	1218	100	1			3	1	1	6	ba1	Jawbone Cap		5	5000		oran						ac		10	15	bar		1	1	red-dmg		3	5	dmg-max		8	12	res-ltng		15	25	howl		66	66																										0
+Pitykiller	1219	100	1			3	1	1	11	ba2	fanged helm		5	5000								ac		20	40	dmg%		15	15	levelup-skill	frozen armor	100	25	res-fire		20	30	res-cold		25	25	nofreeze		1	1																										0
+Darkhunger	1220	100	1			1	1	1	18	ba2	Fanged Helm		5	5000		cred						ac		10	20	stupidity		2	2	res-all		10	15	lifesteal		5	8	heal-kill		3	5	skilltab	12	1	3																										0
+Kygragond	1221	100	1			1	1	3	23	ba3	horned helm		5	5000				invhelm34				ac%		90	120	skilltab	12	1	3	block		15	15	block1		15	15	move1		10	10	manasteal		3	3	mana-kill		2	4																						0
+Dragonkin	1222	100	1			3	1	1	17	ba3	Horned Helm		5	5000		dgrn						ac%		50	75	dur		25	25	rep-dur	20			att		125	125	dmg-fire		10	20	block		15	15	red-dmg%		5	10																						0
+Invader's Glee	1223	100	1			1	1	7	27	ba4	assault helm		5	5000								ac%		100	125	lifesteal		3	5	gold%		75	75	mag%		25	25	rep-dur	15			dur		25	25	openwounds		44	44	skilltab	13	1	3																		0
+Blood Dancer	1224	100	1			3	1	2	22	ba4	Assault Helmet		5	5000		dred						ac		25	50	bloody		1	1	noheal		1	1	move3		25	25	dex		15	15	hp		25	25	res-cold		25	25	res-fire		20	35																		0
+Warsummoner	1225	100	1			1	1	11	31	ba5	avenger guard		5	5000								ac%		100	125	skilltab	14	1	3	oskill	revive	2	2	addxp		3	5	res-pois		35	35	abs-fire		8	10	abs-ltng		8	10	str		15	20																		0
+Chimera's Chaos	1226	100	1			3	1	6	26	ba5	Avenger Guard		5	5000		lyel						ac%		100	140	dmg%		25	25	red-dmg%		10	10	res-all		15	15	oskill	inferno	6	10	str		20	20																										0
+Helms Deep	1227	100	1			1	1	15	35	ba6	jawbone visor		5	5000	dgrn	dgrn						ac		100	120	dmg%		30	50	red-dmg%		15	15	res-mag		15	15	indestruct		1	1	all-stats		10	15	hp		50	75																						0
+Deadgaze	1228	100	1			3	1	10	30	ba6	Jawbone Visor		5	5000	dgry	blac						ac%		100	150	rip		1	1	howl		99	99	manasteal		8	8	mana		35	50	res-ltng		25	25	block		15	15																						0
+Malefactor's Reward	1229	100	1			1	1	22	40	ba7	lion helm		5	5000	lyel							ac%		110	135	bar		2	2	oskill	bone armor	3	3	oskill	life tap	1	1	regen		3	5	res-pois-len		50	50	half-freeze		1	1	balance2		20	20																		0
+Gambler's Glory	1230	100	1			3	1	13	33	ba7	Lion Helm		5	5000	dgld	lpur						ac		50	100	gold%		100	100	mag%/lvl	8			bar		1	1	skilltab	12	1	3	balance2		20	20	swing1		15	15																						0
+Primal Lust	1231	100	1			1	1	26	43	ba8	rage mask		5	5000				invhelm31				ac%		150	170	dmg-max		15	20	dmg-min		3	5	balance3		30	30	swing1		15	15	block2		20	20	vit		15	15	str		10	10																		0
+Slayer's Glee	1232	100	1			3	1	16	36	ba8	Rage Mask		5	5000	whit							ac%		125	150	skill	147	5	5	skill	152	2	2	bar		1	1	kill-skill	decrepify	50	1	gethit-skill	77	25	2	regen		10	10																						0
+Hanabal's Crown	1233	100	1			1	1	30	46	ba9	savage helm		5	5000	cgrn	cgrn						ac%		150	200	dur		75	75	allskills		2	2	skilltab	13	1	1	cheap		15	15	hp%		10	10	skill-rand	3	126	155	skill-rand	2	126	155																		0
+Hellraiser's Casque	1234	100	1			3	1	19	39	ba9	Savage Helmet		5	5000	lred							ac%/lvl	16			rep-dur	9			bar		2	2	heal-kill		10	10	addxp		5	5	sock		2	3																										0
+Vanguard	1235	100	1			1	1	41	51	baa	slayer guard		5	5000		blac						ac		150	190	bar		1	1	skill-rand	5	126	155	skill-rand	4	126	155	skill-rand	3	126	155	red-dmg		20	30	res-mag		20	30	abs-fire		10	20	block		25	25														0
+Conqueror's Feast	1236	100	1			3	1	40	50	bab	carnage helm		5	5000	lred	lred						ac/lvl	14			ac		75	100	heal-kill		10	15	regen		10	15	mana		50	50	move2		20	20	sock		2	2	res-all		25	25																		0
+Foul Embrace	1237	100	1			1	1	47	57	bab	Carnage Helm		5	5000	dgrn	dgrn						ac%		150	200	allskills		3	3	dmg-pois	200	1200	1200	res-all		55	75	regen		-12	-12	dmg-to-mana		10	10	manasteal		6	8	regen-mana		100	100																		0
+Death Knight's Mask	1238	100	1			1	1	58	66	bac	fury visor		5	5000				invhelm35				ac		200	240	skilltab	12	2	4	skilltab	13	2	4	skilltab	14	2	4	lifesteal		10	10	manasteal		8	8	howl		50	50	freeze		3	3																		0
+Wasteland Visage	1239	100	1			1	1	68	74	bad	destroyer helm		5	5000								ac%		150	200	regen		-2	-2	bar		2	2	dmg-norm		10	15	hp		60	60	res-cold		50	50	res-fire		40	50	res-ltng		31	40	crush/lvl	4																0
+Insight of the Ancients	1240	100	1			1	1	77	82	bae	conqueror helm		5	5000	dgld	dgld						ac%		100	140	ethereal		1	1	rep-dur	50			enr		40	40	addxp		20	20	bar		2	2																										0
+Archon's Ache	1241	100	1			3	1	76	81	baf	guardian crown		5	5000	cblu	cblu						ac%		180	210	dmg%		35	35	swing2		20	20	crush		33	33	deadly		50	50	wounds/lvl	12			dmg/lvl	4			charged	87	33	15																		0
+Conscience of the King	1242	100	1			1	1	83	87	baf	Guardian Crown		5	5000								ac		200	300	res-all		25	25	red-dmg%		15	15	allskills		1	3	mag%		50	50	addxp		5	10	block		20	30	all-stats		20	30	slow		20	30														0
+Morning After	1243	100	1			1	1	1	12	dr1	wolf head		5	5000								ac%		100	120	regen		8	12	skilltab	15	1	2	dmg%		20	20	mana-kill		5	5	sock		1	1																										0
+Blood Brother	1244	100	1			3	1	1	4	dr1	Wolf Head		5	5000	lred	lred						ac%		50	75	lifesteal		5	8	hp		25	25	mana		20	20	skill	223	1	3	skill	224	1	3																										0
+Swift Slaughter	1245	100	1			1	1	1	16	dr2	hawk helm		5	5000								ac%		105	125	dmg-max		6	10	swing2		20	20	lifesteal		5	5	skilltab	16	1	2	att		75	75																										0
+Copperbite	1246	100	1			3	1	1	8	dr2	Hawk Helm		5	5000	lgld	lgld						ac%		55	75	ac		10	15	rep-dur	7			res-pois		55	55	dmg-pois	100	100	100	dru		1	1																										0
+Yamanda's Token	1247	100	1			1	1	2	21	dr3	antlers		5	5000								ac%		110	130	dru		1	1	block		15	25	extra-fire		10	10	skill	226	1	3	rep-dur	15			dmg-to-mana		5	10																						0
+Silverskin	1248	100	1			3	1	1	14	dr3	Antlers		5	5000	whit	whit						ac		35	45	red-dmg		8	10	move2		25	25	skilltab	16	1	3	deadly		15	25	dmg-cold		10	15	freeze		2	2																						0
+Voltar's Feather	1249	100	1			1	1	4	24	dr4	falcon mask		5	5000	dgry	dgry						ac%		115	135	res-mag		15	15	dmg-ltng		1	75	res-ltng		25	25	enr		25	25	move2		15	15																										0
+Eye of Heaven	1250	100	1			3	1	1	19	dr4	Falcon Mask		5	5000								ac%		65	100	half-freeze		1	1	enr		15	15	vit		15	15					cast2		25	25																										0
+Lion's Pride	1251	100	1			1	1	10	30	dr5	spirit mask		5	5000	dyel	dyel						ac%		120	140	str		20	20	deadly		20	20	dmg-min		5	5	balance2		20	20	str/lvl	6			mag%		30	30																						0
+Wraith Whisper	1252	100	1			3	1	5	25	dr5	Spirit Mask		5	5000	dgry	dgry						ac%		80	110	dru		1	1	skilltab	17	1	2	light		3	5	ethereal		1	1	rep-dur	15			res-cold/lvl	8																								0
+Moonshadow	1253	100	1			3	1	9	29	dr6	alpha helm		5	5000	blac	blac						ac%		150	180	fade		1	1	res-ltng		15	30	hp		20	40	heal-kill		10	10	ac/lvl	8			charged	267	15	3																						0
+The King's Heart	1254	100	1			1	1	14	34	dr6	Alpha Helm		5	5000								ac%		100	125	allskills		1	1	res-all		25	25	dmg%		25	25	skill	238	7	7	hp%		20	25																										0
+Gathering of Hawks	1255	100	1			1	1	20	38	dr7	griffon headress		5	5000	lred	lred						ac		75	100	skill	221	4	4	skill-rand	1	221	250	skill-rand	2	221	250	skill-rand	3	221	250	res-cold/lvl	8			hp/lvl	4			res-fire/lvl	4																				0
+Creeper's Canopy	1256	100	1			3	1	13	33	dr7	Griffon Headress		5	5000				invhelm14				ac%		100	135	skill	223	5	7	skill	232	5	7	skill	242	5	7	howl		75	75	balance2		25	25	regen-mana		50	50																						0
+Centaur's Sight	1257	100	1			3	1	19	37	dr8	hunters guise		5	5000	oran	oran						ac%		155	185	skill-rand	2	221	250	skill-rand	3	221	250	skilltab	17	2	2	balance2		20	20	ignore-ac		1	1	stamdrain		35	35	dmg-undead		75	75																		0
+Night Prowler	1258	100	1			1	1	28	43	dr8	Hunter's Guise		5	5000	blac	blac						ac%		120	150	dru		2	2	skilltab	15	1	2	move3		50	50	balance2		25	25	swing2		15	15	block3		40	40																						0
+Phoenix Fall	1259	100	1			1	1	34	46	dr9	sacred feathers		5	5000	cred	cred						ac%		160	190	dmg-fire		35	100	dru		1	1	extra-fire		10	15	res-all		25	25	light		1	3	sock		1	1																						0
+Falcon Sharp	1260	100	1			3	1	24	40	dr9	Sacred Feathers		5	5000								ac%		125	150	dmg%		50	50	res-all		20	20	dmg-ltng		15	250	dmg-fire		25	60	oskill	inner sight	2	4	all-stats		15	15	skilltab	16	1	2																		0
 Leader of the Pack	1261	100	1			1		1	50	dra	totemic mask		5	5000	dgry	dgry						ac%		170	200	allskills		1	1	skill-rand	3	221	250	skill-rand	3	221	250	skill	237	3	3	skill	227	3	3	move2		20	20	balance2		20	20	hp%		10	10														0
-Call of the Wild	1262	100	1			1		1	60	drb	blood spirit		5	5000								ac		150	200	skill	227	7	7	skill	237	7	7	skill	247	7	7	allskills		2	2	dmg%		25	50	swing2		25	25	dex		25	25	lifesteal		6	6														0
-Eagle Eyes	1263	100	1			1		1	65	drc	sun spirit		5	5000								ac		160	210	skilltab	15	3	3	dru		1	1	red-dmg		15	15	charged	17	20	20	res-pois-len		60	60	att%		35	35	sock		1	1																		0
-Sanctuary's Scion	1264	100	1			3		1	59	drc	Sun Spirit		5	5000	dyel	dyel						ac%		150	200	dru		2	2	red-dmg%		20	20	red-mag		20	20	mag%		25	50	att%		35	50	skill-rand	7	222	251																						0
-Spirit of the Land	1265	100	1			1		1	72	drd	earth spirit		5	5000								ac		175	240	red-dmg%		25	25	res-mag		25	25	all-stats		25	25	balance2		25	25	move2		25	25	hp%		25	25	dru		1	1																		0
-Hecuba's Tresses	1266	100	1			1		16	16	dre	sky spirit		5	5000								ac		240	300	dru		4	4	sock		3	3																																						0
-Call of the Kindred	1267	100	1			1		1	86	drf	dream spirit		5	5000				invhelm37				ac		200	240	skill	223	3	7	skill	224	3	7	skill	228	3	7	swing1		10	10	hp		50	50	lifesteal		3	6	manasteal		3	6	dru		1	1														0
-Stone Feather	1268	100	1			3		43	43	drf	Dream Spirit		5	5000	oran	oran						ac%		200	300	red-dmg%		25	50	ease		-65	-65	sock		3	3	allskills		2	2																														0
-Killerwatch	1269	100	1			1		15	15	ktr	katar		5	5000								dmg-min		10	20	dmg-max		30	40	skilltab	18	1	3	swing1		15	15	charged	90	1	6																														0
-Hidden Death	1270	100	1			3		1	7	ktr	katar		5	5000	blac	blac						dmg%		100	150	dmg-max		6	10	deadly		25	35	skill	252	1	2																																		0
-Simpleton's Shadow	1271	100	1			5		25	25	ktr	Katar		5	5000	dgry	dgry						dmg%		60	75	move2		25	25	lifesteal		3	5	ass		1	1																																		0
-Razorspine	1272	100	1			1		19	19	wrb	wrist blade		5	5000				invclaw1				dmg-min		12	23	dmg-max		32	42	skilltab	19	1	3	thorns		15	15	noheal		1	1	res-pois		15	20																										0
-Storms of Spring	1273	100	1			3		1	13	wrb	wrist blade		5	5000	whit	whit						dmg%		105	155	dmg-ltng		10	15	res-ltng		15	25	gethit-skill	38	8	5	block		15	15																														0
-Murdering Bloom	1274	100	1			5		1	8	wrb	Wrist Blade		5	5000	cred	cred						dmg%		60	80	ass		1	1	kill-skill	charged bolt	25	5	swing1		15	15	sock		1	1																														0
-Spirit Hawk	1275	100	1			1		25	25	axf	hatchet hands		5	5000								dmg-min		14	25	dmg-max		34	44	skilltab	20	1	3	oskill	oak sage	3	5	res-mag		10	15	dmg-mag		25	40																										0
-Cold of Winter	1276	100	1			3		1	16	axf	hatchet hands		5	5000	whit	whit						dmg%		110	160	dmg-cold	200	10	15	gethit-skill	44	5	2	swing2		20	20	rep-dur	20			skill	257	1	3	skill	256	1	3																						0
-Crimson Cry	1277	100	1			5		1	11	axf	Hatchet Hands		5	5000	dred	dred						dmg%		65	85	bloody		1	1	noheal		1	1	howl		66	66	swing2		25	25	oskill	shout	2	2																										0
-Samantha's Fist	1278	100	1			1		28	28	ces	cestus		5	5000								dmg-min		16	27	dmg-max		36	46	skilltab	19	1	3	swing2		25	25	sock		2	2																														0
-Androsphinx	1279	100	1			3		1	20	ces	cestus		5	5000	dred	dred						dmg%		115	165	swing1		15	15	move2		20	20	lifesteal		6	6	ac-hth		200	200	crush		15	15	ass		1	1																						0
-Liege Reaver	1280	100	1			5		1	15	ces	Cestus		5	5000	cgrn	cgrn						dmg%		65	90	dmg-norm		5	10	skilltab	20	1	3	rep-dur	25			dur		75	75	att		150	150	openwounds		33	33																						0
-Frostshiver	1281	100	1			1		30	30	clw	claws		5	5000	lblu	lblu						dmg-min		22	35	dmg-max		45	70	skilltab	18	1	3	dmg-cold		25	35	freeze		3	3	gethit-skill	40	4	6	charged	55	81	6	res-cold		25	35																		0
-Lynx Talon	1282	100	1			3		1	24	clw	claws		5	5000	dyel	dyel						dmg%		120	170	swing3		25	25	mana-kill		3	5	aura	104	1	3	balance2		25	25	dex		20	20	res-fire		25	25																						0
-Winterquick	1283	100	1			5		1	19	clw	Claws		5	5000	whit	whit						dmg%		65	100	dmg-cold	300	15	25	swing2		30	30	skill	252	2	2	pierce-cold		15	15	oskill	frost nova	5	5	dmg-max		10	15																						0
-Nightmare Glove	1284	100	1			1		31	32	btl	blade talons		5	5000	blac	blac						dmg-min		25	35	dmg-max		60	80	skilltab	19	1	3	extra-fire		10	10	extra-ltng		10	10	res-all		15	15	lifesteal		4	7	att%		20	20																		0
-Key to the Madhouse	1285	100	1			3		1	28	btl	blade talons		5	5000	oran	oran						dmg%		125	175	dmg-norm		15	30	enr		15	15	mag%		25	35	allskills		1	1	skilltab	18	1	3	sock		2	2																						0
-Bladespan	1286	100	1			5		1	22	btl	Blade Talons		5	5000								dmg%		70	100	ignore-ac		1	1	ass		1	1	skilltab	19	1	2	slow		20	20	skill-rand	3	251	268	dmg-norm		11	22																						0
-Dark Demense	1287	100	1			1		32	38	skr	scissors katar		5	5000	dgry	dgry						dmg-min		35	45	dmg-max		80	100	skilltab	20	1	3	ass		1	1	allskills		1	1	stupidity		2	2	gethit-skill	71	11	4	rep-dur	17																				0
-Martial Law	1288	100	1			3		1	33	skr	scissors katar		5	5000	dgld	dgld						dmg%		130	180	skilltab	20	3	5	str		15	15	dex		20	20	vit		25	25	red-dmg%		10	15	crush		20	20	deadly/lvl	6																				0
-Troll's Touch	1289	100	1			5		1	27	skr	Scissors Katar		5	5000	lgrn	lgrn						dmg%		80	120	regen		25	25	lifesteal		6	8	manasteal		6	8	regen-mana		75	75	ass		2	2	dmg-norm		15	30																						0
-Keys to Hell	1290	100	1			1		55	52	9ar	quhab		5	5000	cred	cred						dmg%		100	100	dmg-min		20	40	dmg-max		50	90	allskills		2	2	block1		25	25	dmg-demon		200	200	charged	88	45	15	skilltab	18	2	2																		0
-Storm Demon's Glair	1291	100	1			3		1	37	9ar	quhab		5	5000	dyel	dyel						dmg%		180	230	skilltab	19	1	3	hit-skill	48	6	9	ignore-ac		1	1	oskill	vengeance	2	4	regen-mana		25	25	cast1		15	15																						0
-Corpseflayer	1292	100	1			5		1	29	9ar	Quhab		5	5000				invclaw3				dmg%		135	190	ass		1	1	dmg-undead		250	250	deadly		15	25	skilltab	19	1	3	att		100	250	reanimate	7	10	10																						0
-Sabertooth	1293	100	1			1		55	56	9wb	wrist spike		5	5000	whit	whit						dmg%		100	100	dmg-min		20	40	dmg-max		50	90	skilltab	19	1	3	ass		1	1	res-cold		25	35	regen		15	15	str		15	15	red-dmg		10	15														0
-Pleasures of the Perverse	1294	100	1			3		1	41	9wb	wrist spike		5	5000								dmg%		190	240	swing3		30	30	ass		2	2	skill	260	1	3	skill	263	1	3	charged	68	25	20	kick/lvl	8			sock		1	1																		0
-Dusk Ray	1295	100	1			5		1	32	9wb	Wrist Spike		5	5000	oran	oran						dmg%		140	180	dmg-norm		20	40	allskills		1	1	skilltab	20	1	1	dmg-fire		40	90	aura	109	4	9	swing2		30	30	mana		35	35																		0
-Razor Knuckle	1296	100	1			1		55	60	9xf	fascia		5	5000								dmg%		100	100	dmg-min		22	40	dmg-max		53	90	skilltab	18	3	3	swing2		30	30	cast2		25	25	thorns/lvl	8																								0
-Heat of Summer	1297	100	1			3		1	43	9xf	fascia		5	5000	lred	lred						dmg%		200	250	dmg-fire		75	150	res-cold		25	50	abs-fire%		10	10	fireskill		5	5	dex		15	15	skill-rand	3	251	280	dmg-norm		15	30																		0
-Scarab Cleaver	1298	100	1			5		1	36	9xf	Fascia		5	5000	cblu	cblu						dmg%		150	200	swing2		20	20	ass		2	2	sock		1	2	res-ltng		75	75	abs-ltng		20	25	dmg-demon		150	250	dmg-max		10	10																		0
-Fullsuffering	1299	100	1			1		55	63	9cs	hand scythe		5	5000				invclaw2				dmg%		100	120	dmg-min		24	40	dmg-max		55	90	skilltab	20	2	2	allskills		2	2	hit-skill	66	20	5	res-fire		25	35	cheap		5	10	mana-kill		6	6														0
-Chi Strike	1300	100	1			3		1	46	9cs	hand scythe		5	5000	lpur	lpur						dmg%		205	255	skill	253	5	7	ass		1	1	deadly		33	33	res-all		20	40	enr		15	25	red-dmg		10	15	heal-kill		8	8																		0
-Slithertongue	1301	100	1			5		1	38	9cs	Hand Scythe		5	5000	lgrn	lgrn						dmg%		175	220	res-pois		45	45	res-pois-max		10	20	res-pois-len		75	75	dmg-pois	125	1000	1000	skilltab	20	1	3	dex		15	15	enr		20	20	dmg-max		15	20														0
-Wight Claw	1302	100	1			1		55	65	9lw	greater claws		5	5000	blac	blac						dmg%		110	130	dmg-min		27	40	dmg-max		60	90	skilltab	19	2	2	ass		1	1	lifesteal		10	10	manasteal		10	10	regen		10	10	regen-mana		65	65														0
-Shadowy Places	1303	100	1			3		1	48	9lw	greater claws		5	5000	dgry	dgry						dmg%		215	265	skill-rand	4	251	280	skill-rand	3	251	280	skill-rand	3	251	280	skill-rand	2	251	280	skill-rand	2	251	280	ass		1	1	swing2		20	20																		0
-Werewolf Talons	1304	100	1			5		1	40	9lw	Greater Claws		5	5000								dmg%		175	240	swing3		30	30	allskills		2	2	oskill	shape shifting	5	8	oskill	wearwolf	5	8	oskill	fury	1	3	att%		25	25	sock		1	2																		0
-Dark Nemesis	1305	100	1			1		55	68	9tw	greater talons		5	5000	dpur	dpur						dmg%		120	140	dmg-min		30	40	dmg-max		70	90	skilltab	18	1	3	swing2		25	25	sock		3	3																										0
-Adamantine Razors	1306	100	1			3		1	50	9tw	greater talons		5	5000	whit	whit						dmg%		220	270	ass		1	1	dmg-norm		30	60	indestruct		1	1	deadly		44	44	crush		27	27	skilltab	18	1	3	manasteal		6	6																		0
-Path of the Nightwalker	1307	100	1			1		55	70	9qr	scissors quhab		5	5000	blac	blac						dmg%		135	160	dmg-min		30	40	dmg-max		70	90	dmg/lvl	5			att%		35	35	balance2		25	25	all-stats		10	25	rep-dur	20			skill	267	7	7														0
-Fearsome Rumors	1308	100	1			3		1	54	9qr	scissors quhab		5	5000	dgrn	dgrn						dmg%		225	275	dmg-max		30	50	swing3		40	40	skill	260	3	5	skill	263	3	5	sock		1	1	ease		-100	-100	hp		75	75	res-pois		30	40														0
-Glitterkill	1309	100	1			5		1	49	9qr	Scissors Quhab		5	5000								dmg%		170	225	ass		2	2	res-mag		20	20	res-all		25	25	move2		25	25	skill	258	1	3	skill	264	1	3	rep-dur	5																				0
-Wakazashi	1310	100	1			1		1	64	7ar	suwayyah		5	5000	whit	whit						dmg%		250	300	ass		2	2	skilltab	20	1	3	swing3		30	30	ignore-ac		1	1	sock		2	2																										0
-Iniquity Razor	1311	100	1			3		1	55	7ar	Suwayyah		5	5000		lpur						dmg%		200	275	allskills		1	2	mag%/lvl	5			mag%		25	50	deadly		50	75	block		15	25	block3		40	40	skilltab	20	1	3																		0
-Biteblade	1312	100	1			1		1	71	7wb	wrist sword		5	5000	dred	dred						dmg%		250	300	dmg-norm		20	40	reduce-ac		15	15	noheal		1	1	skilltab	18	1	2	demon-heal		25	25	skill	260	1	3																						0
-Nightwrath	1313	100	1			1		1	76	7xf	war fist		5	5000								dmg%		250	300	dmg/lvl	6			block		15	25	skill	263	1	3	ass		1	1	fade		1	1	stupidity		1	1																						0
-Silent Shank	1314	100	1			3		38	38	7xf	War Fist		5	5000	blac	blac						dmg%		200	260	swing3		35	35	cast2		25	25	regen		10	15	nofreeze		1	1	cheap		20	20	fade		1	3	dmg/lvl	7																				0
-Flaming Fist	1315	100	1			1		1	79	7cs	battle cestus		5	5000	cred	cred						dmg%		250	300	allskills		1	1	dmg-fire		200	300	pierce-fire		15	15	abs-fire%		10	10	res-fire-max		15	15	res-fire		60	60	res-cold		35	35																		0
-Death Slaad1	1316	100	1			1		1	82	7lw	feral claws		5	5000	dgry	dgry						dmg%		250	300	dmg-norm		25	50	ass		2	2	dmg-max		25	50	rip		1	1	addxp		5	5	rep-dur	15																								0
-Spellfist	1317	100	1			1		1	85	7tw	runic talons		5	5000	oran	oran						dmg%		250	320	res-mag		25	25	red-mag		25	25	dmg-mag		75	200	oskill	battle command	3	3	skilltab	19	1	2	gethit-skill	49	6	12	res-all		25	25																		0
-Sin Sister	1318	100	1			3		45	45	7tw	Runic Talons		5	5000	blac	blac						dmg%		200	300	swing2		30	30	sock		3	3	dmg/lvl	7																																				0
-Avalanche Strike	1319	100	1			1		35	35	7qr	scissors suwayyah		5	5000	cblu	cblu						dmg%		300	400	dmg-cold	300	200	250	hit-skill	55	50	4	res-cold		45	45	rep-dur	15			lifesteal		6	8	manasteal		6	8																						0
-Torturer's Trust	1320	100	1			3		83	83	7qr	Scissors Suwayyah		5	5000								dmg%		225	300	allskills		2	2	skilltab	20	1	3	res-all		30	50	skill-rand	7	252	281	regen		15	20	gold%		100	100	mag%		25	50	att%		100	100														0
-Ring of Engagement	1321	100	1			9		3	3	rin	ring		5	5000				invring1				dmg-max		2	5	hp		10	20	str		5	5	aura	98	1	1																																		0
-Nameless Fear	1322	100	1			9		11	11	rin	ring		5	5000				invring3				dmg%		10	15	swing1		10	10	howl		45	45	noheal		1	1																																		0
-Elven Heartband	1323	100	1			8		18	18	rin	ring		5	5000				invring5				addxp		3	5	hp		20	30	red-dmg%		5	5	mag%		15	25	lifesteal		4	6																														0
-Knell of Discord	1324	100	1			8		20	20	rin	ring		5	5000				invring6				lifesteal		5	7	slow		15	15	knock		3	3	enr		10	10																																		0
-Vampiric Regeneration	1325	100	1			7		28	28	rin	ring		5	5000				invring8				hp		35	35	regen		8	12	regen-mana		35	35	regen-stam		20	20	manasteal		3	5	lifesteal		5	7																										0
-Golem's Might	1326	100	1			6		24	24	rin	ring		5	5000				invring10				str		25	25	dmg-norm		10	15	res-all		8	15	heal-kill		5	8	swing1		10	10																														0
-Planatar Enlightenment	1327	100	1			2		23	23	rin	ring		5	5000				invring12				allskills		1	1	res-all		8	15	hp		35	50	gold%		65	65	enr		20	20	addxp		3	5	cheap		8	10																						0
-Thief of Dreams	1328	100	1			5		50	50	rin	ring		5	5000				invring13				mag%		33	50	res-fire		25	35	mana		65	80	cast1		15	15	addxp		3	3																														0
-Jackal's Laughter	1329	100	1			3		64	64	rin	ring		5	5000				invring16				allskills		1	1	lifesteal		8	11	manasteal		7	8	hp		55	80	oskill	terror	6	6	deadly/lvl	3																												0
-Fellowship's Hope	1330	100	1			2		73	73	rin	ring		5	5000				invring18				allskills		1	1	mag%		25	35	res-all		15	15	red-dmg		5	8	red-mag		5	8	move1		10	10	cast1		10	10	block1		10	10																		0
-Faerie Ring	1331	100	1			1		82	82	rin	ring		5	5000				invring20				allskills		1	1	hp%		15	15	mana%		15	15	light		7	7	fade		1	1	block		15	20	mag%		25	50	balance2		20	20																		0
-Stone Of Jordan*	1332	100	1			1		85	85	rin	ring		5	5000				invring21				allskills		2	2	mana%		40	40	cast1		15	15	dmg-ltng		10	100																																		0
-Eye of Kahn	1333	100	1			9		3	3	amu	amulet		5	5000				invammy7				hp		25	35	mana		25	35	dex		5	10	str		5	10	dmg-max		3	6																														0
-Psyche Shroud	1334	100	1			9		6	6	amu	amulet		5	5000				invammy5				move2		15	15	res-ltng		20	20	hp		20	30	enr		10	10																																		0
-Amulet of Warding	1335	100	1			7		12	12	amu	amulet		5	5000				invammy2				red-dmg		5	8	res-all		10	15	red-mag		4	6	block		5	12	ac		35	50																														0
-Cryptking	1336	100	1			6		27	27	amu	amulet		5	5000				invammy8				oskill	skeleton mastery	5	10	oskill	raise skeletal mage	3	5	dmg-undead		200	200	allskills		1	1	regen		6	8	regen-mana		25	50																										0
-Sequence of Seasons	1337	100	1			6		30	30	amu	amulet		5	5000				invammy4				allskills		1	1	dmg-cold	100	15	25	dmg-ltng		1	70	dmg-fire		30	50	aura	103	1	1	regen		6	8																										0
-Rat Lord's Gate	1338	100	1			6		38	38	amu	amulet		5	5000				invammy1				dmg-demon		100	100	hp		35	50	str		15	25	dex		15	25	red-dmg%		10	10	red-mag		6	9																										0
-Luck Sigil	1339	100	1			5		45	45	amu	amulet		5	5000				invammy3				allskills		1	1	mag%/lvl	12			gold%/lvl	16			att%		10	10	fade		1	1																														0
-The Vanquisher	1340	100	1			3		15	15	amu	amulet		5	5000				invammy9				dmg%		50	50	dmg-max		10	20	cast2		20	20	lifesteal		8	8	manasteal		5	8	swing2		25	25																										0
-Foulsigil	1341	100	1			3		78	78	amu	amulet		5	5000				invammy13				allskills		1	2	all-stats		15	25	regen		-3	-3	res-pois		65	65	swing1		15	15	block		15	15	nofreeze		1	1																						0
-Veil of Despair	1342	100	1			1		85	85	amu	amulet		5	5000				invammy6				allskills		2	2	block		10	15	kill-skill	corpse explosion	5	15	mag%		35	50	gold%/lvl	16			att%		25	25	res-all-max		5	20	res-all		20	50																		0
-Autumn's Avatar	1343	100	1			5		12	12	cm1	charm	1	5	5000				invscm3				hp		12	15	mana		10	12	dmg-max		3	3	str		1	3																																		0
-Remembrance of Glory	1344	100	1			4		64	64	cm1	charm	1	5	5000				invscm1				hp		20	20	mana		17	17	res-all		5	5	dex		5	5																																		0
-Argo's Anchor	1345	100	1			3		48	48	cm1	charm	1	5	5000				invscm4				dmg-max		5	5	mag%		7	7	block		5	10	att		50	75																																		0
-Ogre King's Bowl	1346	100	1			2		60	60	cm1	charm	1	5	5000				invscm2				lifesteal		3	5	manasteal		3	5	regen		3	8	regen-mana		25	50																																		0
-Peacemaker	1347	100	1			5		15	15	cm2	charm	1	5	5000								hp		20	25	mana		15	20	str		5	5	dex		5	5																																		0
-Lifesever	1348	100	1			3		55	55	cm2	charm	1	5	5000								allskills		1	1	mag%		15	20	thorns		6	15																																						0
-Thronegranter	1349	100	1			1		81	81	cm2	charm	1	5	5000	dred	dred		invlcm1				hp		30	35	mana		25	30	dmg-max		6	8	cheap		3	5	addxp		3	5																														0
-Nightdrifter	1350	100	1			5		6	6	cm3	charm	1	5	5000								hp		15	25	dmg-cold	200	5	8	freeze		1	2	move1		15	15																																		0
-Queenscall	1351	100	1			1		71	75	cm3	charm	1	5	5000								allskills		1	1	hp		40	44	res-all		11	15	block1		10	10	move1		10	10	swing1		10	10																										0
-Tiger Eye	1352	100	1			5		5	5	jew	jewel		3	5000								dmg%		15	20	dmg-max		5	8																																										0
-Jade Facet	1353	100	1			5		18	18	jew	jewel		3	5000		lgrn						dmg%		20	29	dmg-max		8	10																																										0
-Topaz Facet	1354	100	1			5		27	27	jew	jewel		3	5000		lyel						gold%		25	25	mag%		10	15	ac		25	50																																						0
-Emerald Facet	1355	100	1			5		38	38	jew	jewel		3	5000		cgrn						dmg%		27	34	swing1		15	15																																										0
-Quartz Facet	1356	100	1			5		43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
-Rainbow Facet1	1357	100	1			1		49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
-Rainbow Facet2	1358	100	1			1		49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
-Rainbow Facet3	1359	100	1			1		49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
-Rainbow Facet4	1360	100	1			1		49	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	levelup-skill	Nova	100	41																																		0
-Rainbow Facet5	1361	100	1			1		49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
-Rainbow Facet6	1362	100	1			1		49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
-Rainbow Facet7	1363	100	1			1		49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Sapphire Facet	1364	100	1			1		58	58	jew	jewel		3	5000		cblu						dmg%		37	40	swing1		15	15																																										0
-Sapphire Facet1	1365	100	1			1		58	58	jew	jewel		3	5000		cblu						dmg%		37	40	dmg-max		12	15																																										0
-Diamond Facet	1366	100	1			1		67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
-Adamantine Facet	1367	100	1			1		71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0
-Star Facet	1368	100	1			1		76	76	jew	jewel		3	5000								dmg%		40	40	swing1		15	15	dmg-max		15	15																																						0
-Heaven Facet	1369	100	1			1		85	85	jew	jewel		3	5000								allskills		1	1	hp%		5	5	mana%		5	5																																						0
+Call of the Wild	1262	100	1			1	1	50	60	drb	blood spirit		5	5000								ac		150	200	skill	227	7	7	skill	237	7	7	skill	247	7	7	allskills		2	2	dmg%		25	50	swing2		25	25	dex		25	25	lifesteal		6	6														0
+Eagle Eyes	1263	100	1			1	1	56	65	drc	sun spirit		5	5000								ac		160	210	skilltab	15	3	3	dru		1	1	red-dmg		15	15	charged	17	20	20	res-pois-len		60	60	att%		35	35	sock		1	1																		0
+Sanctuary's Scion	1264	100	1			3	1	49	59	drc	Sun Spirit		5	5000	dyel	dyel						ac%		150	200	dru		2	2	red-dmg%		20	20	red-mag		20	20	mag%		25	50	att%		35	50	skill-rand	7	222	251																						0
+Spirit of the Land	1265	100	1			1	1	65	72	drd	earth spirit		5	5000								ac		175	240	red-dmg%		25	25	res-mag		25	25	all-stats		25	25	balance2		25	25	move2		25	25	hp%		25	25	dru		1	1																		0
+Hecuba's Tresses	1266	100	1			1	1	1	16	dre	sky spirit		5	5000								ac		240	300	dru		4	4	sock		3	3																																						0
+Call of the Kindred	1267	100	1			1	1	82	86	drf	dream spirit		5	5000				invhelm37				ac		200	240	skill	223	3	7	skill	224	3	7	skill	228	3	7	swing1		10	10	hp		50	50	lifesteal		3	6	manasteal		3	6	dru		1	1														0
+Stone Feather	1268	100	1			3	1	26	43	drf	Dream Spirit		5	5000	oran	oran						ac%		200	300	red-dmg%		25	50	ease		-65	-65	sock		3	3	allskills		2	2																														0
+Killerwatch	1269	100	1			1	1	1	15	ktr	katar		5	5000								dmg-min		10	20	dmg-max		30	40	skilltab	18	1	3	swing1		15	15	charged	90	1	6																														0
+Hidden Death	1270	100	1			3	1	1	7	ktr	katar		5	5000	blac	blac						dmg%		100	150	dmg-max		6	10	deadly		25	35	skill	252	1	2																																		0
+Simpleton's Shadow	1271	100	1			5	1	5	25	ktr	Katar		5	5000	dgry	dgry						dmg%		60	75	move2		25	25	lifesteal		3	5	ass		1	1																																		0
+Razorspine	1272	100	1			1	1	1	19	wrb	wrist blade		5	5000				invclaw1				dmg-min		12	23	dmg-max		32	42	skilltab	19	1	3	thorns		15	15	noheal		1	1	res-pois		15	20																										0
+Storms of Spring	1273	100	1			3	1	1	13	wrb	wrist blade		5	5000	whit	whit						dmg%		105	155	dmg-ltng		10	15	res-ltng		15	25	gethit-skill	38	8	5	block		15	15																														0
+Murdering Bloom	1274	100	1			5	1	1	8	wrb	Wrist Blade		5	5000	cred	cred						dmg%		60	80	ass		1	1	kill-skill	charged bolt	25	5	swing1		15	15	sock		1	1																														0
+Spirit Hawk	1275	100	1			1	1	5	25	axf	hatchet hands		5	5000								dmg-min		14	25	dmg-max		34	44	skilltab	20	1	3	oskill	oak sage	3	5	res-mag		10	15	dmg-mag		25	40																										0
+Cold of Winter	1276	100	1			3	1	1	16	axf	hatchet hands		5	5000	whit	whit						dmg%		110	160	dmg-cold	200	10	15	gethit-skill	44	5	2	swing2		20	20	rep-dur	20			skill	257	1	3	skill	256	1	3																						0
+Crimson Cry	1277	100	1			5	1	1	11	axf	Hatchet Hands		5	5000	dred	dred						dmg%		65	85	bloody		1	1	noheal		1	1	howl		66	66	swing2		25	25	oskill	shout	2	2																										0
+Samantha's Fist	1278	100	1			1	1	8	28	ces	cestus		5	5000								dmg-min		16	27	dmg-max		36	46	skilltab	19	1	3	swing2		25	25	sock		2	2																														0
+Androsphinx	1279	100	1			3	1	2	20	ces	cestus		5	5000	dred	dred						dmg%		115	165	swing1		15	15	move2		20	20	lifesteal		6	6	ac-hth		200	200	crush		15	15	ass		1	1																						0
+Liege Reaver	1280	100	1			5	1	1	15	ces	Cestus		5	5000	cgrn	cgrn						dmg%		65	90	dmg-norm		5	10	skilltab	20	1	3	rep-dur	25			dur		75	75	att		150	150	openwounds		33	33																						0
+Frostshiver	1281	100	1			1	1	10	30	clw	claws		5	5000	lblu	lblu						dmg-min		22	35	dmg-max		45	70	skilltab	18	1	3	dmg-cold		25	35	freeze		3	3	gethit-skill	40	4	6	charged	55	81	6	res-cold		25	35																		0
+Lynx Talon	1282	100	1			3	1	4	24	clw	claws		5	5000	dyel	dyel						dmg%		120	170	swing3		25	25	mana-kill		3	5	aura	104	1	3	balance2		25	25	dex		20	20	res-fire		25	25																						0
+Winterquick	1283	100	1			5	1	1	19	clw	Claws		5	5000	whit	whit						dmg%		65	100	dmg-cold	300	15	25	swing2		30	30	skill	252	2	2	pierce-cold		15	15	oskill	frost nova	5	5	dmg-max		10	15																						0
+Nightmare Glove	1284	100	1			1	1	13	32	btl	blade talons		5	5000	blac	blac						dmg-min		25	35	dmg-max		60	80	skilltab	19	1	3	extra-fire		10	10	extra-ltng		10	10	res-all		15	15	lifesteal		4	7	att%		20	20																		0
+Key to the Madhouse	1285	100	1			3	1	8	28	btl	blade talons		5	5000	oran	oran						dmg%		125	175	dmg-norm		15	30	enr		15	15	mag%		25	35	allskills		1	1	skilltab	18	1	3	sock		2	2																						0
+Bladespan	1286	100	1			5	1	2	22	btl	Blade Talons		5	5000								dmg%		70	100	ignore-ac		1	1	ass		1	1	skilltab	19	1	2	slow		20	20	skill-rand	3	251	268	dmg-norm		11	22																						0
+Dark Demense	1287	100	1			1	1	22	38	skr	scissors katar		5	5000	dgry	dgry						dmg-min		35	45	dmg-max		80	100	skilltab	20	1	3	ass		1	1	allskills		1	1	stupidity		2	2	gethit-skill	71	11	4	rep-dur	17																				0
+Martial Law	1288	100	1			3	1	13	33	skr	scissors katar		5	5000	dgld	dgld						dmg%		130	180	skilltab	20	3	5	str		15	15	dex		20	20	vit		25	25	red-dmg%		10	15	crush		20	20	deadly/lvl	6																				0
+Troll's Touch	1289	100	1			5	1	7	27	skr	Scissors Katar		5	5000	lgrn	lgrn						dmg%		80	120	regen		25	25	lifesteal		6	8	manasteal		6	8	regen-mana		75	75	ass		2	2	dmg-norm		15	30																						0
+Keys to Hell	1290	100	1			1	1	52	52	9ar	quhab		5	5000	cred	cred						dmg%		100	100	dmg-min		20	40	dmg-max		50	90	allskills		2	2	block1		25	25	dmg-demon		200	200	charged	88	45	15	skilltab	18	2	2																		0
+Storm Demon's Glair	1291	100	1			3	1	20	37	9ar	quhab		5	5000	dyel	dyel						dmg%		180	230	skilltab	19	1	3	hit-skill	48	6	9	ignore-ac		1	1	oskill	vengeance	2	4	regen-mana		25	25	cast1		15	15																						0
+Corpseflayer	1292	100	1			5	1	9	29	9ar	Quhab		5	5000				invclaw3				dmg%		135	190	ass		1	1	dmg-undead		250	250	deadly		15	25	skilltab	19	1	3	att		100	250	reanimate	7	10	10																						0
+Sabertooth	1293	100	1			1	1	46	56	9wb	wrist spike		5	5000	whit	whit						dmg%		100	100	dmg-min		20	40	dmg-max		50	90	skilltab	19	1	3	ass		1	1	res-cold		25	35	regen		15	15	str		15	15	red-dmg		10	15														0
+Pleasures of the Perverse	1294	100	1			3	1	21	41	9wb	wrist spike		5	5000								dmg%		190	240	swing3		30	30	ass		2	2	skill	260	1	3	skill	263	1	3	charged	68	25	20	kick/lvl	8			sock		1	1																		0
+Dusk Ray	1295	100	1			5	1	12	32	9wb	Wrist Spike		5	5000	oran	oran						dmg%		140	180	dmg-norm		20	40	allskills		1	1	skilltab	20	1	1	dmg-fire		40	90	aura	109	4	9	swing2		30	30	mana		35	35																		0
+Razor Knuckle	1296	100	1			1	1	51	60	9xf	fascia		5	5000								dmg%		100	100	dmg-min		22	40	dmg-max		53	90	skilltab	18	3	3	swing2		30	30	cast2		25	25	thorns/lvl	8																								0
+Heat of Summer	1297	100	1			3	1	33	43	9xf	fascia		5	5000	lred	lred						dmg%		200	250	dmg-fire		75	150	res-cold		25	50	abs-fire%		10	10	fireskill		5	5	dex		15	15	skill-rand	3	251	280	dmg-norm		15	30																		0
+Scarab Cleaver	1298	100	1			5	1	16	36	9xf	Fascia		5	5000	cblu	cblu						dmg%		150	200	swing2		20	20	ass		2	2	sock		1	2	res-ltng		75	75	abs-ltng		20	25	dmg-demon		150	250	dmg-max		10	10																		0
+Fullsuffering	1299	100	1			1	1	55	63	9cs	hand scythe		5	5000				invclaw2				dmg%		100	120	dmg-min		24	40	dmg-max		55	90	skilltab	20	2	2	allskills		2	2	hit-skill	66	20	5	res-fire		25	35	cheap		5	10	mana-kill		6	6														0
+Chi Strike	1300	100	1			3	1	28	46	9cs	hand scythe		5	5000	lpur	lpur						dmg%		205	255	skill	253	5	7	ass		1	1	deadly		33	33	res-all		20	40	enr		15	25	red-dmg		10	15	heal-kill		8	8																		0
+Slithertongue	1301	100	1			5	1	20	38	9cs	Hand Scythe		5	5000	lgrn	lgrn						dmg%		175	220	res-pois		45	45	res-pois-max		10	20	res-pois-len		75	75	dmg-pois	125	1000	1000	skilltab	20	1	3	dex		15	15	enr		20	20	dmg-max		15	20														0
+Wight Claw	1302	100	1			1	1	57	65	9lw	greater claws		5	5000	blac	blac						dmg%		110	130	dmg-min		27	40	dmg-max		60	90	skilltab	19	2	2	ass		1	1	lifesteal		10	10	manasteal		10	10	regen		10	10	regen-mana		65	65														0
+Shadowy Places	1303	100	1			3	1	38	48	9lw	greater claws		5	5000	dgry	dgry						dmg%		215	265	skill-rand	4	251	280	skill-rand	3	251	280	skill-rand	3	251	280	skill-rand	2	251	280	skill-rand	2	251	280	ass		1	1	swing2		20	20																		0
+Werewolf Talons	1304	100	1			5	1	24	40	9lw	Greater Claws		5	5000								dmg%		175	240	swing3		30	30	allskills		2	2	oskill	shape shifting	5	8	oskill	wearwolf	5	8	oskill	fury	1	3	att%		25	25	sock		1	2																		0
+Dark Nemesis	1305	100	1			1	1	55	68	9tw	greater talons		5	5000	dpur	dpur						dmg%		120	140	dmg-min		30	40	dmg-max		70	90	skilltab	18	1	3	swing2		25	25	sock		3	3																										0
+Adamantine Razors	1306	100	1			3	1	40	50	9tw	greater talons		5	5000	whit	whit						dmg%		220	270	ass		1	1	dmg-norm		30	60	indestruct		1	1	deadly		44	44	crush		27	27	skilltab	18	1	3	manasteal		6	6																		0
+Path of the Nightwalker	1307	100	1			1	1	55	70	9qr	scissors quhab		5	5000	blac	blac						dmg%		135	160	dmg-min		30	40	dmg-max		70	90	dmg/lvl	5			att%		35	35	balance2		25	25	all-stats		10	25	rep-dur	20			skill	267	7	7														0
+Fearsome Rumors	1308	100	1			3	1	44	54	9qr	scissors quhab		5	5000	dgrn	dgrn						dmg%		225	275	dmg-max		30	50	swing3		40	40	skill	260	3	5	skill	263	3	5	sock		1	1	ease		-100	-100	hp		75	75	res-pois		30	40														0
+Glitterkill	1309	100	1			5	1	39	49	9qr	Scissors Quhab		5	5000								dmg%		170	225	ass		2	2	res-mag		20	20	res-all		25	25	move2		25	25	skill	258	1	3	skill	264	1	3	rep-dur	5																				0
+Wakazashi	1310	100	1			1	1	57	64	7ar	suwayyah		5	5000	whit	whit						dmg%		250	300	ass		2	2	skilltab	20	1	3	swing3		30	30	ignore-ac		1	1	sock		2	2																										0
+Iniquity Razor	1311	100	1			3	1	45	55	7ar	Suwayyah		5	5000		lpur						dmg%		200	275	allskills		1	2	mag%/lvl	5			mag%		25	50	deadly		50	75	block		15	25	block3		40	40	skilltab	20	1	3																		0
+Biteblade	1312	100	1			1	1	65	71	7wb	wrist sword		5	5000	dred	dred						dmg%		250	300	dmg-norm		20	40	reduce-ac		15	15	noheal		1	1	skilltab	18	1	2	demon-heal		25	25	skill	260	1	3																						0
+Nightwrath	1313	100	1			1	1	1	76	7xf	war fist		5	5000								dmg%		250	300	dmg/lvl	6			block		15	25	skill	263	1	3	ass		1	1	fade		1	1	stupidity		1	1																						0
+Silent Shank	1314	100	1			3	1	38	38	7xf	War Fist		5	5000	blac	blac						dmg%		200	260	swing3		35	35	cast2		25	25	regen		10	15	nofreeze		1	1	cheap		20	20	fade		1	3	dmg/lvl	7																				0
+Flaming Fist	1315	100	1			1	1	74	79	7cs	battle cestus		5	5000	cred	cred						dmg%		250	300	allskills		1	1	dmg-fire		200	300	pierce-fire		15	15	abs-fire%		10	10	res-fire-max		15	15	res-fire		60	60	res-cold		35	35																		0
+Death Slaad1	1316	100	1			1	1	76	82	7lw	feral claws		5	5000	dgry	dgry						dmg%		250	300	dmg-norm		25	50	ass		2	2	dmg-max		25	50	rip		1	1	addxp		5	5	rep-dur	15																								0
+Spellfist	1317	100	1			1	1	80	85	7tw	runic talons		5	5000	oran	oran						dmg%		250	320	res-mag		25	25	red-mag		25	25	dmg-mag		75	200	oskill	battle command	3	3	skilltab	19	1	2	gethit-skill	49	6	12	res-all		25	25																		0
+Sin Sister	1318	100	1			3	1	28	45	7tw	Runic Talons		5	5000	blac	blac						dmg%		200	300	swing2		30	30	sock		3	3	dmg/lvl	7																																				0
+Avalanche Strike	1319	100	1			1	1	15	35	7qr	scissors suwayyah		5	5000	cblu	cblu						dmg%		300	400	dmg-cold	300	200	250	hit-skill	55	50	4	res-cold		45	45	rep-dur	15			lifesteal		6	8	manasteal		6	8																						0
+Torturer's Trust	1320	100	1			3	1	79	83	7qr	Scissors Suwayyah		5	5000								dmg%		225	300	allskills		2	2	skilltab	20	1	3	res-all		30	50	skill-rand	7	252	281	regen		15	20	gold%		100	100	mag%		25	50	att%		100	100														0
+Ring of Engagement	1321	100	1			9	1	1	3	rin	ring		5	5000				invring1				dmg-max		2	5	hp		10	20	str		5	5	aura	98	1	1																																		0
+Nameless Fear	1322	100	1			9	1	1	11	rin	ring		5	5000				invring3				dmg%		10	15	swing1		10	10	howl		45	45	noheal		1	1																																		0
+Elven Heartband	1323	100	1			8	1	1	18	rin	ring		5	5000				invring5				addxp		3	5	hp		20	30	red-dmg%		5	5	mag%		15	25	lifesteal		4	6																														0
+Knell of Discord	1324	100	1			8	1	2	20	rin	ring		5	5000				invring6				lifesteal		5	7	slow		15	15	knock		3	3	enr		10	10																																		0
+Vampiric Regeneration	1325	100	1			7	1	8	28	rin	ring		5	5000				invring8				hp		35	35	regen		8	12	regen-mana		35	35	regen-stam		20	20	manasteal		3	5	lifesteal		5	7																										0
+Golem's Might	1326	100	1			6	1	24	24	rin	ring		5	5000				invring10				str		25	25	dmg-norm		10	15	res-all		8	15	heal-kill		5	8	swing1		10	10																														0
+Planatar Enlightenment	1327	100	1			2	1	23	23	rin	ring		5	5000				invring12				allskills		1	1	res-all		8	15	hp		35	50	gold%		65	65	enr		20	20	addxp		3	5	cheap		8	10																						0
+Thief of Dreams	1328	100	1			5	1	50	50	rin	ring		5	5000				invring13				mag%		33	50	res-fire		25	35	mana		65	80	cast1		15	15	addxp		3	3																														0
+Jackal's Laughter	1329	100	1			3	1	64	64	rin	ring		5	5000				invring16				allskills		1	1	lifesteal		8	11	manasteal		7	8	hp		55	80	oskill	terror	6	6	deadly/lvl	3																												0
+Fellowship's Hope	1330	100	1			2	1	73	73	rin	ring		5	5000				invring18				allskills		1	1	mag%		25	35	res-all		15	15	red-dmg		5	8	red-mag		5	8	move1		10	10	cast1		10	10	block1		10	10																		0
+Faerie Ring	1331	100	1			1	1	82	82	rin	ring		5	5000				invring20				allskills		1	1	hp%		15	15	mana%		15	15	light		7	7	fade		1	1	block		15	20	mag%		25	50	balance2		20	20																		0
+Stone Of Jordan*	1332	100	1			1	1	85	85	rin	ring		5	5000				invring21				allskills		2	2	mana%		40	40	cast1		15	15	dmg-ltng		10	100																																		0
+Eye of Kahn	1333	100	1			9	1	3	3	amu	amulet		5	5000				invammy7				hp		25	35	mana		25	35	dex		5	10	str		5	10	dmg-max		3	6																														0
+Psyche Shroud	1334	100	1			9	1	6	6	amu	amulet		5	5000				invammy5				move2		15	15	res-ltng		20	20	hp		20	30	enr		10	10																																		0
+Amulet of Warding	1335	100	1			7	1	12	12	amu	amulet		5	5000				invammy2				red-dmg		5	8	res-all		10	15	red-mag		4	6	block		5	12	ac		35	50																														0
+Cryptking	1336	100	1			6	1	27	27	amu	amulet		5	5000				invammy8				oskill	skeleton mastery	5	10	oskill	raise skeletal mage	3	5	dmg-undead		200	200	allskills		1	1	regen		6	8	regen-mana		25	50																										0
+Sequence of Seasons	1337	100	1			6	1	30	30	amu	amulet		5	5000				invammy4				allskills		1	1	dmg-cold	100	15	25	dmg-ltng		1	70	dmg-fire		30	50	aura	103	1	1	regen		6	8																										0
+Rat Lord's Gate	1338	100	1			6	1	38	38	amu	amulet		5	5000				invammy1				dmg-demon		100	100	hp		35	50	str		15	25	dex		15	25	red-dmg%		10	10	red-mag		6	9																										0
+Luck Sigil	1339	100	1			5	1	45	45	amu	amulet		5	5000				invammy3				allskills		1	1	mag%/lvl	12			gold%/lvl	16			att%		10	10	fade		1	1																														0
+The Vanquisher	1340	100	1			3	1	15	15	amu	amulet		5	5000				invammy9				dmg%		50	50	dmg-max		10	20	cast2		20	20	lifesteal		8	8	manasteal		5	8	swing2		25	25																										0
+Foulsigil	1341	100	1			3	1	78	78	amu	amulet		5	5000				invammy13				allskills		1	2	all-stats		15	25	regen		-3	-3	res-pois		65	65	swing1		15	15	block		15	15	nofreeze		1	1																						0
+Veil of Despair	1342	100	1			1	1	85	85	amu	amulet		5	5000				invammy6				allskills		2	2	block		10	15	kill-skill	corpse explosion	5	15	mag%		35	50	gold%/lvl	16			att%		25	25	res-all-max		5	20	res-all		20	50																		0
+Autumn's Avatar	1343	100	1			5	1	12	12	cm1	charm	1	5	5000				invscm3				hp		12	15	mana		10	12	dmg-max		3	3	str		1	3																																		0
+Remembrance of Glory	1344	100	1			4	1	64	64	cm1	charm	1	5	5000				invscm1				hp		20	20	mana		17	17	res-all		5	5	dex		5	5																																		0
+Argo's Anchor	1345	100	1			3	1	48	48	cm1	charm	1	5	5000				invscm4				dmg-max		5	5	mag%		7	7	block		5	10	att		50	75																																		0
+Ogre King's Bowl	1346	100	1			2	1	60	60	cm1	charm	1	5	5000				invscm2				lifesteal		3	5	manasteal		3	5	regen		3	8	regen-mana		25	50																																		0
+Peacemaker	1347	100	1			5	1	15	15	cm2	charm	1	5	5000								hp		20	25	mana		15	20	str		5	5	dex		5	5																																		0
+Lifesever	1348	100	1			3	1	55	55	cm2	charm	1	5	5000								allskills		1	1	mag%		15	20	thorns		6	15																																						0
+Thronegranter	1349	100	1			1	1	81	81	cm2	charm	1	5	5000	dred	dred		invlcm1				hp		30	35	mana		25	30	dmg-max		6	8	cheap		3	5	addxp		3	5																														0
+Nightdrifter	1350	100	1			5	1	6	6	cm3	charm	1	5	5000								hp		15	25	dmg-cold	200	5	8	freeze		1	2	move1		15	15																																		0
+Queenscall	1351	100	1			1	1	71	75	cm3	charm	1	5	5000								allskills		1	1	hp		40	44	res-all		11	15	block1		10	10	move1		10	10	swing1		10	10																										0
+Tiger Eye	1352	100	1			5	1	5	5	jew	jewel		3	5000								dmg%		15	20	dmg-max		5	8																																										0
+Jade Facet	1353	100	1			5	1	18	18	jew	jewel		3	5000		lgrn						dmg%		20	29	dmg-max		8	10																																										0
+Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						gold%		25	25	mag%		10	15	ac		25	50																																						0
+Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						dmg%		27	34	swing1		15	15																																										0
+Quartz Facet	1356	100	1			5	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
+Rainbow Facet1	1357	100	1			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
+Rainbow Facet2	1358	100	1			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
+Rainbow Facet3	1359	100	1			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	death-skill	Poison Nova	100	51																																		0
+Rainbow Facet4	1360	100	1			1	1	49	49	jew	jewel		3	5000								dmg-ltng		1	74	pierce-ltng		3	5	extra-ltng		3	5	levelup-skill	Nova	100	41																																		0
+Rainbow Facet5	1361	100	1			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
+Rainbow Facet6	1362	100	1			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
+Rainbow Facet7	1363	100	1			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
+Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		37	40	swing1		15	15																																										0
+Sapphire Facet1	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		37	40	dmg-max		12	15																																										0
+Diamond Facet	1366	100	1			1	1	67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
+Adamantine Facet	1367	100	1			1	1	71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0
+Star Facet	1368	100	1			1	1	76	76	jew	jewel		3	5000								dmg%		40	40	swing1		15	15	dmg-max		15	15																																						0
+Heaven Facet	1369	100	1			1	1	85	85	jew	jewel		3	5000								allskills		1	1	hp%		5	5	mana%		5	5																																						0
 t1 Splash Charm	1370	100	1			1	1	1	1	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splash	proc_SplashDamage	100	1	dmg2%		-40	-40																																										0
 t2 Splash Charm	1371	100	0			1	1	1	3	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashtwo	proc_SplashDamage_Two	100	1	dmg2%		-36	-36																																										0
 t3 Splash Charm	1372	100	0			1	1	1	11	cm4	charm	1	1	1			flpmss	invmss	item_gem	12	item_gem	splashtwo	proc_SplashDamage_Two	100	1	dmg2%		-33	-33																																										0
-Keychain	1373	100	1			1		1	1	sto	Keychain Storage		1	1			flpmph	invsto1	item_key		item_key	stacked/terror-key		1	1	stacked/hate-key		1	1	stacked/destruction-key		1	1																																						0
+Keychain	1373	100	1			1	1	1	1	sto	Keychain Storage		1	1			flpmph	invsto1	item_key		item_key	stacked/terror-key		1	1	stacked/hate-key		1	1	stacked/destruction-key		1	1																																						0
 Terror Key Grabber	1374	100	1			1	1	1	1	stt	Terror Key Grabber		1	1			flpgsv	invgsva	item_monsterguts		item_monsterguts																																																		0
 Hate Key Grabber	1375	100	1			1	1	1	1	stt	Hate Key Grabber		1	1			flpgsv	invgsva	item_monsterguts		item_monsterguts																																																		0
 Destruction Key Grabber	1376	100	1			1	1	1	1	stt	Destruction Key Grabber		1	1			flpgsv	invgsva	item_monsterguts		item_monsterguts																																																		0


### PR DESCRIPTION
- Set "nolimit" for all uniques to 1 to enable uniques appearing multiple times in the same session to make it harder to min/max for specific uniques with the new Orb of Conversion or for example gambling.
- Set "lvl" to an appropriate value in relation to "lvl req" to reduce the drop chance of high level items by the item not dropping from low level enemys. This was somewhat regulated by the base items _lvl_ inside _armor.txt_ and _weapon.txt_ but with this change it is made sure.