### PR TITLE
Skill Hotkeys

### DIFF
--- a/data/global/ui/layouts/_profilehd.json
+++ b/data/global/ui/layouts/_profilehd.json
@@ -429,24 +429,34 @@
     "SkillHotkeyTextStyle": {
         "fontColor": "$FontColorLightGold",
         "dropShadow": {
-            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 200 },
-            "offset": { "x": 25, "y": 8 }
+            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 255 },
+            "offset": { "x": 4, "y": 4 }
         },
         "pointSize": "$MediumFontSize",
-        "alignment": { "h": "center" },
-        "options": { "hideOverflow": true }
+        "alignment": { "h": "right" }
     },
-    "SkillHotkeyTextRect": { "x": 90, "y": 12, "width": 320 },
+    "SkillHotkeyTextAltStyle": {
+        "fontColor": "$FontColorLightGold",
+        "dropShadow": {
+            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 255 },
+            "offset": { "x": 4, "y": 4 }
+        },
+        "pointSize": "$MediumFontSize",
+        "alignment": { "h": "right" },
+        "options": { "lineWrap": true },
+        "spacing": "$MinimumSpacing"
+    },
     "SkillQuantityTextStyle": {
         "fontColor": "$FontColorBlue",
         "dropShadow": {
-            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 200 },
+            "shadowColor": { "r": 0, "g": 0, "b": 0, "a": 255 },
             "offset": { "x": 4, "y": 4 }
         },
         "pointSize": "$MediumFontSize",
         "alignment": { "h": "left" },
         "options": { "hideOverflow": true }
     },
+    "SkillHotkeyTextRect": { "x": -4, "y": 5, "width": 124, "height": 114 },
     "SkillQuantityTextRect": { "x": 6, "y": 85 },
     "SkillQuantityTextRectController": { "x": 6, "y": 6 },
 


### PR DESCRIPTION
1.21.1 - 2.0 Preview causing blz-log.text error "Cannot find JSON reference ($SkillHotkeyTextAltStyle)" so investigated and the entire reference for the skill row icon bar thing was missing so D2 was tossing default there and it wasn't compatible with the old _profilehd.json which used multiple workaorunds to at least show some kind of key. I got it working at 1080P and doesn't alter controller layout/behavior; Could someone test with a higher resolution monitor for me?

Edit: Screenshots on my most hot keyed character; Have tested on others using spacebar (Space) numpad keys (Show up as Num0-9) and shift and looks fine. Dropshadow changed to no transparency but can dial it back to default 200 of 255 if it is too glaring.

![image](https://github.com/user-attachments/assets/a9bbd294-511e-4853-9cf6-cd59e72f035c)
![image](https://github.com/user-attachments/assets/99ce6d1d-ef07-400b-ba84-f475c48fb988)
