### PR TITLE
Gold & Transmute button QoL + Cube X button moved

### DIFF
--- a/data/global/ui/layouts/bankexpansionlayouthd.json
+++ b/data/global/ui/layouts/bankexpansionlayouthd.json
@@ -21,13 +21,13 @@
         {
             "type": "TextBoxWidget", "name": "gold_amount",
             "fields": {
-                "rect": { "x": 775, "y": 1380 }
+                "rect": { "x": 780, "y": 1382 }
             }
         },
         {
             "type": "ButtonWidget", "name": "gold_withdraw",
             "fields": {
-                "rect": { "x": 715, "y": 1382 }
+                "rect": { "x": 703, "y": 1372 }
             }
         },
         {

--- a/data/global/ui/layouts/horadriccubelayouthd.json
+++ b/data/global/ui/layouts/horadriccubelayouthd.json
@@ -37,7 +37,7 @@
         {
             "type": "ButtonWidget", "name": "convert",
             "fields": {
-                "rect": { "x": 795, "y": 1305 },
+                "rect": { "x": 1427, "y": 1315 },
                 "filename": "PANEL\\Horadric_Cube\\TransmuteButton",
                 "tooltipString": "@strUiMenu2",
                 "hoveredFrame": 2,
@@ -47,7 +47,7 @@
         {
             "type": "ButtonWidget", "name": "close",
             "fields": {
-                "rect": { "x": 1650, "y": -200 },
+                "rect": { "x": 1551, "y": -208 },
                 "filename": "PANEL\\closebtn_4x",
                 "hoveredFrame": 3,
                 "tooltipString": "@strClose",

--- a/data/global/ui/layouts/playerinventoryoriginallayouthd.json
+++ b/data/global/ui/layouts/playerinventoryoriginallayouthd.json
@@ -36,14 +36,14 @@
         {
             "type": "TextBoxWidget", "name": "gold_amount",
             "fields": {
-                "rect": { "x": 544, "y": 1401, "width": 249, "height": 48 },
+                "rect": { "x": 560, "y": 1405, "width": 246, "height": 48 },
                 "style": "$StyleGoldAmount",
             },
         },
         {
             "type": "ButtonWidget", "name": "gold_button",
             "fields": {
-                "rect": { "x": 480, "y": 1403 },
+                "rect": { "x": 480, "y": 1395 },
                 "filename": "PANEL\\GoldButton",
                 "hoveredFrame": 0,
                 "tooltipString": "@strGoldDrop",

--- a/data/hd/global/ui/panel/goldbutton.sprite
+++ b/data/hd/global/ui/panel/goldbutton.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8971f26bf6f414ee1d879e77a4cf227e8d1e63fe90b36a142bfc996739428945
+size 150568

--- a/data/hd/global/ui/panel/horadric_cube/transmutebutton.sprite
+++ b/data/hd/global/ui/panel/horadric_cube/transmutebutton.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:263e762370278a0c2e8c3af5a8492eb06bfa8dec48a46a0e87eefeaca4b0b910
+size 651496


### PR DESCRIPTION
QoL for the lazy and imprecise folk on PC.

Added 20% larger Transmute button for Cube and moved it closer to the inventory screen. Now it's easier to click.

Moved the X (exit) button of cube slightly to the left so now it is part of it's own UI like other X buttons.

Added 25% larger Gold button, adjusted it's positions. It is easier to click now.

Button images were upscaled via AI.

![D2R cube](https://github.com/user-attachments/assets/c5c0f761-7b23-4d0d-ae53-e0d9dce26752)
![D2R inv+bank](https://github.com/user-attachments/assets/c4d6f855-33ec-45ea-aa62-2ac71d92c288)
