### PR TITLE
Missing String

### DIFF
--- a/data/global/excel/magicsuffix.txt
+++ b/data/global/excel/magicsuffix.txt
@@ -176,9 +176,9 @@ of the Bat	100	1	1	35		27				48	28	manasteal		3	3									cred	glov												0
 of the Bat	100	1	1	25		21				24	28	manasteal		2	3										ring												0	0
 of the Wraith	100	1	1	58		46				24	28	manasteal		4	5										ring												0	0
 of the Vampire	100	1	1	86		74				24	28	manasteal		6	8									cred	ring												0	0
-of the Lich1	100	1	1	44		38				12	60	manasteal		3	5	lifesteal		5	7						ring	amul											0	0
-of the Lich1	100	1	1	66		60				12	60	manasteal		6	7	lifesteal		8	9						ring	amul											0	0
-of the Lich1	100	1	1	87		84				12	60	manasteal		8	9	lifesteal		10	12						ring	amul											0	0
+of the Lich	100	1	1	44		38				12	60	manasteal		3	5	lifesteal		5	7						ring	amul											0	0
+of the Lich	100	1	1	66		60				12	60	manasteal		6	7	lifesteal		8	9						ring	amul											0	0
+of the Lich	100	1	1	87		84				12	60	manasteal		8	9	lifesteal		10	12						ring	amul											0	0
 of Health	100	1	1	7	20	5				48	1	red-dmg		1	1										tors	shld	ring	amul	circ								0	0
 of Protection	100	1	1	18	40	13				48	1	red-dmg		2	2										ring	amul	circ										0	0
 of Absorption	100	1	1	26	50	19				48	1	red-dmg		3	5										amul	circ	ring										0	0
@@ -723,5 +723,5 @@ of Draining	100	1	1	20		20				8	80	healperhit		1	3									dred	mele	amaz							
 of Funneling	100	1	1	20		20				6	80	healperhit		4	6									dred	mele	amaz											0	0
 of Pumping	100	1	1	20		20				4	80	healperhit		7	9									dred	mele	amaz											0	0
 of Siphoning	100	1	1	20		20				2	80	healperhit		10	12									dred	mele	amaz											0	0
-of Splitting	100	1	1	30		30		nec	30	32	81	extra_bonespears		1	1										head	wand											0	0
-of Splitting	100	1	1	30		30		pal	30	32	81	extra_holybolt		1	1										scep	ashd											0	0
+of Splitting	100	1	1	30		30		nec	30	64	81	extra_bonespears		1	1										head	wand											0	0
+of Splitting	100	1	1	30		30		pal	30	64	81	extra_holybolt		1	1										scep	ashd											0	0

--- a/data/local/lng/strings/item-nameaffixes.json
+++ b/data/local/lng/strings/item-nameaffixes.json
@@ -18358,5 +18358,22 @@
         "ptBR": "of Splitting",
         "ruRU": "of Splitting",
         "zhCN": "of Splitting"
+    },
+    {
+        "id": 29075,
+        "Key": "of the Lich",
+        "enUS": "of the Lich",
+        "zhTW": "of the Lich",
+        "deDE": "of the Lich",
+        "esES": "of the Lich",
+        "frFR": "of the Lich",
+        "itIT": "of the Lich",
+        "koKR": "of the Lich",
+        "plPL": "of the Lich",
+        "esMX": "of the Lich",
+        "jaJP": "of the Lich",
+        "ptBR": "of the Lich",
+        "ruRU": "of the Lich",
+        "zhCN": "of the Lich"
     }
 ]


### PR DESCRIPTION
- Added missing string "of the Lich"
- Boosted chance to roll +Bone Spear and +Holy Bolt affixes.