### PR TITLE
Conversion and Assemblage Drop Fix

### DIFF
--- a/data/global/excel/treasureclassex.txt
+++ b/data/global/excel/treasureclassex.txt
@@ -3,10 +3,10 @@ Gold			1					4	gld,mul=1024	1																									0
 Gold 2x			1					4	gld,mul=2048	1																									0
 Gold 2.5x			1					4	gld,mul=2560	1																									0
 Gold 3x			1					4	gld,mul=3072	1																									0
+Conversion Orbs			1					0	ooc	1	ooa	1																							0
 Jewelry A			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	Conversion Orbs	2													0
 Jewelry B			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	Conversion Orbs	2													0
 Jewelry C			1					0	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	Conversion Orbs	2													0
-Conversion Orbs			1					0	ooc	1	ooa	1																							0
 Chipped Gem			1					0	gcv	3	gcy	3	gcb	3	gcg	3	gcr	3	gcw	3	skc	2													0
 Flawed Gem			1					0	gfv	3	gfy	3	gfb	3	gfg	3	gfr	3	gfw	3	skf	2													0
 Normal Gem			1					0	gsv	3	gsy	3	gsb	3	gsg	3	gsr	3	gsw	3	sku	2													0


### PR DESCRIPTION
The class "Conversion Orbs" needs to be above the classes that are trying to nest from it, relocated above Jewelry so these orbs will properly drop.