### PR TITLE
Fix stash tab getting cut off on Steam Deck (and other tall resolutions)

### DIFF
--- a/data/global/ui/layouts/controller/bankexpansionlayouthd.json
+++ b/data/global/ui/layouts/controller/bankexpansionlayouthd.json
@@ -3,7 +3,7 @@
     "fields": {
         "priority": 0,
         "anchor": "$LeftPanelAnchor",
-        "rect": { "x": -1920, "y": -502, "width": 0, "height": 0 },
+        "rect": { "x": -1535, "y": -502, "width": 0, "height": 0 },
     },
     "children": [
         {


### PR DESCRIPTION
_This is a rehash/cleanup of #203 (sorry for the mess)_

-----

On taller resolutions (closer to a 1:1 ratio) the Stash/Bank is cut off on the left side, when using a controller. I first noticed this on the Steam Deck as it has a relatively taller native resolution (1280x800). However, my proposed change here should fix it for the Steam Deck and other devices with more "square" resolutions (old monitors, and handheld devices). Moreover, it will make it easier to move items around (where the player's stash and inventory are side-by-side).

From my testing, my proposed  works well with any resolution (but I only tried a few):

- 3840x2160
- 2560x1440
- 1280x960 (Very square; but still visible ...  barely. _Side note: there's plenty of room to the right of the player inventory, the whole thing could probably move over in a future commit_)
- 1280x800 (Steam Deck)
