### PR TITLE
Expanding terror zones in Acts1/2/3/5

### DIFF
--- a/data/hd/global/excel/desecratedzones.json
+++ b/data/hd/global/excel/desecratedzones.json
@@ -56,54 +56,6 @@
                     "id": 1,
                     "levels": [
                         {
-                            /* Cathedral */
-                            "level_id": 33,
-                            /* Inner Cloister */
-                            "waypoint_level_id": 32
-                        },
-                        {
-                            /* Catacombs Level 1 */
-                            "level_id": 34
-                        },
-                        {
-                            /* Catacombs Level 2 */
-                            "level_id": 35
-                        },
-                        {
-                            /* Catacombs Level 3 */
-                            "level_id": 36
-                        },
-                        {
-                            /* Catacombs Level 4 */
-                            "level_id": 37
-                        },                       
-                        {
-                            /* Underground Passage Level 1 */
-                            "level_id": 10
-                        },
-                        {
-                            /* Den of Evil */
-                            "level_id": 8
-                        },
-                        {
-                            /* Barracks */
-                            "level_id": 28,
-                            /* Outer Cloister */
-                            "waypoint_level_id": 27
-                        },
-                        {
-                            /* Jail Level 1 */
-                            "level_id": 29
-                        },
-                        {
-                            /* Jail Level 2 */
-                            "level_id": 30
-                        },
-                        {
-                            /* Jail Level 3 */
-                            "level_id": 31
-                        },
-                        {
                             /* Stony Field */
                             "level_id": 4,
                             /* Stony Field */
@@ -112,6 +64,34 @@
                         {
                             /* Black Marsh */
                             "waypoint_level_id": 6
+                        },
+                        {
+                            /* Den of Evil */
+                            "level_id": 8
+                        },
+                        {
+                            /* Underground Passage Level 1 */
+                            "level_id": 10
+                        },
+                        {
+                            /*  Pit Level 1 */
+                            "level_id": 12
+                        },
+                        {
+                            /* Pit Level 2 */
+                            "level_id": 16
+                        },
+                        {
+                            /* Burial Grounds */
+                            "level_id": 17
+                        },
+                        {
+                            /* The Crypt */
+                            "level_id": 18
+                        },
+                        {
+                            /* The Mausoleum */
+                            "level_id": 19
                         },
                         {
                             /* Tower Cellar Level 1 */
@@ -134,16 +114,48 @@
                             "level_id": 25
                         },
                         {
+                            /* Barracks */
+                            "level_id": 28,
+                            /* Outer Cloister */
+                            "waypoint_level_id": 27
+                        },
+                        {
+                            /* Jail Level 1 */
+                            "level_id": 29
+                        },
+                        {
+                            /* Jail Level 2 */
+                            "level_id": 30
+                        },
+                        {
+                            /* Jail Level 3 */
+                            "level_id": 31
+                        },
+                        {
+                            /* Cathedral */
+                            "level_id": 33,
+                            /* Inner Cloister */
+                            "waypoint_level_id": 32
+                        },
+                        {
+                            /* Catacombs Level 1 */
+                            "level_id": 34
+                        },
+                        {
+                            /* Catacombs Level 2 */
+                            "level_id": 35
+                        },
+                        {
+                            /* Catacombs Level 3 */
+                            "level_id": 36
+                        },
+                        {
+                            /* Catacombs Level 4 */
+                            "level_id": 37
+                        },                       
+                        {
                             /* Tristram */
                             "level_id": 38
-                        },
-                        {
-                            /*  Pit Level 1 */
-                            "level_id": 12
-                        },
-                        {
-                            /* Pit Level 2 */
-                            "level_id": 16
                         }
                     ]
                 },
