### PR TITLE
Controller UI Stash

### DIFF
--- a/data/global/ui/layouts/controller/bankexpansionlayouthd.json
+++ b/data/global/ui/layouts/controller/bankexpansionlayouthd.json
@@ -37,14 +37,14 @@
         {
             "type": "TextBoxWidget", "name": "gold_amount",
             "fields": {
-                "rect": { "x": 775, "y": 1380 },
+                "rect": { "x": 780, "y": 1408 },
                 "style": "$StyleGoldAmount"
             }
         },
         {
             "type": "ButtonWidget", "name": "gold_withdraw",
             "fields": {
-                "rect": { "x": 715, "y": 1382 },
+                "rect": { "x": 703, "y": 1372 },
                 "filename": "PANEL\\GoldButton",
                 "hoveredFrame": 3,
                 "tooltipString": "@strGoldWithdraw",

--- a/data/global/ui/layouts/controller/bankoriginallayouthd.json
+++ b/data/global/ui/layouts/controller/bankoriginallayouthd.json
@@ -2,8 +2,8 @@
     "type": "BankPanel", "name": "BankOriginalLayout",
     "fields": {
         "priority": 0,
-        "anchor": {"x":0, "y":0},
-        "rect": {"x":0, "y":0},
+        "anchor": "$LeftPanelAnchor",
+        "rect": { "x": -1535, "y": -502, "width": 0, "height": 0 },
     },
     "children": [
         {
@@ -44,7 +44,7 @@
         {
             "type": "ButtonWidget", "name": "gold_withdraw",
             "fields": {
-                "rect": { "x": 717, "y": 1383 },
+                "rect": { "x": 707, "y": 1373 },
                 "filename": "PANEL\\GoldButton",
                 "hoveredFrame": 3,
                 "tooltipString": "@strGoldWithdraw",


### PR DESCRIPTION
Fixed gold withdraw and amounts overlapping and appearing in the wrong locations on both classic and expansion characters.

![image](https://github.com/user-attachments/assets/256e0581-1c48-4137-a721-a193cef62eb6)

Fixed stash appearing half in half out of screen on classic characters.