### PR TITLE
Fixed Sting RW for Amazon

### DIFF
--- a/data/global/excel/runes.txt
+++ b/data/global/excel/runes.txt
@@ -144,7 +144,7 @@ Runeword132	Starlight	1				weap	armo	shld							ZodHelIstEl	r33	r15	r24	r01			al
 Runeword133	Stealth	1				tors									TalEth	r07	r05					red-mag		3	3	dex		6	6	move2		25	25	cast2		25	25	balance2		25	25									0
 Runeword134	Steel	1				swor	axe	mace							TirEl	r03	r01					swing2		25	25	dmg-min		3	3	dmg-max		3	3	openwounds		50	50	dmg%		20	20									0
 Runeword135	Still Water	1				abow									GulUmMalNef	r25	r22	r23	r04			ama		1	1	swing1		20	20	dmg-norm		30	150	dmg%		80	120	skilltab	0	2	2	heal-kill		15	20	dmg-cold	300	100	150	0
-Runeword136	Sting	1				miss									NefTalEth	r04	r07	r05				dmg-max		25	40	swing1		15	15	manasteal		5	8	oskill	Multiple Shot	3	3	oskill	Ice Arrow	5	5									0
+Runeword136	Sting	1				miss									NefTalEth	r04	r07	r05				dmg-max		25	40	swing1		15	15	manasteal		5	8	oskill	Multiple Shot	3	3	oskill	Ice Arrow	5	5	skill	Ice Arrow	2	2					0
 Runeword137	Stone	1				tors									ShaelUmPulLum	r13	r22	r21	r17			ac%		220	260	charged	Clay Golem	16	16	ac-miss		300	300	charged	Molten Boulder	80	16	str		16	16	vit		16	16	balance2		40	40	0
 Runeword138	Storm	1				spea									JahUmOhmOrtNef	r31	r22	r27	r09	r04		dmg%		333	333	swing1		20	20	hit-skill	Lightning	16	21	oskill	Thunder Storm	10	10	res-ltng		100	100	abs-ltng%		25	25	addxp		3	3	0
 Runeword139	Strength	1				mele									AmnTir	r11	r03					str		20	20	dmg%		35	35	vit		10	10	crush		25	25													0


### PR DESCRIPTION
Sting RW didn't give +5 Ice Arrow if equipped as Amazon so I gave +2 Ice Arrow for Amazon Only
![Sting BEFORE](https://github.com/user-attachments/assets/8eaf47f1-bdf7-4701-9532-2fbfe5a0cca0)
![Sting AFTER](https://github.com/user-attachments/assets/130a2968-03bc-4d12-b511-700f43f270e5)
