### PR TITLE
Spikethrower Missing String

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -767,7 +767,7 @@ Nail Flinger	762	100	1			3	1	1	12	lxb	light crossbow		5	5000				invlxb				dmg%		
 Piercing Bolt	763	100	1			1	1	28	28	mxb	crossbow		5	5000				invcbow5				dmg-norm		25	50	pierce		100	100	res-all		20	30	knock		1	1	att%		20	20	lifesteal		5	5	addxp		2	3																						0
 Janglebright	764	100	1			3	1	6	18	mxb	crossbow		5	5000	whit	whit		invmxb				dmg%		125	175	light		3	5	res-all		25	25	balance2		15	15	swing1		10	10	sock		1	1																										0
 Harpo Bogglinn	765	100	1			1	1	32	32	hxb	heavy crossbow		5	5000								dmg-norm		25	50	swing1		10	10	slow		15	15	pierce-fire		10	10	extra-fire		10	10	allskills		1	1																										0
-Spikethrower 	766	100	1			3	1	10	24	hxb	heavy crossbow		5	5000				invhxb				dmg%		150	200	dmg-norm		10	20	crush		25	25	deadly		25	25	noheal		1	1	ama		1	1																										0
+Spikethrower	766	100	1			3	1	10	24	hxb	heavy crossbow		5	5000				invhxb				dmg%		150	200	dmg-norm		10	20	crush		25	25	deadly		25	25	noheal		1	1	ama		1	1																										0
 Synthalus	767	100	1			1	1	33	35	rxb	repeating crossbow		5	5000				invcbow3				dmg-norm		35	70	att		200	200	balance2		20	20	dex		15	15	mana		35	35	dmg/lvl	4			magicarrow		1	1																						0
 King's Nail	768	100	1			3	1	15	30	rxb	repeating crossbow		5	5000				invrxb				allskills		1	1	oskill	guided arrow	3	5	swing2		30	30	lifesteal		5	5	manasteal		3	3	gold%		50	50	hit-skill	Decrepify	15	3	dmg-min		10	20	dmg-max		30	50	dmg%		100	125										0
 Kyuss' Crossbow	769	100	1			1	1	55	48	8lx	arbalest		5	5000				invcbow6				dmg%		175	220	swing2		20	20	oskill	freezing arrow	1	1	heal-kill		10	15	regen-mana		60	60	mag%		30	50	gold%		75	75																						0


### PR DESCRIPTION
There is a whitespace after Spikethrower in uniqueitems.txt

Credits to Delegus