### PR TITLE
Level 100 Cap - Controller Cube Button

### DIFF
--- a/data/global/excel/experience.txt
+++ b/data/global/excel/experience.txt
@@ -1,5 +1,5 @@
 Level	Amazon	Sorceress	Necromancer	Paladin	Barbarian	Druid	Assassin	ExpRatio
-MaxLvl	99	99	99	99	99	99	99	10
+MaxLvl	100	100	100	100	100	100	100	10
 0	0	0	0	0	0	0	0	1024
 1	500	500	500	500	500	500	500	1024
 2	1500	1500	1500	1500	1500	1500	1500	1024

--- a/data/global/ui/layouts/controller/horadriccubelayouthd.json
+++ b/data/global/ui/layouts/controller/horadriccubelayouthd.json
@@ -23,7 +23,7 @@
         {
             "type": "ButtonWidget", "name": "convert",
             "fields": {
-                "rect": { "x": 450, "y": 1510 },
+                "rect": { "x": 1160, "y": 1460 },
                 "filename": "PANEL\\Horadric_Cube\\TransmuteButton",
                 "hoveredFrame": 2,
                 "focusIndicatorFilename": "Controller/HoverImages/Transmute_Hover",


### PR DESCRIPTION
Updates overall level cap to 100 for all classes. (Save Breaking?)

Moves the controller cube transmute button into a more sensible location.
![image](https://github.com/user-attachments/assets/afabb73a-2c80-4184-86cf-c75a80f07902)
