### PR TITLE
Rune Stack Changes

### DIFF
--- a/data/global/excel/cubemain.txt
+++ b/data/global/excel/cubemain.txt
@@ -1124,136 +1124,330 @@ REPAIR NORMAL - Armor & Ral-Rune & Flawed-Gem (Any)= Fully Repaired and Recharge
 REROLL RING - 3 Ring Magic = Amulet Magic	1				0					3	rin,mag,qty=3							amu,mag		75																																																																																					0
 REROLL RING - 3 Ring Rare = Amulet Rare	1				100					3	rin,rar,qty=3							amu,rar		100																																																																																					0
 REPAIR WEAPON - Weapon Normal & Ort-Rune = Fully Repaired Weapon	1				100					2	weap,noe	r09						useitem,rep,qty=255																																																																																							0
-RUNE UPGRADE - 2 El-Rune = Eld-Rune	1				100					2	r01,qty=2							r02																																																																																							0
-RUNE UPGRADE - 2 Eld-Rune = Tir-Rune	1				100					2	r02,qty=2							r03																																																																																							0
-RUNE UPGRADE - 2 Tir-Rune = Nef-Rune	1				100					2	r03,qty=2							r04																																																																																							0
-RUNE UPGRADE - 2 Nef-Rune = Eth-Rune	1				100					2	r04,qty=2							r05																																																																																							0
-RUNE UPGRADE - 2 Eth-Rune = Ith-Rune	1				100					2	r05,qty=2							r06																																																																																							0
-RUNE UPGRADE - 2 Ith-Rune = Tal-Rune	1				100					2	r06,qty=2							r07																																																																																							0
-RUNE UPGRADE - 2 Tal-Rune = Ral-Rune	1				100					2	r07,qty=2							r08																																																																																							0
-RUNE UPGRADE - 2 Ral-Rune = Ort-Rune	1				100					2	r08,qty=2							r09																																																																																							0
-RUNE UPGRADE - 2 Ort-Rune = Thul-Rune	1				100					2	r09,qty=2							r10																																																																																							0
-RUNE UPGRADE - 2 Thul-Rune = Amn-Rune	1				100					2	r10,qty=2							r11																																																																																							0
-RUNE UPGRADE - 2 Amn-Rune = Sol-Rune	1				100					2	r11,qty=2							r12																																																																																							0
-RUNE UPGRADE - 2 Sol-Rune = ShaEl-Rune	1				100					2	r12,qty=2							r13																																																																																							0
-RUNE UPGRADE - 2 ShaEl-Rune = Dol-Rune	1				100					2	r13,qty=2							r14																																																																																							0
-RUNE UPGRADE - 2 Dol-Rune = Hel-Rune	1				100					2	r14,qty=2							r15																																																																																							0
-RUNE UPGRADE - 2 Hel-Rune = Io-Rune	1				100					2	r15,qty=2							r16																																																																																							0
-RUNE UPGRADE - 2 Io-Rune = Lum-Rune	1				100					2	r16,qty=2							r17																																																																																							0
-RUNE UPGRADE - 2 Lum-Rune = Ko-Rune	1				100					2	r17,qty=2							r18																																																																																							0
-RUNE UPGRADE - 2 Ko-Rune = Fal-Rune	1				100					2	r18,qty=2							r19																																																																																							0
-RUNE UPGRADE - 2 Fal-Rune = Lem-Rune	1				100					2	r19,qty=2							r20																																																																																							0
-RUNE UPGRADE - 2 Lem-Rune = Pul-Rune	1				100					2	r20,qty=2							r21																																																																																							0
-RUNE UPGRADE - 2 Pul-Rune = Um-Rune	1				100					2	r21,qty=2							r22																																																																																							0
-RUNE UPGRADE - 2 Um-Rune = Mal-Rune	1				100					2	r22,qty=2							r23																																																																																							0
-RUNE UPGRADE - 2 Mal-Rune = Ist-Rune	1				100					2	r23,qty=2							r24																																																																																							0
-RUNE UPGRADE - 2 Ist-Rune = Gul-Rune	1				100					2	r24,qty=2							r25																																																																																							0
-RUNE UPGRADE - 2 Gul-Rune = Vex-Rune	1				100					2	r25,qty=2							r26																																																																																							0
-RUNE UPGRADE - 2 Vex-Rune = Ohm-Rune	1				100					2	r26,qty=2							r27																																																																																							0
-RUNE UPGRADE - 2 Ohm-Rune = Lo-Rune	1				100					2	r27,qty=2							r28																																																																																							0
-RUNE UPGRADE - 2 Lo-Rune = Sur-Rune	1				100					2	r28,qty=2							r29																																																																																							0
-RUNE UPGRADE - 2 Sur-Rune = Ber-Rune	1				100					2	r29,qty=2							r30																																																																																							0
-RUNE UPGRADE - 2 Ber-Rune = Jah-Rune	1				100					2	r30,qty=2							r31																																																																																							0
-RUNE UPGRADE - 2 Jah-Rune = Cham-Rune	1				100					2	r31,qty=2							r32																																																																																							0
-RUNE UPGRADE - 2 Cham-Rune = Zod-Rune	1				100					2	r32,qty=2							r33																																																																																							0
-RUNE DOWNGRADE - Zod-Rune = Cham-Rune	1				100					1	r33							r32																																																																																							0
-RUNE DOWNGRADE - Cham-Rune = Jah-Rune	1				100					1	r32							r31																																																																																							0
-RUNE DOWNGRADE - Jah-Rune = Ber-Rune	1				100					1	r31							r30																																																																																							0
-RUNE DOWNGRADE - Ber-Rune = Sur-Rune	1				100					1	r30							r29																																																																																							0
-RUNE DOWNGRADE - Sur-Rune = Lo-Rune	1				100					1	r29							r28																																																																																							0
-RUNE DOWNGRADE - Lo-Rune = Ohm-Rune	1				100					1	r28							r27																																																																																							0
-RUNE DOWNGRADE - Ohm-Rune = Vex-Rune	1				100					1	r27							r26																																																																																							0
-RUNE DOWNGRADE - Vex-Rune = Gul-Rune	1				100					1	r26							r25																																																																																							0
-RUNE DOWNGRADE - Gul-Rune = Ist-Rune	1				100					1	r25							r24																																																																																							0
-RUNE DOWNGRADE - Ist-Rune = Mal-Rune	1				100					1	r24							r23																																																																																							0
-RUNE DOWNGRADE - Mal-Rune = Um-Rune	1				100					1	r23							r22																																																																																							0
-RUNE DOWNGRADE - Um-Rune = Pul-Rune	1				100					1	r22							r21																																																																																							0
-RUNE DOWNGRADE - Pul-Rune = Lem-Rune	1				100					1	r21							r20																																																																																							0
-RUNE DOWNGRADE - Lem-Rune = Fal-Rune	1				100					1	r20							r19																																																																																							0
-RUNE DOWNGRADE - Fal-Rune = Ko-Rune	1				100					1	r19							r18																																																																																							0
-RUNE DOWNGRADE - Ko-Rune = Lum-Rune	1				100					1	r18							r17																																																																																							0
-RUNE DOWNGRADE - Lum-Rune = Io-Rune	1				100					1	r17							r16																																																																																							0
-RUNE DOWNGRADE - Io-Rune = Hel-Rune	1				100					1	r16							r15																																																																																							0
-RUNE DOWNGRADE - Hel-Rune = Dol-Rune	1				100					1	r15							r14																																																																																							0
-RUNE DOWNGRADE - Dol-Rune = Shael-Rune	1				100					1	r14							r13																																																																																							0
-RUNE DOWNGRADE - Shael-Rune = Sol-Rune	1				100					1	r13							r12																																																																																							0
-RUNE DOWNGRADE - Sol-Rune = Amn-Rune	1				100					1	r12							r11																																																																																							0
-RUNE DOWNGRADE - Amn-Rune = Thul-Rune	1				100					1	r11							r10																																																																																							0
-RUNE DOWNGRADE - Thul-Rune = Ort-Rune	1				100					1	r10							r09																																																																																							0
-RUNE DOWNGRADE - Ort-Rune = Ral-Rune	1				100					1	r09							r08																																																																																							0
-RUNE DOWNGRADE - Ral-Rune = Tal-Rune	1				100					1	r08							r07																																																																																							0
-RUNE DOWNGRADE - Tal-Rune = Ith-Rune	1				100					1	r07							r06																																																																																							0
-RUNE DOWNGRADE - Ith-Rune = Eth-Rune	1				100					1	r06							r05																																																																																							0
-RUNE DOWNGRADE - Eth-Rune = Nef-Rune	1				100					1	r05							r04																																																																																							0
-RUNE DOWNGRADE - Nef-Rune = Tir-Rune	1				100					1	r04							r03																																																																																							0
-RUNE DOWNGRADE - Tir-Rune = Eld-Rune	1				100					1	r03							r02																																																																																							0
-RUNE DOWNGRADE - Eld-Rune = El-Rune	1				100					1	r02							r01																																																																																							0
-RUNE STACK - 3 El-Rune = 3 Stacked El-Rune	1				100					3	r01,qty=3							s01,qty=3																																																																																							0
-RUNE STACK - 3 Eld-Rune = 3 Stacked Eld-Rune	1				100					3	r02,qty=3							s02,qty=3																																																																																							0
-RUNE STACK - 3 Tir-Rune = 3 Stacked Tir-Rune	1				100					3	r03,qty=3							s03,qty=3																																																																																							0
-RUNE STACK - 3 Nef-Rune = 3 Stacked Nef-Rune	1				100					3	r04,qty=3							s04,qty=3																																																																																							0
-RUNE STACK - 3 Eth-Rune = 3 Stacked Eth-Rune	1				100					3	r05,qty=3							s05,qty=3																																																																																							0
-RUNE STACK - 3 Ith-Rune = 3 Stacked Ith-Rune	1				100					3	r06,qty=3							s06,qty=3																																																																																							0
-RUNE STACK - 3 Tal-Rune = 3 Stacked Tal-Rune	1				100					3	r07,qty=3							s07,qty=3																																																																																							0
-RUNE STACK - 3 Ral-Rune = 3 Stacked Ral-Rune	1				100					3	r08,qty=3							s08,qty=3																																																																																							0
-RUNE STACK - 3 Ort-Rune = 3 Stacked Ort-Rune	1				100					3	r09,qty=3							s09,qty=3																																																																																							0
-RUNE STACK - 3 Thul-Rune = 3 Stacked Thul-Rune	1				100					3	r10,qty=3							s10,qty=3																																																																																							0
-RUNE STACK - 3 Amn-Rune = 3 Stacked Amn-Rune	1				100					3	r11,qty=3							s11,qty=3																																																																																							0
-RUNE STACK - 3 Sol-Rune = 3 Stacked Sol-Rune	1				100					3	r12,qty=3							s12,qty=3																																																																																							0
-RUNE STACK - 3 ShaEl-Rune = 3 Stacked ShaEl-Rune	1				100					3	r13,qty=3							s13,qty=3																																																																																							0
-RUNE STACK - 3 Dol-Rune = 3 Stacked Dol-Rune	1				100					3	r14,qty=3							s14,qty=3																																																																																							0
-RUNE STACK - 3 Hel-Rune = 3 Stacked Hel-Rune	1				100					3	r15,qty=3							s15,qty=3																																																																																							0
-RUNE STACK - 3 Io-Rune = 3 Stacked Io-Rune	1				100					3	r16,qty=3							s16,qty=3																																																																																							0
-RUNE STACK - 3 Lum-Rune = 3 Stacked Lum-Rune	1				100					3	r17,qty=3							s17,qty=3																																																																																							0
-RUNE STACK - 3 Ko-Rune = 3 Stacked Ko-Rune	1				100					3	r18,qty=3							s18,qty=3																																																																																							0
-RUNE STACK - 3 Fal-Rune = 3 Stacked Fal-Rune	1				100					3	r19,qty=3							s19,qty=3																																																																																							0
-RUNE STACK - 3 Lem-Rune = 3 Stacked Lem-Rune	1				100					3	r20,qty=3							s20,qty=3																																																																																							0
-RUNE STACK - 3 Pul-Rune = 3 Stacked Pul-Rune	1				100					3	r21,qty=3							s21,qty=3																																																																																							0
-RUNE STACK - 3 Um-Rune = 3 Stacked Um-Rune	1				100					3	r22,qty=3							s22,qty=3																																																																																							0
-RUNE STACK - 3 Mal-Rune = 3 Stacked Mal-Rune	1				100					3	r23,qty=3							s23,qty=3																																																																																							0
-RUNE STACK - 3 Ist-Rune = 3 Stacked Ist-Rune	1				100					3	r24,qty=3							s24,qty=3																																																																																							0
-RUNE STACK - 3 Gul-Rune = 3 Stacked Gul-Rune	1				100					3	r25,qty=3							s25,qty=3																																																																																							0
-RUNE STACK - 3 Vex-Rune = 3 Stacked Vex-Rune	1				100					3	r26,qty=3							s26,qty=3																																																																																							0
-RUNE STACK - 3 Ohm-Rune = 3 Stacked Ohm-Rune	1				100					3	r27,qty=3							s27,qty=3																																																																																							0
-RUNE STACK - 3 Lo-Rune = 3 Stacked Lo-Rune	1				100					3	r28,qty=3							s28,qty=3																																																																																							0
-RUNE STACK - 3 Sur-Rune = 3 Stacked Sur-Rune	1				100					3	r29,qty=3							s29,qty=3																																																																																							0
-RUNE STACK - 3 Ber-Rune = 3 Stacked Ber-Rune	1				100					3	r30,qty=3							s30,qty=3																																																																																							0
-RUNE STACK - 3 Jah-Rune = 3 Stacked Jah-Rune	1				100					3	r31,qty=3							s31,qty=3																																																																																							0
-RUNE STACK - 3 Cham-Rune = 3 Stacked Cham-Rune	1				100					3	r32,qty=3							s32,qty=3																																																																																							0
-RUNE STACK - 3 Zod-Rune = 3 Stacked Zod-Rune	1				100					3	r33,qty=3							s33,qty=3																																																																																							0
-RUNE UNSTACK - 1 Stacked El-Rune = 1 El-Rune	1				100	18	70	1		1	s01							r01																																																																																							0
-RUNE UNSTACK - 1 Stacked Eld-Rune = 1 Eld-Rune	1				100	18	70	1		1	s02							r02																																																																																							0
-RUNE UNSTACK - 1 Stacked Tir-Rune = 1 Tir-Rune	1				100	18	70	1		1	s03							r03																																																																																							0
-RUNE UNSTACK - 1 Stacked Nef-Rune = 1 Nef-Rune	1				100	18	70	1		1	s04							r04																																																																																							0
-RUNE UNSTACK - 1 Stacked Eth-Rune = 1 Eth-Rune	1				100	18	70	1		1	s05							r05																																																																																							0
-RUNE UNSTACK - 1 Stacked Ith-Rune = 1 Ith-Rune	1				100	18	70	1		1	s06							r06																																																																																							0
-RUNE UNSTACK - 1 Stacked Tal-Rune = 1 Tal-Rune	1				100	18	70	1		1	s07							r07																																																																																							0
-RUNE UNSTACK - 1 Stacked Ral-Rune = 1 Ral-Rune	1				100	18	70	1		1	s08							r08																																																																																							0
-RUNE UNSTACK - 1 Stacked Ort-Rune = 1 Ort-Rune	1				100	18	70	1		1	s09							r09																																																																																							0
-RUNE UNSTACK - 1 Stacked Thul-Rune = 1 Thul-Rune	1				100	18	70	1		1	s10							r10																																																																																							0
-RUNE UNSTACK - 1 Stacked Amn-Rune = 1 Amn-Rune	1				100	18	70	1		1	s11							r11																																																																																							0
-RUNE UNSTACK - 1 Stacked Sol-Rune = 1 Sol-Rune	1				100	18	70	1		1	s12							r12																																																																																							0
-RUNE UNSTACK - 1 Stacked ShaEl-Rune = 1 ShaEl-Rune	1				100	18	70	1		1	s13							r13																																																																																							0
-RUNE UNSTACK - 1 Stacked Dol-Rune = 1 Dol-Rune	1				100	18	70	1		1	s14							r14																																																																																							0
-RUNE UNSTACK - 1 Stacked Hel-Rune = 1 Hel-Rune	1				100	18	70	1		1	s15							r15																																																																																							0
-RUNE UNSTACK - 1 Stacked Io-Rune = 1 Io-Rune	1				100	18	70	1		1	s16							r16																																																																																							0
-RUNE UNSTACK - 1 Stacked Lum-Rune = 1 Lum-Rune	1				100	18	70	1		1	s17							r17																																																																																							0
-RUNE UNSTACK - 1 Stacked Ko-Rune = 1 Ko-Rune	1				100	18	70	1		1	s18							r18																																																																																							0
-RUNE UNSTACK - 1 Stacked Fal-Rune = 1 Fal-Rune	1				100	18	70	1		1	s19							r19																																																																																							0
-RUNE UNSTACK - 1 Stacked Lem-Rune = 1 Lem-Rune	1				100	18	70	1		1	s20							r20																																																																																							0
-RUNE UNSTACK - 1 Stacked Pul-Rune = 1 Pul-Rune	1				100	18	70	1		1	s21							r21																																																																																							0
-RUNE UNSTACK - 1 Stacked Um-Rune = 1 Um-Rune	1				100	18	70	1		1	s22							r22																																																																																							0
-RUNE UNSTACK - 1 Stacked Mal-Rune = 1 Mal-Rune	1				100	18	70	1		1	s23							r23																																																																																							0
-RUNE UNSTACK - 1 Stacked Ist-Rune = 1 Ist-Rune	1				100	18	70	1		1	s24							r24																																																																																							0
-RUNE UNSTACK - 1 Stacked Gul-Rune = 1 Gul-Rune	1				100	18	70	1		1	s25							r25																																																																																							0
-RUNE UNSTACK - 1 Stacked Vex-Rune = 1 Vex-Rune	1				100	18	70	1		1	s26							r26																																																																																							0
-RUNE UNSTACK - 1 Stacked Ohm-Rune = 1 Ohm-Rune	1				100	18	70	1		1	s27							r27																																																																																							0
-RUNE UNSTACK - 1 Stacked Lo-Rune = 1 Lo-Rune	1				100	18	70	1		1	s28							r28																																																																																							0
-RUNE UNSTACK - 1 Stacked Sur-Rune = 1 Sur-Rune	1				100	18	70	1		1	s29							r29																																																																																							0
-RUNE UNSTACK - 1 Stacked Ber-Rune = 1 Ber-Rune	1				100	18	70	1		1	s30							r30																																																																																							0
-RUNE UNSTACK - 1 Stacked Jah-Rune = 1 Jah-Rune	1				100	18	70	1		1	s31							r31																																																																																							0
-RUNE UNSTACK - 1 Stacked Cham-Rune = 1 Cham-Rune	1				100	18	70	1		1	s32							r32																																																																																							0
-RUNE UNSTACK - 1 Stacked Zod-Rune = 1 Zod-Rune	1				100	18	70	1		1	s33							r33																																																																																							0
+RUNE STACK - El-Rune = Stacked El-Rune	1				100					1	r01							s01																																																																																							0
+RUNE STACK - Eld-Rune = Stacked Eld-Rune	1				100					1	r02							s02																																																																																							0
+RUNE STACK - Tir-Rune  = Stacked Tir-Rune	1				100					1	r03							s03																																																																																							0
+RUNE STACK - Nef-Rune = Stacked Nef-Rune	1				100					1	r04							s04																																																																																							0
+RUNE STACK - Eth-Rune = Stacked Eth-Rune	1				100					1	r05							s05																																																																																							0
+RUNE STACK - Ith-Rune = Stacked Ith-Rune	1				100					1	r06							s06																																																																																							0
+RUNE STACK - Tal-Rune = Stacked Tal-Rune	1				100					1	r07							s07																																																																																							0
+RUNE STACK - Ral-Rune = Stacked Ral-Rune	1				100					1	r08							s08																																																																																							0
+RUNE STACK - Ort-Rune = Stacked Ort-Rune	1				100					1	r09							s09																																																																																							0
+RUNE STACK - Thul-Rune = Stacked Thul-Rune	1				100					1	r10							s10																																																																																							0
+RUNE STACK - Amn-Rune = Stacked Amn-Rune	1				100					1	r11							s11																																																																																							0
+RUNE STACK - Sol-Rune = Stacked Sol-Rune	1				100					1	r12							s12																																																																																							0
+RUNE STACK - Shael-Rune = Stacked Shael-Rune	1				100					1	r13							s13																																																																																							0
+RUNE STACK - Dol-Rune = Stacked Dol-Rune	1				100					1	r14							s14																																																																																							0
+RUNE STACK - Hel-Rune = Stacked Hel-Rune	1				100					1	r15							s15																																																																																							0
+RUNE STACK - Io-Rune = Stacked Io-Rune	1				100					1	r16							s16																																																																																							0
+RUNE STACK - Lum-Rune = Stacked Lum-Rune	1				100					1	r17							s17																																																																																							0
+RUNE STACK - Ko-Rune = Stacked Ko-Rune	1				100					1	r18							s18																																																																																							0
+RUNE STACK - Fal-Rune = Stacked Fal-Rune	1				100					1	r19							s19																																																																																							0
+RUNE STACK - Lem-Rune = Stacked Lem-Rune	1				100					1	r20							s20																																																																																							0
+RUNE STACK - Pul-Rune = Stacked Pul-Rune	1				100					1	r21							s21																																																																																							0
+RUNE STACK - Um-Rune = Stacked Um-Rune	1				100					1	r22							s22																																																																																							0
+RUNE STACK - Mal-Rune = Stacked Mal-Rune	1				100					1	r23							s23																																																																																							0
+RUNE STACK - Ist-Rune = Stacked Ist-Rune	1				100					1	r24							s24																																																																																							0
+RUNE STACK - Gul-Rune = Stacked Gul-Rune	1				100					1	r25							s25																																																																																							0
+RUNE STACK - Vex-Rune = Stacked Vex-Rune	1				100					1	r26							s26																																																																																							0
+RUNE STACK - Ohm-Rune = Stacked Ohm-Rune	1				100					1	r27							s27																																																																																							0
+RUNE STACK - Lo-Rune = Stacked Lo-Rune	1				100					1	r28							s28																																																																																							0
+RUNE STACK - Sur-Rune = Stacked Sur-Rune	1				100					1	r29							s29																																																																																							0
+RUNE STACK - Ber-Rune = Stacked Ber-Rune	1				100					1	r30							s30																																																																																							0
+RUNE STACK - Jah-Rune = Stacked Jah-Rune	1				100					1	r31							s31																																																																																							0
+RUNE STACK - Cham-Rune = Stacked Cham-Rune	1				100					1	r32							s32																																																																																							0
+RUNE STACK - Zod-Rune = Stacked Zod-Rune	1				100					1	r33							s33																																																																																							0
+RUNE STACK - Stacked El-Rune + El-Rune = Stacked El-Rune qty+1	1				100					2	s01	r01						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Eld-Rune + Eld-Rune = Stacked Eld-Rune qty+1	1				100					2	s02	r02						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Tir-Rune + Tir-Rune = Stacked Tir-Rune qty+1	1				100					2	s03	r03						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Nef-Rune + Nef-Rune = Stacked Nef-Rune qty+1	1				100					2	s04	r04						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Eth-Rune + Eth-Rune = Stacked Eth-Rune qty+1	1				100					2	s05	r05						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ith-Rune + Ith-Rune = Stacked Ith-Rune qty+1	1				100					2	s06	r06						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Tal-Rune + Tal-Rune = Stacked Tal-Rune qty+1	1				100					2	s07	r07						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ral-Rune + Ral-Rune = Stacked Ral-Rune qty+1	1				100					2	s08	r08						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ort-Rune + Ort-Rune = Stacked Ort-Rune qty+1	1				100					2	s09	r09						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Thul-Rune + Thul-Rune = Stacked Thul-Rune qty+1	1				100					2	s10	r10						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Amn-Rune + Amn-Rune = Stacked Amn-Rune qty+1	1				100					2	s11	r11						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Sol-Rune + Sol-Rune = Stacked Sol-Rune qty+1	1				100					2	s12	r12						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Shael-Rune + Shael-Rune = Stacked Shael-Rune qty+1	1				100					2	s13	r13						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Dol-Rune + Dol-Rune = Stacked Dol-Rune qty+1	1				100					2	s14	r14						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Hel-Rune + Hel-Rune = Stacked Hel-Rune qty+1	1				100					2	s15	r15						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Io-Rune + Io-Rune = Stacked Io-Rune qty+1	1				100					2	s16	r16						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Lum-Rune + Lum-Rune = Stacked Lum-Rune qty+1	1				100					2	s17	r17						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ko-Rune + Ko-Rune = Stacked Ko-Rune qty+1	1				100					2	s18	r18						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Fal-Rune + Fal-Rune = Stacked Fal-Rune qty+1	1				100					2	s19	r19						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Lem-Rune + Lem-Rune = Stacked Lem-Rune qty+1	1				100					2	s20	r20						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Pul-Rune + Pul-Rune = Stacked Pul-Rune qty+1	1				100					2	s21	r21						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Um-Rune + Um-Rune = Stacked Um-Rune qty+1	1				100					2	s22	r22						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Mal-Rune + Mal-Rune = Stacked Mal-Rune qty+1	1				100					2	s23	r23						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ist-Rune + Ist-Rune = Stacked Ist-Rune qty+1	1				100					2	s24	r24						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Gul-Rune + Gul-Rune = Stacked Gul-Rune qty+1	1				100					2	s25	r25						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Vex-Rune + Vex-Rune = Stacked Vex-Rune qty+1	1				100					2	s26	r26						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ohm-Rune + Ohm-Rune = Stacked Ohm-Rune qty+1	1				100					2	s27	r27						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Lo-Rune + Lo-Rune = Stacked Lo-Rune qty+1	1				100					2	s28	r28						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Sur-Rune + Sur-Rune = Stacked Sur-Rune qty+1	1				100					2	s29	r29						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Ber-Rune + Ber-Rune = Stacked Ber-Rune qty+1	1				100					2	s30	r30						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Jah-Rune + Jah-Rune = Stacked Jah-Rune qty+1	1				100					2	s31	r31						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Cham-Rune + Cham-Rune = Stacked Cham-Rune qty+1	1				100					2	s32	r32						useitem				item-qty			1	1																																																																															0
+RUNE STACK - Stacked Zod-Rune + Zod Rune = Stacked Zod-Rune qty+1	1				100					2	s33	r33						useitem				item-qty			1	1																																																																															0
+RUNE UNSTACK - Stacked El-Rune (qty>1) = Stacked El-Rune qty-1 + 1 El-Rune	1				100	17	70	1		1	s01							useitem				item-qty			-1	-1																					r01																																																										0
+RUNE UNSTACK - Stacked Eld-Rune (qty>1) = Stacked Eld-Rune qty-1 + 1 Eld-Rune	1				100	17	70	1		1	s02							useitem				item-qty			-1	-1																					r02																																																										0
+RUNE UNSTACK - Stacked Tir-Rune (qty>1) = Stacked Tir-Rune qty-1 + 1 Tir-Rune	1				100	17	70	1		1	s03							useitem				item-qty			-1	-1																					r03																																																										0
+RUNE UNSTACK - Stacked Nef-Rune (qty>1) = Stacked Nef-Rune qty-1 + 1 Nef-Rune	1				100	17	70	1		1	s04							useitem				item-qty			-1	-1																					r04																																																										0
+RUNE UNSTACK - Stacked Eth-Rune (qty>1) = Stacked Eth-Rune qty-1 + 1 Eth-Rune	1				100	17	70	1		1	s05							useitem				item-qty			-1	-1																					r05																																																										0
+RUNE UNSTACK - Stacked Ith-Rune (qty>1) = Stacked Ith-Rune qty-1 + 1 Ith-Rune	1				100	17	70	1		1	s06							useitem				item-qty			-1	-1																					r06																																																										0
+RUNE UNSTACK - Stacked Tal-Rune (qty>1) = Stacked Tal-Rune qty-1 + 1 Tal-Rune	1				100	17	70	1		1	s07							useitem				item-qty			-1	-1																					r07																																																										0
+RUNE UNSTACK - Stacked Ral-Rune (qty>1) = Stacked Ral-Rune qty-1 + 1 Ral-Rune	1				100	17	70	1		1	s08							useitem				item-qty			-1	-1																					r08																																																										0
+RUNE UNSTACK - Stacked Ort-Rune (qty>1) = Stacked Ort-Rune qty-1 + 1 Ort-Rune	1				100	17	70	1		1	s09							useitem				item-qty			-1	-1																					r09																																																										0
+RUNE UNSTACK - Stacked Thul-Rune (qty>1) = Stacked Thul-Rune qty-1 + 1 Thul-Rune	1				100	17	70	1		1	s10							useitem				item-qty			-1	-1																					r10																																																										0
+RUNE UNSTACK - Stacked Amn-Rune (qty>1) = Stacked Amn-Rune qty-1 + 1 Amn-Rune	1				100	17	70	1		1	s11							useitem				item-qty			-1	-1																					r11																																																										0
+RUNE UNSTACK - Stacked Sol-Rune (qty>1) = Stacked Sol-Rune qty-1 + 1 Sol-Rune	1				100	17	70	1		1	s12							useitem				item-qty			-1	-1																					r12																																																										0
+RUNE UNSTACK - Stacked Shael-Rune (qty>1) = Stacked Shael-Rune qty-1 + 1 Shael-Rune	1				100	17	70	1		1	s13							useitem				item-qty			-1	-1																					r13																																																										0
+RUNE UNSTACK - Stacked Dol-Rune (qty>1) = Stacked Shael-Rune qty-1 + 1 Dol-Rune	1				100	17	70	1		1	s14							useitem				item-qty			-1	-1																					r14																																																										0
+RUNE UNSTACK - Stacked Hel-Rune (qty>1) = Stacked Hel-Rune qty-1 + 1 Hel-Rune	1				100	17	70	1		1	s15							useitem				item-qty			-1	-1																					r15																																																										0
+RUNE UNSTACK - Stacked Io-Rune (qty>1) = Stacked Io-Rune qty-1 + 1 Io-Rune	1				100	17	70	1		1	s16							useitem				item-qty			-1	-1																					r16																																																										0
+RUNE UNSTACK - Stacked Lum-Rune (qty>1) = Stacked Lum-Rune qty-1 + 1 Lum-Rune	1				100	17	70	1		1	s17							useitem				item-qty			-1	-1																					r17																																																										0
+RUNE UNSTACK - Stacked Ko-Rune (qty>1) = Stacked Ko-Rune qty-1 + 1 Ko-Rune	1				100	17	70	1		1	s18							useitem				item-qty			-1	-1																					r18																																																										0
+RUNE UNSTACK - Stacked Fal-Rune (qty>1) = Stacked Fal-Rune qty-1 + 1 Fal-Rune	1				100	17	70	1		1	s19							useitem				item-qty			-1	-1																					r19																																																										0
+RUNE UNSTACK - Stacked Lem-Rune (qty>1) = Stacked Lem-Rune qty-1 + 1 Lem-Rune	1				100	17	70	1		1	s20							useitem				item-qty			-1	-1																					r20																																																										0
+RUNE UNSTACK - Stacked Pul-Rune (qty>1) = Stacked Pul-Rune qty-1 + 1 Pul-Rune	1				100	17	70	1		1	s21							useitem				item-qty			-1	-1																					r21																																																										0
+RUNE UNSTACK - Stacked Um-Rune (qty>1) = Stacked Um-Rune qty-1 + 1 Um-Rune	1				100	17	70	1		1	s22							useitem				item-qty			-1	-1																					r22																																																										0
+RUNE UNSTACK - Stacked Mal-Rune (qty>1) = Stacked Mal-Rune qty-1 + 1 Mal-Rune	1				100	17	70	1		1	s23							useitem				item-qty			-1	-1																					r23																																																										0
+RUNE UNSTACK - Stacked Ist-Rune (qty>1) = Stacked Ist-Rune qty-1 + 1 Ist-Rune	1				100	17	70	1		1	s24							useitem				item-qty			-1	-1																					r24																																																										0
+RUNE UNSTACK - Stacked Gul-Rune (qty>1) = Stacked Gul-Rune qty-1 + 1 Gul-Rune	1				100	17	70	1		1	s25							useitem				item-qty			-1	-1																					r25																																																										0
+RUNE UNSTACK - Stacked Vex-Rune (qty>1) = Stacked Vex-Rune qty-1 + 1 Vex-Rune	1				100	17	70	1		1	s26							useitem				item-qty			-1	-1																					r26																																																										0
+RUNE UNSTACK - Stacked Ohm-Rune (qty>1) = Stacked Ohm-Rune qty-1 + 1 Ohm-Rune	1				100	17	70	1		1	s27							useitem				item-qty			-1	-1																					r27																																																										0
+RUNE UNSTACK - Stacked Lo-Rune (qty>1) = Stacked Lo-Rune qty-1 + 1 Lo-Rune	1				100	17	70	1		1	s28							useitem				item-qty			-1	-1																					r28																																																										0
+RUNE UNSTACK - Stacked Sur-Rune (qty>1) = Stacked Sur-Rune qty-1 + 1 Sur-Rune	1				100	17	70	1		1	s29							useitem				item-qty			-1	-1																					r29																																																										0
+RUNE UNSTACK - Stacked Ber-Rune (qty>1) = Stacked Ber-Rune qty-1 + 1 Ber-Rune	1				100	17	70	1		1	s30							useitem				item-qty			-1	-1																					r30																																																										0
+RUNE UNSTACK - Stacked Jah-Rune (qty>1) = Stacked Jah-Rune qty-1 + 1 Jah-Rune	1				100	17	70	1		1	s31							useitem				item-qty			-1	-1																					r31																																																										0
+RUNE UNSTACK - Stacked Cham-Rune (qty>1) = Stacked Cham-Rune qty-1 + 1 Cham-Rune	1				100	17	70	1		1	s32							useitem				item-qty			-1	-1																					r32																																																										0
+RUNE UNSTACK - Stacked Zod-Rune (qty>1) = Stacked Zod-Rune qty-1 + 1 Zod-Rune	1				100	17	70	1		1	s33							useitem				item-qty			-1	-1																					r33																																																										0
+RUNE UNSTACK - Stacked El-Rune (qty=1) = 1 El-Rune	1				100	18	70	1		1	s01							r01																																																																																							0
+RUNE UNSTACK - Stacked Eld-Rune (qty=1) = 1 Eld-Rune	1				100	18	70	1		1	s02							r02																																																																																							0
+RUNE UNSTACK - Stacked Tir-Rune (qty=1) = 1 Tir-Rune	1				100	18	70	1		1	s03							r03																																																																																							0
+RUNE UNSTACK - Stacked Nef-Rune (qty=1) = 1 Nef-Rune	1				100	18	70	1		1	s04							r04																																																																																							0
+RUNE UNSTACK - Stacked Eth-Rune (qty=1) = 1 Eth-Rune	1				100	18	70	1		1	s05							r05																																																																																							0
+RUNE UNSTACK - Stacked Ith-Rune (qty=1) = 1 Ith-Rune	1				100	18	70	1		1	s06							r06																																																																																							0
+RUNE UNSTACK - Stacked Tal-Rune (qty=1) = 1 Tal-Rune	1				100	18	70	1		1	s07							r07																																																																																							0
+RUNE UNSTACK - Stacked Ral-Rune (qty=1) = 1 Ral-Rune	1				100	18	70	1		1	s08							r08																																																																																							0
+RUNE UNSTACK - Stacked Ort-Rune (qty=1) = 1 Ort-Rune	1				100	18	70	1		1	s09							r09																																																																																							0
+RUNE UNSTACK - Stacked Thul-Rune (qty=1) = 1 Thul-Rune	1				100	18	70	1		1	s10							r10																																																																																							0
+RUNE UNSTACK - Stacked Amn-Rune (qty=1) = 1 Amn-Rune	1				100	18	70	1		1	s11							r11																																																																																							0
+RUNE UNSTACK - Stacked Sol-Rune (qty=1) = 1 Sol-Rune	1				100	18	70	1		1	s12							r12																																																																																							0
+RUNE UNSTACK - Stacked Shael-Rune (qty=1) = 1 Shael-Rune	1				100	18	70	1		1	s13							r13																																																																																							0
+RUNE UNSTACK - Stacked Dol-Rune (qty=1) = 1 Dol-Rune	1				100	18	70	1		1	s14							r14																																																																																							0
+RUNE UNSTACK - Stacked Hel-Rune (qty=1) = 1 Hel-Rune	1				100	18	70	1		1	s15							r15																																																																																							0
+RUNE UNSTACK - Stacked Io-Rune (qty=1) = 1 Io-Rune	1				100	18	70	1		1	s16							r16																																																																																							0
+RUNE UNSTACK - Stacked Lum-Rune (qty=1) = 1 Lum-Rune	1				100	18	70	1		1	s17							r17																																																																																							0
+RUNE UNSTACK - Stacked Ko-Rune (qty=1) = 1 Ko-Rune	1				100	18	70	1		1	s18							r18																																																																																							0
+RUNE UNSTACK - Stacked Fal-Rune (qty=1) = 1 Fal-Rune	1				100	18	70	1		1	s19							r19																																																																																							0
+RUNE UNSTACK - Stacked Lem-Rune (qty=1) = 1 Lem-Rune	1				100	18	70	1		1	s20							r20																																																																																							0
+RUNE UNSTACK - Stacked Pul-Rune (qty=1) = 1 Pul-Rune	1				100	18	70	1		1	s21							r21																																																																																							0
+RUNE UNSTACK - Stacked Um-Rune (qty=1) = 1 Um-Rune	1				100	18	70	1		1	s22							r22																																																																																							0
+RUNE UNSTACK - Stacked Mal-Rune (qty=1) = 1 Mal-Rune	1				100	18	70	1		1	s23							r23																																																																																							0
+RUNE UNSTACK - Stacked Ist-Rune (qty=1) = 1 Ist-Rune	1				100	18	70	1		1	s24							r24																																																																																							0
+RUNE UNSTACK - Stacked Gul-Rune (qty=1) = 1 Gul-Rune	1				100	18	70	1		1	s25							r25																																																																																							0
+RUNE UNSTACK - Stacked Vex-Rune (qty=1) = 1 Vex-Rune	1				100	18	70	1		1	s26							r26																																																																																							0
+RUNE UNSTACK - Stacked Ohm-Rune (qty=1) = 1 Ohm-Rune	1				100	18	70	1		1	s27							r27																																																																																							0
+RUNE UNSTACK - Stacked Lo-Rune (qty=1) = 1 Lo-Rune	1				100	18	70	1		1	s28							r28																																																																																							0
+RUNE UNSTACK - Stacked Sur-Rune (qty=1) = 1 Sur-Rune	1				100	18	70	1		1	s29							r29																																																																																							0
+RUNE UNSTACK - Stacked Ber-Rune (qty=1) = 1 Ber-Rune	1				100	18	70	1		1	s30							r30																																																																																							0
+RUNE UNSTACK - Stacked Jah-Rune (qty=1) = 1 Jah-Rune	1				100	18	70	1		1	s31							r31																																																																																							0
+RUNE UNSTACK - Stacked Cham-Rune (qty=1) = 1 Cham-Rune	1				100	18	70	1		1	s32							r32																																																																																							0
+RUNE UNSTACK - Stacked Zod-Rune (qty=1) = 1 Zod-Rune	1				100	18	70	1		1	s33							r33																																																																																							0
+RUNE UPGRADE - 2 El-Runes = Eld-Rune	1				100					2	r01,qty=2							r02																																																																																							0
+RUNE UPGRADE - 2 Eld-Runes = Tir-Rune	1				100					2	r02,qty=2							r03																																																																																							0
+RUNE UPGRADE - 2 Tir-Runes = Nef-Rune	1				100					2	r03,qty=2							r04																																																																																							0
+RUNE UPGRADE - 2 Nef-Runes = Eth-Rune	1				100					2	r04,qty=2							r05																																																																																							0
+RUNE UPGRADE - 2 Eth-Runes = Ith-Rune	1				100					2	r05,qty=2							r06																																																																																							0
+RUNE UPGRADE - 2 Ith-Runes = Tal-Rune	1				100					2	r06,qty=2							r07																																																																																							0
+RUNE UPGRADE - 2 Tal-Runes = Ral-Rune	1				100					2	r07,qty=2							r08																																																																																							0
+RUNE UPGRADE - 2 Ral-Runes = Ort-Rune	1				100					2	r08,qty=2							r09																																																																																							0
+RUNE UPGRADE - 2 Ort-Runes = Thul-Rune	1				100					2	r09,qty=2							r10																																																																																							0
+RUNE UPGRADE - 2 Thul-Runes = Amn-Rune	1				100					2	r10,qty=2							r11																																																																																							0
+RUNE UPGRADE - 2 Amn-Runes = Sol-Rune	1				100					2	r11,qty=2							r12																																																																																							0
+RUNE UPGRADE - 2 Sol-Runes = Shael-Rune	1				100					2	r12,qty=2							r13																																																																																							0
+RUNE UPGRADE - 2 Shael-Runes = Dol-Rune	1				100					2	r13,qty=2							r14																																																																																							0
+RUNE UPGRADE - 2 Dol-Runes = Hel-Rune	1				100					2	r14,qty=2							r15																																																																																							0
+RUNE UPGRADE - 2 Hel-Runes = Io-Rune	1				100					2	r15,qty=2							r16																																																																																							0
+RUNE UPGRADE - 2 Io-Runes = Lum-Rune	1				100					2	r16,qty=2							r17																																																																																							0
+RUNE UPGRADE - 2 Lum-Runes = Ko-Rune	1				100					2	r17,qty=2							r18																																																																																							0
+RUNE UPGRADE - 2 Ko-Runes = Fal-Rune	1				100					2	r18,qty=2							r19																																																																																							0
+RUNE UPGRADE - 2 Fal-Runes = Lem-Rune	1				100					2	r19,qty=2							r20																																																																																							0
+RUNE UPGRADE - 2 Lem-Runes = Pul-Rune	1				100					2	r20,qty=2							r21																																																																																							0
+RUNE UPGRADE - 2 Pul-Runes = Um-Rune	1				100					2	r21,qty=2							r22																																																																																							0
+RUNE UPGRADE - 2 Um-Runes = Mal-Rune	1				100					2	r22,qty=2							r23																																																																																							0
+RUNE UPGRADE - 2 Mal-Runes = Ist-Rune	1				100					2	r23,qty=2							r24																																																																																							0
+RUNE UPGRADE - 2 Ist-Runes = Gul-Rune	1				100					2	r24,qty=2							r25																																																																																							0
+RUNE UPGRADE - 2 Gul-Runes = Vex-Rune	1				100					2	r25,qty=2							r26																																																																																							0
+RUNE UPGRADE - 2 Vex-Runes = Ohm-Rune	1				100					2	r26,qty=2							r27																																																																																							0
+RUNE UPGRADE - 2 Ohm-Runes = Lo-Rune	1				100					2	r27,qty=2							r28																																																																																							0
+RUNE UPGRADE - 2 Lo-Runes = Sur-Rune	1				100					2	r28,qty=2							r29																																																																																							0
+RUNE UPGRADE - 2 Sur-Runes = Ber-Rune	1				100					2	r29,qty=2							r30																																																																																							0
+RUNE UPGRADE - 2 Ber-Runes = Jah-Rune	1				100					2	r30,qty=2							r31																																																																																							0
+RUNE UPGRADE - 2 Jah-Runes = Cham-Rune	1				100					2	r31,qty=2							r32																																																																																							0
+RUNE UPGRADE - 2 Cham-Runes = Zod-Rune	1				100					2	r32,qty=2							r33																																																																																							0
+RUNE UPGRADE - Stacked El-Rune (qty=2) + TP Tome = Eld-Rune	1				100	18	70	2		2	s01	tbk						r02																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Eld-Rune (qty=2) + TP Tome = Tir-Rune	1				100	18	70	2		2	s02	tbk						r03																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Tir-Rune (qty=2) + TP Tome = Nef-Rune	1				100	18	70	2		2	s03	tbk						r04																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Nef-Rune (qty=2) + TP Tome = Eth-Rune	1				100	18	70	2		2	s04	tbk						r05																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Eth-Rune (qty=2) + TP Tome = Ith-Rune	1				100	18	70	2		2	s05	tbk						r06																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ith-Rune (qty=2) + TP Tome = Tal-Rune	1				100	18	70	2		2	s06	tbk						r07																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Tal-Rune (qty=2) + TP Tome = Ral-Rune	1				100	18	70	2		2	s07	tbk						r08																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ral-Rune (qty=2) + TP Tome = Ort-Rune	1				100	18	70	2		2	s08	tbk						r09																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ort-Rune (qty=2) + TP Tome = Thul-Rune	1				100	18	70	2		2	s09	tbk						r10																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Thul-Rune (qty=2) + TP Tome = Amn-Rune	1				100	18	70	2		2	s10	tbk						r11																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Amn-Rune (qty=2) + TP Tome = Sol-Rune	1				100	18	70	2		2	s11	tbk						r12																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Sol-Rune (qty=2) + TP Tome = Shael-Rune	1				100	18	70	2		2	s12	tbk						r13																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Shael-Rune (qty=2) + TP Tome = Dol-Rune	1				100	18	70	2		2	s13	tbk						r14																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Dol-Rune (qty=2) + TP Tome = Hel-Rune	1				100	18	70	2		2	s14	tbk						r15																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Hel-Rune (qty=2) + TP Tome = Io-Rune	1				100	18	70	2		2	s15	tbk						r16																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Io-Rune (qty=2) + TP Tome = Lum-Rune	1				100	18	70	2		2	s16	tbk						r17																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Lum-Rune (qty=2) + TP Tome = Ko-Rune	1				100	18	70	2		2	s17	tbk						r18																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ko-Rune (qty=2) + TP Tome = Fal-Rune	1				100	18	70	2		2	s18	tbk						r19																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Fal-Rune (qty=2) + TP Tome = Lem-Rune	1				100	18	70	2		2	s19	tbk						r20																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Lem-Rune (qty=2) + TP Tome = Pul-Rune	1				100	18	70	2		2	s20	tbk						r21																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Pul-Rune (qty=2) + TP Tome = Um-Rune	1				100	18	70	2		2	s21	tbk						r22																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Um-Rune (qty=2) + TP Tome = Mal-Rune	1				100	18	70	2		2	s22	tbk						r23																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Mal-Rune (qty=2) + TP Tome = Ist-Rune	1				100	18	70	2		2	s23	tbk						r24																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ist-Rune (qty=2) + TP Tome = Gul-Rune	1				100	18	70	2		2	s24	tbk						r25																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Gul-Rune (qty=2) + TP Tome = Vex-Rune	1				100	18	70	2		2	s25	tbk						r26																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Vex-Rune (qty=2) + TP Tome = Ohm-Rune	1				100	18	70	2		2	s26	tbk						r27																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ohm-Rune (qty=2) + TP Tome = Lo-Rune	1				100	18	70	2		2	s27	tbk						r28																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Lo-Rune (qty=2) + TP Tome= Sur-Rune	1				100	18	70	2		2	s28	tbk						r29																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Sur-Rune (qty=2) + TP Tome = Ber-Rune	1				100	18	70	2		2	s29	tbk						r30																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Ber-Rune (qty=2) + TP Tome = Jah-Rune	1				100	18	70	2		2	s30	tbk						r31																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Jah-Rune (qty=2) + TP Tome = Cham-Rune	1				100	18	70	2		2	s31	tbk						r32																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked Cham-Rune (qty=2) + TP Tome = Zod-Rune	1				100	18	70	2		2	s32	tbk						r33																													tbk,qty=100																																																										0
+RUNE UPGRADE - Stacked El-Rune (qty>2) + TP Tome = Stacked El-Rune qty-2 + Eld-Rune	1				100	15	70	2		2	s01	tbk						useitem				item-qty	100		-2	-2																					r02																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Eld-Rune (qty>2) + TP Tome = Stacked Eld-Rune qty-2 + Tir-Rune	1				100	15	70	2		2	s02	tbk						useitem				item-qty	100		-2	-2																					r03																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Tir-Rune (qty>2) + TP Tome = Stacked Tir-Rune qty-2 + Nef-Rune	1				100	15	70	2		2	s03	tbk						useitem				item-qty	100		-2	-2																					r04																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Nef-Rune (qty>2) + TP Tome = Stacked Nef-Rune qty-2 + Eth-Rune	1				100	15	70	2		2	s04	tbk						useitem				item-qty	100		-2	-2																					r05																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Eth-Rune (qty>2) + TP Tome = Stacked Eth-Rune qty-2 + Ith-Rune	1				100	15	70	2		2	s05	tbk						useitem				item-qty	100		-2	-2																					r06																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ith-Rune (qty>2) + TP Tome = Stacked Ith-Rune qty-2 + Tal-Rune	1				100	15	70	2		2	s06	tbk						useitem				item-qty	100		-2	-2																					r07																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Tal-Rune (qty>2) + TP Tome = Stacked Tal-Rune qty-2 + Ral-Rune	1				100	15	70	2		2	s07	tbk						useitem				item-qty	100		-2	-2																					r08																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ral-Rune (qty>2) + TP Tome = Stacked Ral-Rune qty-2 + Ort-Rune	1				100	15	70	2		2	s08	tbk						useitem				item-qty	100		-2	-2																					r09																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ort-Rune (qty>2) + TP Tome = Stacked Ort-Rune qty-2 + Thul-Rune	1				100	15	70	2		2	s09	tbk						useitem				item-qty	100		-2	-2																					r10																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Thul-Rune (qty>2) + TP Tome = Stacked Thul-Rune qty-2 + Amn-Rune	1				100	15	70	2		2	s10	tbk						useitem				item-qty	100		-2	-2																					r11																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Amn-Rune (qty>2) + TP Tome = Stacked Amn-Rune qty-2 + Sol-Rune	1				100	15	70	2		2	s11	tbk						useitem				item-qty	100		-2	-2																					r12																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Sol-Rune (qty>2) + TP Tome = Stacked Sol-Rune qty-2 + Shael-Rune	1				100	15	70	2		2	s12	tbk						useitem				item-qty	100		-2	-2																					r13																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Shael-Rune (qty>2) + TP Tome = Stacked Shael-Rune qty-2 + Dol-Rune	1				100	15	70	2		2	s13	tbk						useitem				item-qty	100		-2	-2																					r14																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Dol-Rune (qty>2) + TP Tome = Stacked Dol-Rune qty-2 + Hel-Rune	1				100	15	70	2		2	s14	tbk						useitem				item-qty	100		-2	-2																					r15																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Hel-Rune (qty>2) + TP Tome = Stacked Hel-Rune qty-2 + Io-Rune	1				100	15	70	2		2	s15	tbk						useitem				item-qty	100		-2	-2																					r16																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Io-Rune (qty>2) + TP Tome = Stacked Io-Rune qty-2 + Lum-Rune	1				100	15	70	2		2	s16	tbk						useitem				item-qty	100		-2	-2																					r17																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Lum-Rune (qty>2) + TP Tome = Stacked Lum-Rune qty-2 + Ko-Rune	1				100	15	70	2		2	s17	tbk						useitem				item-qty	100		-2	-2																					r18																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ko-Rune (qty>2) + TP Tome = Stacked Ko-Rune qty-2 + Fal-Rune	1				100	15	70	2		2	s18	tbk						useitem				item-qty	100		-2	-2																					r19																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Fal-Rune (qty>2) + TP Tome = Stacked Fal-Rune qty-2 + Lem-Rune	1				100	15	70	2		2	s19	tbk						useitem				item-qty	100		-2	-2																					r20																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Lem-Rune (qty>2) + TP Tome = Stacked Lem-Rune qty-2 + Pul-Rune	1				100	15	70	2		2	s20	tbk						useitem				item-qty	100		-2	-2																					r21																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Pul-Rune (qty>2) + TP Tome = Stacked Pul-Rune qty-2 + Um-Rune	1				100	15	70	2		2	s21	tbk						useitem				item-qty	100		-2	-2																					r22																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Um-Rune (qty>2) + TP Tome = Stacked Um-Rune qty-2 + Mal-Rune	1				100	15	70	2		2	s22	tbk						useitem				item-qty	100		-2	-2																					r23																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Mal-Rune (qty>2) + TP Tome = Stacked Mal-Rune qty-2 + Ist-Rune	1				100	15	70	2		2	s23	tbk						useitem				item-qty	100		-2	-2																					r24																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ist-Rune (qty>2) + TP Tome = Stacked Ist-Rune qty-2 + Gul-Rune	1				100	15	70	2		2	s24	tbk						useitem				item-qty	100		-2	-2																					r25																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Gul-Rune (qty>2) + TP Tome = Stacked Gul-Rune qty-2 + Vex-Rune	1				100	15	70	2		2	s25	tbk						useitem				item-qty	100		-2	-2																					r26																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Vex-Rune (qty>2) + TP Tome = Stacked Vex-Rune qty-2 + Ohm-Rune	1				100	15	70	2		2	s26	tbk						useitem				item-qty	100		-2	-2																					r27																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ohm-Rune (qty>2) + TP Tome = Stacked Ohm-Rune qty-2 + Lo-Rune	1				100	15	70	2		2	s27	tbk						useitem				item-qty	100		-2	-2																					r28																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Lo-Rune (qty>2) + TP Tome= Stacked Lo-Rune qty-2 + Sur-Rune	1				100	15	70	2		2	s28	tbk						useitem				item-qty	100		-2	-2																					r29																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Sur-Rune (qty>2) + TP Tome = Stacked Sur-Rune qty-2 + Ber-Rune	1				100	15	70	2		2	s29	tbk						useitem				item-qty	100		-2	-2																					r30																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Ber-Rune (qty>2) + TP Tome = Stacked Ber-Rune qty-2 + Jah-Rune	1				100	15	70	2		2	s30	tbk						useitem				item-qty	100		-2	-2																					r31																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Jah-Rune (qty>2) + TP Tome = Stacked Jah-Rune qty-2 + Cham-Rune	1				100	15	70	2		2	s31	tbk						useitem				item-qty	100		-2	-2																					r32																													tbk,qty=100																													0
+RUNE UPGRADE - Stacked Cham-Rune (qty>2) + TP Tome = Stacked Cham-Rune qty-2 + Zod-Rune	1				100	15	70	2		2	s32	tbk						useitem				item-qty	100		-2	-2																					r33																													tbk,qty=100																													0
+RUNE DOWNGRADE - Zod-Rune + ID Tome = Cham-Rune	1				100					2	r33	ibk						r32																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Cham-Rune + ID Tome = Jah-Rune	1				100					2	r32	ibk						r31																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Jah-Rune + ID Tome = Ber-Rune	1				100					2	r31	ibk						r30																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ber-Rune + ID Tome = Sur-Rune	1				100					2	r30	ibk						r29																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Sur-Rune + ID Tome = Lo-Rune	1				100					2	r29	ibk						r28																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Lo-Rune + ID Tome = Ohm-Rune	1				100					2	r28	ibk						r27																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ohm-Rune + ID Tome = Vex-Rune	1				100					2	r27	ibk						r26																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Vex-Rune + ID Tome = Gul-Rune	1				100					2	r26	ibk						r25																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Gul-Rune + ID Tome = Ist-Rune	1				100					2	r25	ibk						r24																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ist-Rune + ID Tome = Mal-Rune	1				100					2	r24	ibk						r23																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Mal-Rune + ID Tome = Um-Rune	1				100					2	r23	ibk						r22																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Um-Rune + ID Tome = Pul-Rune	1				100					2	r22	ibk						r21																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Pul-Rune + ID Tome = Lem-Rune	1				100					2	r21	ibk						r20																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Lem-Rune + ID Tome = Fal-Rune	1				100					2	r20	ibk						r19																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Fal-Rune + ID Tome = Ko-Rune	1				100					2	r19	ibk						r18																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ko-Rune + ID Tome = Lum-Rune	1				100					2	r18	ibk						r17																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Lum-Rune + ID Tome = Io-Rune	1				100					2	r17	ibk						r16																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Io-Rune + ID Tome = Hel-Rune	1				100					2	r16	ibk						r15																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Hel-Rune + ID Tome = Dol-Rune	1				100					2	r15	ibk						r14																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Dol-Rune + ID Tome = Shael-Rune	1				100					2	r14	ibk						r13																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Shael-Rune + ID Tome = Sol-Rune	1				100					2	r13	ibk						r12																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Sol-Rune + ID Tome = Amn-Rune	1				100					2	r12	ibk						r11																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Amn-Rune + ID Tome = Thul-Rune	1				100					2	r11	ibk						r10																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Thul-Rune + ID Tome = Ort-Rune	1				100					2	r10	ibk						r09																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ort-Rune + ID Tome = Ral-Rune	1				100					2	r09	ibk						r08																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ral-Rune + ID Tome = Tal-Rune	1				100					2	r08	ibk						r07																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Tal-Rune + ID Tome = Ith-Rune	1				100					2	r07	ibk						r06																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Ith-Rune + ID Tome = Eth-Rune	1				100					2	r06	ibk						r05																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Eth-Rune + ID Tome = Nef-Rune	1				100					2	r05	ibk						r04																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Nef-Rune + ID Tome = Tir-Rune	1				100					2	r04	ibk						r03																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Tir-Rune + ID Tome = Eld-Rune	1				100					2	r03	ibk						r02																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Eld-Rune + ID Tome = El-Rune	1				100					2	r02	ibk						r01																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Zod-Rune (qty=1) + ID Tome = Cham-Rune	1				100	18	70	1		2	s33	ibk						r32																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Cham-Rune (qty=1) + ID Tome = Jah-Rune	1				100	18	70	1		2	s32	ibk						r31																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Jah-Rune (qty=1) + ID Tome = Ber-Rune	1				100	18	70	1		2	s31	ibk						r30																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ber-Rune (qty=1) + ID Tome = Sur-Rune	1				100	18	70	1		2	s30	ibk						r29																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Sur-Rune (qty=1) + ID Tome = Lo-Rune	1				100	18	70	1		2	s29	ibk						r28																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Lo-Rune (qty=1) + ID Tome = Ohm-Rune	1				100	18	70	1		2	s28	ibk						r27																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ohm-Rune (qty=1) + ID Tome = Vex-Rune	1				100	18	70	1		2	s27	ibk						r26																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Vex-Rune (qty=1) + ID Tome = Gul-Rune	1				100	18	70	1		2	s26	ibk						r25																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Gul-Rune (qty=1) + ID Tome = Ist-Rune	1				100	18	70	1		2	s25	ibk						r24																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ist-Rune (qty=1) + ID Tome = Mal-Rune	1				100	18	70	1		2	s24	ibk						r23																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Mal-Rune (qty=1) + ID Tome = Um-Rune	1				100	18	70	1		2	s23	ibk						r22																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked  Um-Rune (qty=1) + ID Tome = Pul-Rune	1				100	18	70	1		2	s22	ibk						r21																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Pul-Rune (qty=1) + ID Tome = Lem-Rune	1				100	18	70	1		2	s21	ibk						r20																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Lem-Rune (qty=1) + ID Tome = Fal-Rune	1				100	18	70	1		2	s20	ibk						r19																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Fal-Rune (qty=1) + ID Tome = Ko-Rune	1				100	18	70	1		2	s19	ibk						r18																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ko-Rune (qty=1) + ID Tome = Lum-Rune	1				100	18	70	1		2	s18	ibk						r17																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked  Lum-Rune (qty=1) + ID Tome = Io-Rune	1				100	18	70	1		2	s17	ibk						r16																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Io-Rune (qty=1) + ID Tome = Hel-Rune	1				100	18	70	1		2	s16	ibk						r15																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Hel-Rune (qty=1) + ID Tome = Dol-Rune	1				100	18	70	1		2	s15	ibk						r14																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Dol-Rune (qty=1) + ID Tome = Shael-Rune	1				100	18	70	1		2	s14	ibk						r13																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Shael-Rune (qty=1) + ID Tome = Sol-Rune	1				100	18	70	1		2	s13	ibk						r12																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Sol-Rune (qty=1) + ID Tome = Amn-Rune	1				100	18	70	1		2	s12	ibk						r11																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Amn-Rune (qty=1) + ID Tome = Thul-Rune	1				100	18	70	1		2	s11	ibk						r10																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Thul-Rune (qty=1) + ID Tome = Ort-Rune	1				100	18	70	1		2	s10	ibk						r09																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ort-Rune (qty=1) + ID Tome = Ral-Rune	1				100	18	70	1		2	s09	ibk						r08																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ral-Rune (qty=1) + ID Tome = Tal-Rune	1				100	18	70	1		2	s08	ibk						r07																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Tal-Rune (qty=1) + ID Tome = Ith-Rune	1				100	18	70	1		2	s07	ibk						r06																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Ith-Rune (qty=1) + ID Tome = Eth-Rune	1				100	18	70	1		2	s06	ibk						r05																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Eth-Rune (qty=1) + ID Tome = Nef-Rune	1				100	18	70	1		2	s05	ibk						r04																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Nef-Rune (qty=1) + ID Tome = Tir-Rune	1				100	18	70	1		2	s04	ibk						r03																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Tir-Rune (qty=1) + ID Tome = Eld-Rune	1				100	18	70	1		2	s03	ibk						r02																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Eld-Rune (qty=1) + ID Tome = El-Rune	1				100	18	70	1		2	s02	ibk						r01																													ibk,qty=100																																																										0
+RUNE DOWNGRADE - Stacked Zod-Rune (qty>1) + ID Tome = Zod-Rune Stack qty-1 + Cham-Rune	1				100	15	70	1		2	s33	ibk						useitem				item-qty	100		-1	-1																					r32																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Cham-Rune (qty>1) + ID Tome = Cham-Rune Stack qty-1 + Jah-Rune	1				100	15	70	1		2	s32	ibk						useitem				item-qty	100		-1	-1																					r31																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Jah-Rune (qty>1) + ID Tome = Jah-Rune Stack qty-1 + Ber-Rune	1				100	15	70	1		2	s31	ibk						useitem				item-qty	100		-1	-1																					r30																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ber-Rune (qty>1) + ID Tome = Ber-Rune Stack qty-1 + Sur-Rune	1				100	15	70	1		2	s30	ibk						useitem				item-qty	100		-1	-1																					r29																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Sur-Rune (qty>1) + ID Tome = Sur-Rune Stack qty-1 + Lo-Rune	1				100	15	70	1		2	s29	ibk						useitem				item-qty	100		-1	-1																					r28																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Lo-Rune (qty>1) + ID Tome = Lo-Rune Stack qty-1 + Ohm-Rune	1				100	15	70	1		2	s28	ibk						useitem				item-qty	100		-1	-1																					r27																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ohm-Rune (qty>1) + ID Tome = Ohm-Rune Stack qty-1 + Vex-Rune	1				100	15	70	1		2	s27	ibk						useitem				item-qty	100		-1	-1																					r26																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Vex-Rune (qty>1) + ID Tome = Vex-Rune Stack qty-1 + Gul-Rune	1				100	15	70	1		2	s26	ibk						useitem				item-qty	100		-1	-1																					r25																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Gul-Rune (qty>1) + ID Tome = Gul-Rune Stack qty-1 + Ist-Rune	1				100	15	70	1		2	s25	ibk						useitem				item-qty	100		-1	-1																					r24																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ist-Rune (qty>1) + ID Tome = Ist-Rune Stack qty-1 + Mal-Rune	1				100	15	70	1		2	s24	ibk						useitem				item-qty	100		-1	-1																					r23																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Mal-Rune (qty>1) + ID Tome = Mal-Rune Stack qty-1 + Um-Rune	1				100	15	70	1		2	s23	ibk						useitem				item-qty	100		-1	-1																					r22																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Um-Rune (qty>1) + ID Tome = Um-Rune Stack qty-1 + Pul-Rune	1				100	15	70	1		2	s22	ibk						useitem				item-qty	100		-1	-1																					r21																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Pul-Rune (qty>1) + ID Tome = Pul-Rune Stack qty-1 + Lem-Rune	1				100	15	70	1		2	s21	ibk						useitem				item-qty	100		-1	-1																					r20																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Lem-Rune (qty>1) + ID Tome = Lem-Rune Stack qty-1 + Fal-Rune	1				100	15	70	1		2	s20	ibk						useitem				item-qty	100		-1	-1																					r19																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Fal-Rune (qty>1) + ID Tome = Fal-Rune Stack qty-1 + Ko-Rune	1				100	15	70	1		2	s19	ibk						useitem				item-qty	100		-1	-1																					r18																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ko-Rune (qty>1) + ID Tome = Ko-Rune Stack qty-1 + Lum-Rune	1				100	15	70	1		2	s18	ibk						useitem				item-qty	100		-1	-1																					r17																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked  Lum-Rune (qty>1) + ID Tome = Lum-Rune Stack qty-1 + Io-Rune	1				100	15	70	1		2	s17	ibk						useitem				item-qty	100		-1	-1																					r16																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Io-Rune (qty>1) + ID Tome = Io-Rune Stack qty-1 + Hel-Rune	1				100	15	70	1		2	s16	ibk						useitem				item-qty	100		-1	-1																					r15																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Hel-Rune (qty>1) + ID Tome = Hel-Rune Stack qty-1 + Dol-Rune	1				100	15	70	1		2	s15	ibk						useitem				item-qty	100		-1	-1																					r14																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Dol-Rune (qty>1) + ID Tome = Dol-Rune Stack qty-1 + Shael-Rune	1				100	15	70	1		2	s14	ibk						useitem				item-qty	100		-1	-1																					r13																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Shael-Rune (qty>1) + ID Tome = Shael-Rune Stack qty-1 + Sol-Rune	1				100	15	70	1		2	s13	ibk						useitem				item-qty	100		-1	-1																					r12																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Sol-Rune (qty>1) + ID Tome = Sol-Rune Stack qty-1 + Amn-Rune	1				100	15	70	1		2	s12	ibk						useitem				item-qty	100		-1	-1																					r11																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Amn-Rune (qty>1) + ID Tome = Amn-Rune Stack qty-1 + Thul-Rune	1				100	15	70	1		2	s11	ibk						useitem				item-qty	100		-1	-1																					r10																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Thul-Rune (qty>1) + ID Tome = Thul-Rune Stack qty-1 + Ort-Rune	1				100	15	70	1		2	s10	ibk						useitem				item-qty	100		-1	-1																					r09																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ort-Rune (qty>1) + ID Tome = Ort-Rune Stack qty-1 + Ral-Rune	1				100	15	70	1		2	s09	ibk						useitem				item-qty	100		-1	-1																					r08																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ral-Rune (qty>1) + ID Tome = Ral-Rune Stack qty-1 + Tal-Rune	1				100	15	70	1		2	s08	ibk						useitem				item-qty	100		-1	-1																					r07																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Tal-Rune (qty>1) + ID Tome = Tal-Rune Stack qty-1 + Ith-Rune	1				100	15	70	1		2	s07	ibk						useitem				item-qty	100		-1	-1																					r06																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Ith-Rune (qty>1) + ID Tome = Ith-Rune Stack qty-1 + Eth-Rune	1				100	15	70	1		2	s06	ibk						useitem				item-qty	100		-1	-1																					r05																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Eth-Rune (qty>1) + ID Tome = Eth-Rune Stack qty-1 + Nef-Rune	1				100	15	70	1		2	s05	ibk						useitem				item-qty	100		-1	-1																					r04																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Nef-Rune (qty>1) + ID Tome = Nef-Rune Stack qty-1 + Tir-Rune	1				100	15	70	1		2	s04	ibk						useitem				item-qty	100		-1	-1																					r03																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Tir-Rune (qty>1) + ID Tome = Tir-Rune Stack qty-1 + Eld-Rune	1				100	15	70	1		2	s03	ibk						useitem				item-qty	100		-1	-1																					r02																													ibk,qty=100																													0
+RUNE DOWNGRADE - Stacked Eld-Rune (qty>1) + ID Tome = Eld-Rune Stack qty-1 + El-Rune	1				100	15	70	1		2	s02	ibk						useitem				item-qty	100		-1	-1																					r01																													ibk,qty=100																													0
 SOCKET ARMOR - Torso Normal & Tal-Rune & Thul-Rune & Perfect-Topaz = Socketed Torso Normal	1				100					4	tors,nor,nos	r07	r10	gpy				useitem				sock			1	6																																																																															0
 SOCKET ITEM - Item Rare & 3 Perfect-Skull & 1 Stone of Jordan = Socketed Item Rare	1				0					5	any,rar,nos	skz,qty=3	The Stone of Jordan					useitem,sock=1																																																																																							0
 SOCKET DESTROY - 1 Hel-Rune & Scroll of Town Portal & 1 Socketed Item = Destroy Socketed Items	1				100					3	any,sock	r15	tsc					useitem,uns																																																																																							0


### PR DESCRIPTION
1) Create Rune Stack: Cube a single rune to convert it to a stack with quantity of 1.

2) Stack Runes: Cube a single rune and a rune stack of the same type to combine them. Rune stack quantity increases by 1.

3) Unstack Runes: Cube a rune stack to create a single, useable rune of the same type. Rune stack quantity decreases by 1.

4) Upgrade Runes: Cube a rune stack (quantity of 2 or more) and a TP Tome to create a single, useable rune from the next tier up. Rune Stack quantity decreases by 2. Can still cube two single runes of the same type to create a rune from the next tier up.

5) Downgrade Runes: Cube a single rune, or a rune stack, with an ID Tome to create a single, useable rune from the previous tier. Rune Stack quantity decreases by 1.