### PR TITLE
Removed * from second SoJ

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1333,7 +1333,7 @@ Thief of Dreams	1328	100	1			5	1	50	50	rin	ring		5	5000				invring13				mag%		33
 Jackal's Laughter	1329	100	1			3	1	64	64	rin	ring		5	5000				invring16				allskills		1	1	lifesteal		8	11	manasteal		7	8	hp		55	80	oskill	terror	6	6	deadly/lvl	3																												0
 Fellowship's Hope	1330	100	1			2	1	73	73	rin	ring		5	5000				invring18				allskills		1	1	mag%		25	35	res-all		15	15	red-dmg		5	8	red-mag		5	8	move1		10	10	cast1		10	10	block1		10	10																		0
 Faerie Ring	1331	100	1			1	1	82	82	rin	ring		5	5000				invring20				allskills		1	1	hp%		15	15	mana%		15	15	light		7	7	fade		1	1	block		15	20	mag%		25	50	balance2		20	20																		0
-Stone Of Jordan*	1332	100	1			1	1	85	85	rin	ring		5	5000				invring21				allskills		2	2	mana%		40	40	cast1		15	15	dmg-ltng		10	100																																		0
+Stone Of Jordan	1332	100	1			1	1	85	85	rin	ring		5	5000				invring21				allskills		2	2	mana%		40	40	cast1		15	15	dmg-ltng		10	100																																		0
 Eye of Kahn	1333	100	1			9	1	3	3	amu	amulet		5	5000				invammy7				hp		25	35	mana		25	35	dex		5	10	str		5	10	dmg-max		3	6																														0
 Psyche Shroud	1334	100	1			9	1	6	6	amu	amulet		5	5000				invammy5				move2		15	15	res-ltng		20	20	hp		20	30	enr		10	10																																		0
 Amulet of Warding	1335	100	1			7	1	12	12	amu	amulet		5	5000				invammy2				red-dmg		5	8	res-all		10	15	red-mag		4	6	block		5	12	ac		35	50																														0


### PR DESCRIPTION
There is no * in the item-names.json and I doubt we should have special characters in the uniqueitems.txt
![image](https://github.com/user-attachments/assets/44093f07-0d10-4d62-99fe-4b145f5d7229)
