### PR TITLE
Weight Refix after Gem Merge

### DIFF
--- a/data/global/excel/itemstatcost.txt
+++ b/data/global/excel/itemstatcost.txt
@@ -384,5 +384,5 @@ item_splashonhit_four	381		1	7	16						1				-400	0		21	0	7	0	16										1	domel
 extra_holybolt	382		1	5										0		0		5	0	5	0																298	19		extraholybolt	extraholybolt										0
 item_splashonhit_five	383		1	7	16						1				-400	0		21	0	7	0	16										1	domeleedamage	20			160	15	0	splash7	splash7										0
 charm_weight	384		1	7																7	6																1	19		mod_weight	mod_weight									1	0
-mana_control	385																			6				11			maxmana										1	19		weightsystem	weightsystem									1	0
+mana_control	385																			6				11			mana										1	19		weightsystem	weightsystem									1	0
 stacked_gem	386		0	16								1	0	0	1	0		16	0	16	0																56	19	0	StackedGem	StackedGem										0


### PR DESCRIPTION
Fixes weight system, not save breaking. Should be merged and the preview 3 .7z updated, maybe after drop rate changes are also fixed.