### PR TITLE
Updates to Weight System

### DIFF
--- a/data/global/excel/itemstatcost.txt
+++ b/data/global/excel/itemstatcost.txt
@@ -384,4 +384,4 @@ item_splashonhit_four	381		1	7	16						1				-400	0		21	0	7	0	16										1	domel
 extra_holybolt	382		1	5										0		0		5	0	5	0																299	19		extraholybolt	extraholybolt										0
 item_splashonhit_five	383		1	7	16						1				-400	0		21	0	7	0	16										1	domeleedamage	20			160	15	0	splash7	splash7										0
 charm_weight	384		1	7																7	6																1	19		mod_weight	mod_weight									1	0
-mana_control	385																			6				11			maxmana										1	19		weightsystem	weightsystem									1	0
+mana_control	385																			6				11			mana										1	19		weightsystem	weightsystem									1	0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1349,7 +1349,7 @@ Remembrance of Glory	1344	100	1			4	1	64	64	cm1	charm	1	5	5000				invscm1				hp	
 Argo's Anchor	1345	100	1			3	1	48	48	cm1	charm	1	5	5000				invscm4				dmg-max		5	5	mag%		7	7	block		5	10	att		50	75	charm-property		1	1																														0
 Ogre King's Bowl	1346	100	1			2	1	60	60	cm1	charm	1	5	5000				invscm2				lifesteal		3	5	manasteal		3	5	regen		3	8	regen-mana		25	50	charm-property		1	1																														0
 Peacemaker	1347	100	1			5	1	15	15	cm2	charm	1	5	5000								hp		20	25	mana		15	20	str		5	5	dex		5	5	charm-property		2	2																														0
-Life & Death	1348	100	1			3	1	55	55	cm2	charm	1	5	5000								allskills		1	1	mag%		15	20	thorns		6	15	charm-property		2	2	charm-property		2	2																														0
+Life & Death	1348	100	1			3	1	55	55	cm2	charm	1	5	5000								allskills		1	1	mag%		15	20	thorns		6	15	charm-property		2	2																																		0
 Throne of Power	1349	100	1			1	1	81	81	cm2	charm	1	5	5000	dred	dred		invlcm1				hp		30	35	mana		25	30	dmg-max		6	8	cheap		3	5	addxp		3	5	charm-property		2	2																										0
 Nightshade	1350	100	1			5	1	6	6	cm3	charm	1	5	5000								hp		15	25	dmg-cold	200	5	8	freeze		1	2	move1		15	15	charm-property		3	3																														0
 Queen's Call	1351	100	1			1	1	71	75	cm3	charm	1	5	5000								allskills		1	1	hp		40	44	res-all		11	15	block1		10	10	move1		10	10	swing1		10	10	charm-property		3	3																						0


### PR DESCRIPTION
Updates Life & Death Large Charm to only have 2 weight instead of 4.

Updates mana_control to point at mana versus maxmana so that items with max mana % modifiers do not break the system.