### PR TITLE
Match lesser potions sprites

### DIFF
--- a/data/hd/global/ui/items/misc/potion/lesser_healing_potion.lowend.sprite
+++ b/data/hd/global/ui/items/misc/potion/lesser_healing_potion.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3921b12016aceaad53d67b98f7904c21d5c1cb53f56b3f5faf92ea482462d511
+oid sha256:65df7cb6f4489a1e4ccddf787df4240f50ed1961c91a19561cb95fb14271aa9f
 size 9644

--- a/data/hd/global/ui/items/misc/potion/lesser_healing_potion.sprite
+++ b/data/hd/global/ui/items/misc/potion/lesser_healing_potion.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adab9d1e35539b099117658198d8f8caee355a56b12dc5799b0abc5aca6f7753
+oid sha256:26d3c0b8a2d368b0228b90ef5cef80fdd2146a87165208b3fc613b3e308c71eb
 size 38456

--- a/data/hd/global/ui/items/misc/potion/lesser_mana_potion.lowend.sprite
+++ b/data/hd/global/ui/items/misc/potion/lesser_mana_potion.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad2c0b2084536a60b8d0cd76cea8aeeaaba589257e4ad5edac49103210de7de3
+oid sha256:34cfe680485d530e952c14bd21f28c86d2456e916d847a5983bb23a5edc7ad52
 size 9644

--- a/data/hd/global/ui/items/misc/potion/lesser_mana_potion.sprite
+++ b/data/hd/global/ui/items/misc/potion/lesser_mana_potion.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93e9558d79ca5b8b1e383353d19c66cde18ee65422f11b616ab307f1b6b6b682
+oid sha256:5b4089af2fe539d1feed236603b23b03ad5e209d1461667616cbe4555aab561f
 size 38456


### PR DESCRIPTION
The lesser_potions sprite looked out of place, too bright. Adjusted brightness and contrast values ​​to match the rest of the potions.

Actual
![image](https://github.com/user-attachments/assets/0ef2256c-a464-4b3a-9af5-3d1c5fc77ec2)

Modified (darker)
![modified_sprites](https://github.com/user-attachments/assets/4c44c49e-7f60-41f2-8302-c2e676e6b3d6)
