### PR TITLE
WeaponDependentSkills

### DIFF
--- a/data/global/excel/magicprefix.txt
+++ b/data/global/excel/magicprefix.txt
@@ -874,8 +874,8 @@ Charged1	100	1	1	6	24	6		nec	6	1	44	charged	71	25	1										ring	circ	head	weap
 Charged1	100	1	1	18		20		nec	6	1	44	charged	71	25	12										ring	circ	head	weap									0	0
 Charged1	100	1	1	6	24	6		nec	6	1	44	charged	72	25	1										weap	glov	head										0	0
 Charged1	100	1	1	24		24		nec	6	1	44	charged	72	25	18										glov	weap	head										0	0
-Charged1	100	1	1	6	24	6		nec	6	1	44	charged	73	20	1										weap	head	glov	ring	circ								0	0
-Charged1	100	1	1	21		24		nec	6	1	44	charged	73	20	18										glov	ring	circ	weap	head								0	0
+Charged1	100	1	1	6	24	6		nec	6	1	44	charged	73	20	1										knif	head	glov	ring	circ								0	0
+Charged1	100	1	1	21		24		nec	6	1	44	charged	73	20	18										glov	ring	circ	knif	head								0	0
 Charged1	100	1	1	6	24	6		nec	6	1	44	charged	74	150	1										weap	head											0	0
 Charged1	100	1	1	40		45		nec	6	1	44	charged	74	150	15										weap	head											0	0
 Charged1	100	1	1	6	24	6		nec	6	1	44	charged	75	20	1										amul	circ	head	weap									0	0
@@ -940,8 +940,8 @@ Charged1	100	1	1	6	24	6		bar	6	1	44	charged	137	65	1										phlm	mele									
 Charged1	100	1	1	18	51	18		bar	6	1	44	charged	137	65	12										phlm	mele											0	0
 Charged1	100	1	1	6	24	6		bar	6	1	44	charged	138	25	3										phlm	mele											0	0
 Charged1	100	1	1	40		45		bar	6	1	44	charged	138	25	20										phlm	mele											0	0
-Charged1	100	1	1	12	30	12		bar	12	1	44	charged	139	55	1										phlm	mele						staf	wand	orb			0	0
-Charged1	100	1	1	24	50	24		bar	12	1	44	charged	139	55	12										mele	phlm											0	0
+Charged1	100	1	1	12	30	12		bar	12	1	44	charged	139	55	1										phlm	slam						staf	wand	orb			0	0
+Charged1	100	1	1	24	50	24		bar	12	1	44	charged	139	55	12										slam	phlm											0	0
 Charged1	100	1	1	12	30	12		bar	12	1	44	charged	142	300	1										phlm	mele											0	0
 Charged1	100	1	1	50		55		bar	12	1	44	charged	142	300	21										phlm	mele											0	0
 Charged1	100	1	1	18	36	18		bar	18	1	44	charged	144	300	1										phlm	mele											0	0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -454,7 +454,7 @@ Shapeshifter	449	100	1			1	1	68	69	7ba	silver-edged axe		5	5000				invaxe21				d
 Dyer's Eve	450	100	1			1	1	71	73	7bt	decapitator		5	5000				invaxe20				dmg%		200	250	dmg-max		50	100	rip		1	1	lifesteal		12	12	bar		2	2	mag%		40	60	regen		12	15	sock		1	1	oskill	393	1	1														0
 Hero's Welcome	451	100	1			1	1	75	79	7ga	champion axe		5	5000				invaxe14				dmg%		225	270	addxp		3	5	cheap		10	15	swing2		20	20	vit/lvl	5			red-dmg%		10	10	res-all		25	25	nofreeze		1	1	oskill	393	1	1														0
 Nameless Horror	452	100	1			1	1	80	84	7gi	glorious axe		5	5000								dmg%		275	325	howl		129	129	gethit-skill	Howl	10	20	charged	Bone Prison	77	15	res-pois		88	88	res-pois-len		50	75	res-pois-max		5	5	dmg-pois	300	1024	1024	allskills		2	2	oskill	393	1	1										0
-Epee of Speed	453	100	1			1	1	23	24	ssd	short sword		5	5000				invswrd15				dmg-norm		25	50	swing2		30	30	balance2		30	30	move2		20	20	charged	Stun	100	8	block		20	25	oskill	393	1	1																						0
+Epee of Speed	453	100	1			1	1	23	24	ssd	short sword		5	5000				invswrd15				dmg-norm		25	50	swing2		30	30	balance2		30	30	move2		20	20	charged	Concentrate	100	8	block		20	25	oskill	393	1	1																						0
 Deviljack	454	100	1			3	1	1	5	ssd	short sword		5	5000	lgry	lgry						dmg%		100	150	dmg-demon		100	100	addxp		3	5	cheap		10	10	oskill	393	1	1																														0
 Anadek's Sword	455	100	1			1	1	24	26	scm	scimitar		5	5000								dmg-norm		25	50	swing1		15	15	dmg%		50	60	dmg-fire		25	40	res-cold		20	30	rep-dur	25			oskill	393	1	1																						0
 Briarblade	456	100	1			3	1	1	8	scm	scimitar		5	5000	dgrn	dgrn						dmg%		100	150	dmg-pois	250	100	100	openwounds		50	50	heal-kill		3	5	deadly		15	15	oskill	393	1	1																										0


### PR DESCRIPTION
- Tectonic Slam charges will no longer spawn on non-Slam weapons
- Poison Dagger charges will no longer spawn on non-Knife weapons
- "Epee of Speed" unique now has charges of Concentrate instead of Stun/Tectonic Slam as it is not a slam weapon

Note: Double check recent keychain/gembag change was not blown out