### PR TITLE
Tectonic Slam Icon

### DIFF
--- a/data/hd/global/ui/spells/barbarian/baskillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/barbarian/baskillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bbdd214602f01740d4d5ea8f461b0fe11cb41c375529a7d6b81a7109f55fb363
+oid sha256:224c2cce32ac3d52aa5a24397b95240298ff3920b24eba7ce2e9ca4df35a28c8
 size 1029640

--- a/data/hd/global/ui/spells/barbarian/baskillicon.sprite
+++ b/data/hd/global/ui/spells/barbarian/baskillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c2a198e70e2c2af5dbc9ead174bc23cbaaccd3f56af61c96a94f33788c343a9
+oid sha256:5a777bea1fb82d4b7d4b99ecbbd2a6077343b0951fb5557cc1368958a25419e6
 size 4118440


### PR DESCRIPTION
Updates new Barbarian skill Tectonic Slam with a sprite made for it.
![image](https://github.com/user-attachments/assets/2b2edcd1-f6a3-4ab1-ac1f-f3e577bb0c9b)
![image](https://github.com/user-attachments/assets/64529ac0-304c-496c-aa0b-57e8ec8f668f)
![image](https://github.com/user-attachments/assets/9c0e067f-9a61-4759-b528-9fdc4d9e51d1)