@@ -151,6 +163,18 @@
                     /* Act 2 */
                     "id": 2,
                     "levels": [
+                        {
+                            /* Dry Hills */
+                            "level_id": 42,
+                            /* Dry Hills */
+                            "waypoint_level_id": 42
+                        },
+                        {
+                            /* Lost City */
+                            "level_id": 44,
+                            /* Lost City */
+                            "waypoint_level_id": 44
+                        },
                         {
                             /* Sewers Level 1 */
                             "level_id": 47,
@@ -166,10 +190,8 @@
                             "level_id": 49
                         },
                         {
-                            /* Dry Hills */
-                            "level_id": 42,
-                            /* Dry Hills */
-                            "waypoint_level_id": 42
+                            /* Stony Tomb Level 1 */
+                            "level_id": 55
                         },
                         {
                             /* Halls of the Dead Level 1 */
@@ -180,22 +202,26 @@
                             "level_id": 57
                         },
                         {
-                            /* Halls of the Dead Level 3 */
-                            "level_id": 60
-                        },
-                        {
-                            /* Lost City */
-                            "level_id": 44,
-                            /* Lost City */
-                            "waypoint_level_id": 44
-                        },
-                        {
                             /* Claw Viper Temple Level 1 */
                             "level_id": 58
                         },
                         {
+                            /* Stony Tomb Level 2 */
+                            "level_id": 59
+                        },
+                        {
+                            /* Halls of the Dead Level 3 */
+                            "level_id": 60
+                        },
+                        {
                             /* Claw Viper Temple Level 2 */
                             "level_id": 61
+                        },
+                        {
+                            /* Ancient Tunnels */
+                            "level_id": 65,
+                            /* Lost City */
+                            "waypoint_level_id": 44
                         },
                         {
                             /* Tal Rasha's Tomb */
@@ -244,10 +270,46 @@
                     "id": 3,
                     "levels": [
                         {
+                            /* Spider Forest */
+                            "level_id": 76
+                        },
+                        {
+                            /* Great Marsh */
+                            "level_id": 77
+                        },
+                        {
                             /* Flayer Jungle */
                             "level_id": 78,
                             /* Flayer Jungle */
                             "waypoint_level_id": 78
+                        },
+                        {
+                            /* Lower Kurast */
+                            "level_id": 79
+                        },
+                        {
+                            /* Kurast Bazaar */
+                            "level_id": 80,
+                            /* Kurast Bazaar */
+                            "waypoint_level_id": 80
+                        },
+                        {
+                            /* Upper Kurast */
+                            "level_id": 81
+                        },
+                        {
+                            /* Travincal */
+                            "level_id": 83,
+                            /* Travincal */
+                            "waypoint_level_id": 83
+                        },
+                        {
+                            /* Arachnid Lair */
+                            "level_id": 84
+                        },
+                        {
+                            /* Spider Cavern */
+                            "level_id": 85
                         },
                         {
                             /* Flayer Dungeon Level 1 */
@@ -258,10 +320,12 @@
                             "level_id": 89
                         },
                         {
-                            /* Kurast Bazaar */
-                            "level_id": 80,
-                            /* Kurast Bazaar */
-                            "waypoint_level_id": 80
+                            /* Flayer Dungeon Level 3 */
+                            "level_id": 91
+                        },
+                        {
+                            /* Sewers Level 1 */
+                            "level_id": 92
                         },
                         {
                             /* Ruined Temple */
@@ -270,18 +334,6 @@
                         {
                             /* Disused Fane */
                             "level_id": 95
-                        },
-                        {
-                            /* Lower Kurast */
-                            "level_id": 79
-                        },
-                        {
-                            /* Upper Kurast */
-                            "level_id": 81
-                        },
-                        {
-                            /* Sewers Level 1 */
-                            "level_id": 92
                         },
                         {
                             /* Forgotten Reliquary */
@@ -298,12 +350,6 @@
                         {
                             /* Disused Reliquary */
                             "level_id": 99
-                        },
-                        {
-                            /* Travincal */
-                            "level_id": 83,
-                            /* Travincal */
-                            "waypoint_level_id": 83
                         },
                         {
                             /* Durance of Hate Level 1 */
@@ -374,18 +420,10 @@
                             "waypoint_level_id": 111
                         },
                         {
-                            /* Abbadon */
-                            "level_id": 125
-                        },
-                        {
                             /* Arreat Plateau */
                             "level_id": 112,
                             /* Arreat Plateau */
                             "waypoint_level_id": 112
-                        },
-                        {
-                            /* Pit of Acheron */
-                            "level_id": 126
                         },
                         {
                             /* Crystalline Passage */
@@ -396,6 +434,30 @@
                         {
                             /* Frozen River */
                             "level_id": 114
+                        },
+                        {
+                            /* Glacial Trail */
+                            "level_id": 115,
+                            /* Glacial Trail */
+                            "waypoint_level_id": 115
+                        },
+                        {
+                            /* Drifter Cavern */
+                            "level_id": 116
+                        },
+                        {
+                            /* Frozen Tundra */
+                            "level_id": 117
+                        },
+                        {
+                            /* Ancient's Way */
+                            "level_id": 118,
+                            /* Ancient's Way */
+                            "waypoint_level_id": 118
+                        },
+                        {
+                            /* Icy Cellar */
+                            "level_id": 119
                         },
                         {
                             /* Nihlathak's Temple */
@@ -416,20 +478,16 @@
                             "level_id": 124
                         },
                         {
-                            /* Glacial Trail */
-                            "level_id": 115,
-                            /* Glacial Trail */
-                            "waypoint_level_id": 115
+                            /* Abbadon */
+                            "level_id": 125
                         },
                         {
-                            /* Ancient's Way */
-                            "level_id": 118,
-                            /* Ancient's Way */
-                            "waypoint_level_id": 118
+                            /* Pit of Acheron */
+                            "level_id": 126
                         },
                         {
-                            /* Icy Cellar */
-                            "level_id": 119
+                            /* Infernal Pit */
+                            "level_id": 127
                         },
                         {
                             /* Worldstone Keep Level 1 */


### PR DESCRIPTION
Fixes #523 

Terror Zone entries are now in order.

Added new Terror Zones now that level cap is 25 (up from 20).

Act1 - Burial Grounds, Crypt, Mausoleum (24 zones total)

Act2 - Stony Tomb (all levels), Ancient Tunnels (22 zones total)

Act 3 - Spider Forest, Great Marsh, Arachnid Lair, Spider Cavern, Flayer Dungeon Level 3, Ruined Temple, Disused Fane (22 zones total)

Act 5 - Drifter Cavern, Frozen Tundra, Infernal Pit (22 zones total)