### PR TITLE
Druid Skill Tree Update

### DIFF
--- a/data/hd/global/ui/spells/skill_trees/drskilltree.lowend.sprite
+++ b/data/hd/global/ui/spells/skill_trees/drskilltree.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31838f947b446b1c0f359649ed9129e0e7ac06a7e720506a10ccd45643afeadd
+size 3211900

--- a/data/hd/global/ui/spells/skill_trees/drskilltree.sprite
+++ b/data/hd/global/ui/spells/skill_trees/drskilltree.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e31bf8825b7fee0ad7814f76ff699b757fe46bc7de2717f388dad23c4ddb8684
+size 12863020


### PR DESCRIPTION
Just removed the arrows from the Druid skill tree in order to remove prereq skills across the board. The purpose is to clear up the travel points to have more overall skill points be available to each class. 

![Elemental](https://github.com/user-attachments/assets/909e0763-550b-4b84-838d-40910f256388)
![Shapeshifting](https://github.com/user-attachments/assets/90c10f88-5313-48e9-b082-67bded03ce31)
![Summoning](https://github.com/user-attachments/assets/b3faccc4-7635-4939-9cd7-46631ab2a4b6)
