### PR TITLE
WP UI Animated And More TZ Updates

### DIFF
--- a/data/global/ui/layouts/controller/waypointspanelexpansionhd.json
+++ b/data/global/ui/layouts/controller/waypointspanelexpansionhd.json
@@ -3,16 +3,16 @@
     "type": "WaypointsPanel", "name": "WaypointsPanelExpansion",
     "children": [
         {
-            "type": "ClickCatcherWidget", "name": "ClickCatcher",
+            "type": "ClickCatcherWidget", "name": "ClickCatcher"
         },
         {
-            "type": "ImageWidget", "name": "Background",
+            "type": "ImageWidget", "name": "Background"
         },
         {
-            "type": "ImageWidget", "name": "LeftHinge",
+            "type": "ImageWidget", "name": "LeftHinge"
         },
         {
-            "type": "TextBoxWidget", "name": "WaypointsTitle",
+            "type": "TextBoxWidget", "name": "WaypointsTitle"
         },
         {
             "type": "TabBarWidget", "name": "Tabs",
@@ -24,7 +24,7 @@
                 "tabSize": { "x": 174, "y": 70 },
                 "tabPadding": { "x": -1, "y": 0 },
                 "tabLeftIndicatorPosition": { "x": -46, "y": -1 },
-                "tabRightIndicatorPosition": { "x": 870, "y": -1 },
+                "tabRightIndicatorPosition": { "x": 870, "y": -1 }
             }
         },
         // waypoint button templates
@@ -35,20 +35,20 @@
                     "type": "ButtonWidget", "name": "UnselectableButtonTemplate",
                     "children": [
                         {
-                            "type": "ImageWidget", "name": "TerrorZone",
-                        },
+                            "type": "ImageWidget", "name": "TerrorZone"
+                        }
                     ]
                 },
                 {
-                    "type": "ImageWidget", "name": "SelectableButton",
+                    "type": "ImageWidget", "name": "SelectableButton"
                 },
                 {
-                    "type": "ImageWidget", "name": "CurrentButton",
+                    "type": "ImageWidget", "name": "CurrentButton"
                 }
             ]
         },
         {
-            "type": "ButtonWidget", "name": "CloseButton",
-        },
+            "type": "ButtonWidget", "name": "CloseButton"
+        }
     ]
 }

--- a/data/global/ui/layouts/controller/waypointspaneloriginalhd.json
+++ b/data/global/ui/layouts/controller/waypointspaneloriginalhd.json
@@ -4,8 +4,8 @@
         "buttonOffset": 140,
         "rect": "$ConsoleCenterPanelRect",
         "selectableFontColor": "$FontColorGoldYellow",
-        "defaultFontColor": { "r": 105, "g": 105, "b": 105, "a": 255 },
-        "terrorZoneFontColor": { "r": 135, "g": 82, "b": 161, "a": 255 }
+        "currentFontColor": "$FontColorBlue",
+        "terrorZoneFontColor": { "r": 200, "g": 175, "b": 250, "a": 255 }
     },
     "children": [
         {
@@ -27,14 +27,14 @@
             "fields": {
                 "rect": "$LeftHingeRect",
                 "filename": "$LeftHingeSprite"
-            },
+            }
         },
         {
             "type": "TextBoxWidget", "name": "WaypointsTitle",
             "fields": {
                 "rect": "$InGamePanelTitleRect",
                 "text": "@Waypoint",
-                "style": "$StyleTitleBlock",
+                "style": "$StyleTitleBlock"
             }
         },
         {
@@ -54,7 +54,7 @@
                 "onSwitchTabMessage": "Waypoints:SelectTab",
                 "focusOnMouseOver": true,
                 "tabLeftIndicatorPosition": { "x": -46, "y": -1 },
-                "tabRightIndicatorPosition": { "x": 870, "y": -1 },
+                "tabRightIndicatorPosition": { "x": 870, "y": -1 }
             }
         },
         // waypoint button templates
@@ -75,11 +75,11 @@
                         {
                             "type": "ImageWidget", "name": "TerrorZone",
                             "fields": {
-                        				"rect": { "x": 47, "y": 28 },
+                        				"rect": { "x": 31, "y": 31 },
                         				"filename": "PANEL\\Waypoints\\terror_zone_icon",
                         				"visible": false
                         		}
-                        },
+                        }
                     ]
                 },
                 {
@@ -106,8 +106,8 @@
                 "hoveredFrame": 3,
                 "tooltipString": "@strClose",
                 "sound": "cursor_close_window_hd",
-                "onClickMessage": "Waypoints:CloseWaypointPanel",
-            },
-        },
+                "onClickMessage": "Waypoints:CloseWaypointPanel"
+            }
+        }
     ]
 }

--- a/data/global/ui/layouts/waypointspanelexpansionhd.json
+++ b/data/global/ui/layouts/waypointspanelexpansionhd.json
@@ -30,7 +30,12 @@
             "type": "Widget", "name": "Templates",
             "children": [
                 {
-                    "type": "ButtonWidget", "name": "UnselectableButtonTemplate"
+                    "type": "ButtonWidget", "name": "UnselectableButtonTemplate",
+                    "children": [
+                        {
+                            "type": "ImageWidget", "name": "TerrorZone"
+                        }
+                    ]
                 },
                 {
                     "type": "ImageWidget", "name": "SelectableButton"

--- a/data/global/ui/layouts/waypointspaneloriginalhd.json
+++ b/data/global/ui/layouts/waypointspaneloriginalhd.json
@@ -6,7 +6,8 @@
         "buttonOffset": 123,
         "selectableFontColor": "$FontColorGoldYellow",
         "selectableFrames": [ 0, 1 ],
-        "currentFontColor": "$FontColorBlue"
+        "currentFontColor": "$FontColorBlue",
+        "terrorZoneFontColor": { "r": 200, "g": 175, "b": 250, "a": 255 }
     },
     "children": [
         {
@@ -67,7 +68,17 @@
                         "pointSize": "$MediumPanelFontSize",
                         "textColor": "$FontColorLightGray",
                         "text/rect": { "x": 210 }
-                    }
+                    },
+                    "children": [
+                        {
+                            "type": "ImageWidget", "name": "TerrorZone",
+                            "fields": {
+                        				"rect": { "x": 31, "y": 31 },
+                        				"filename": "PANEL\\Waypoints\\terror_zone_icon",
+                        				"visible": false
+                        		}
+                        }
+                    ]
                 },
                 {
                     "type": "ImageWidget", "name": "SelectableButton",

--- a/data/hd/global/excel/desecratedzones.json
+++ b/data/hd/global/excel/desecratedzones.json
@@ -62,26 +62,6 @@
                             "waypoint_level_id": 4
                         },
                         {
-                            /* Black Marsh */
-                            "waypoint_level_id": 6
-                        },
-                        {
-                            /* Den of Evil */
-                            "level_id": 8
-                        },
-                        {
-                            /* Underground Passage Level 1 */
-                            "level_id": 10
-                        },
-                        {
-                            /*  Pit Level 1 */
-                            "level_id": 12
-                        },
-                        {
-                            /* Pit Level 2 */
-                            "level_id": 16
-                        },
-                        {
                             /* Burial Grounds */
                             "level_id": 17
                         },
@@ -92,6 +72,22 @@
                         {
                             /* The Mausoleum */
                             "level_id": 19
+                        },
+                        {
+                            /* Underground Passage Level 1 */
+                            "level_id": 10
+                        },
+                        {
+                            /* Dark Wood */
+                            "level_id": 5,
+                            /* Dark Wood */
+                            "waypoint_level_id": 5
+                        },
+                        {
+                            /* Black Marsh */
+                            "level_id": 6,
+                            /* Black Marsh */
+                            "waypoint_level_id": 6
                         },
                         {
                             /* Tower Cellar Level 1 */
@@ -114,6 +110,14 @@
                             "level_id": 25
                         },
                         {
+                            /*  Pit Level 1 */
+                            "level_id": 12
+                        },
+                        {
+                            /* Pit Level 2 */
+                            "level_id": 16
+                        },
+                        {
                             /* Barracks */
                             "level_id": 28,
                             /* Outer Cloister */
@@ -121,7 +125,9 @@
                         },
                         {
                             /* Jail Level 1 */
-                            "level_id": 29
+                            "level_id": 29,
+                            /* Jail Level 1 */
+                            "waypoint_level_id": 29
                         },
                         {
                             /* Jail Level 2 */
@@ -143,7 +149,9 @@
                         },
                         {
                             /* Catacombs Level 2 */
-                            "level_id": 35
+                            "level_id": 35,
+                            /* Catacombs Level 2 */
+                            "waypoint_level_id": 35
                         },
                         {
                             /* Catacombs Level 3 */
@@ -152,7 +160,7 @@
                         {
                             /* Catacombs Level 4 */
                             "level_id": 37
-                        },                       
+                        },
                         {
                             /* Tristram */
                             "level_id": 38
@@ -164,26 +172,14 @@
                     "id": 2,
                     "levels": [
                         {
-                            /* Dry Hills */
-                            "level_id": 42,
-                            /* Dry Hills */
-                            "waypoint_level_id": 42
-                        },
-                        {
-                            /* Lost City */
-                            "level_id": 44,
-                            /* Lost City */
-                            "waypoint_level_id": 44
-                        },
-                        {
                             /* Sewers Level 1 */
-                            "level_id": 47,
-                            /* Lut Gholein */
-                            "waypoint_level_id": 40
+                            "level_id": 47
                         },
                         {
                             /* Sewers Level 2 */
-                            "level_id": 48
+                            "level_id": 48,
+                            /* Lut Gholein */
+                            "waypoint_level_id": 48
                         },
                         {
                             /* Sewers Level 3 */
@@ -194,28 +190,34 @@
                             "level_id": 55
                         },
                         {
+                            /* Stony Tomb Level 2 */
+                            "level_id": 59
+                        },
+                        {
+                            /* Dry Hills */
+                            "level_id": 42,
+                            /* Dry Hills */
+                            "waypoint_level_id": 42
+                        },
+                        {
                             /* Halls of the Dead Level 1 */
                             "level_id": 56
                         },
                         {
                             /* Halls of the Dead Level 2 */
-                            "level_id": 57
-                        },
-                        {
-                            /* Claw Viper Temple Level 1 */
-                            "level_id": 58
-                        },
-                        {
-                            /* Stony Tomb Level 2 */
-                            "level_id": 59
+                            "level_id": 57,
+                            /* Halls of the Dead Level 2 */
+                            "waypoint_level_id": 57
                         },
                         {
                             /* Halls of the Dead Level 3 */
                             "level_id": 60
                         },
                         {
-                            /* Claw Viper Temple Level 2 */
-                            "level_id": 61
+                            /* Lost City */
+                            "level_id": 44,
+                            /* Lost City */
+                            "waypoint_level_id": 44
                         },
                         {
                             /* Ancient Tunnels */
@@ -224,10 +226,28 @@
                             "waypoint_level_id": 44
                         },
                         {
-                            /* Tal Rasha's Tomb */
-                            "level_id": 66,
+                            /* Claw Viper Temple Level 1 */
+                            "level_id": 58
+                        },
+                        {
+                            /* Claw Viper Temple Level 2 */
+                            "level_id": 61
+                        },
+                        {
+                            /* Arcane Sanctuary */
+                            "level_id": 74,
+                            /* Arcane Sanctuary */
+                            "waypoint_level_id": 74
+                        },
+                        {
+                            /* Canyon of the Magi */
+                            "level_id": 46,
                             /* Canyon of the Magi */
                             "waypoint_level_id": 46
+                        },
+                        {
+                            /* Tal Rasha's Tomb */
+                            "level_id": 66
                         },
                         {
                             /* Tal Rasha's Tomb */
@@ -256,12 +276,6 @@
                         {
                             /* Tal Rasha's Chamber */
                             "level_id": 73
-                        },
-                        {
-                            /* Arcane Sanctuary */
-                            "level_id": 74,
-                            /* Arcane Sanctuary */
-                            "waypoint_level_id": 74
                         }
                     ]
                 },
@@ -271,37 +285,9 @@
                     "levels": [
                         {
                             /* Spider Forest */
-                            "level_id": 76
-                        },
-                        {
-                            /* Great Marsh */
-                            "level_id": 77
-                        },
-                        {
-                            /* Flayer Jungle */
-                            "level_id": 78,
-                            /* Flayer Jungle */
-                            "waypoint_level_id": 78
-                        },
-                        {
-                            /* Lower Kurast */
-                            "level_id": 79
-                        },
-                        {
-                            /* Kurast Bazaar */
-                            "level_id": 80,
-                            /* Kurast Bazaar */
-                            "waypoint_level_id": 80
-                        },
-                        {
-                            /* Upper Kurast */
-                            "level_id": 81
-                        },
-                        {
-                            /* Travincal */
-                            "level_id": 83,
-                            /* Travincal */
-                            "waypoint_level_id": 83
+                            "level_id": 76,
+                            /* Spider Forest */
+                            "waypoint_level_id": 76
                         },
                         {
                             /* Arachnid Lair */
@@ -310,6 +296,18 @@
                         {
                             /* Spider Cavern */
                             "level_id": 85
+                        },
+                        {
+                            /* Great Marsh */
+                            "level_id": 77,
+                            /* Great Marsh */
+                            "waypoint_level_id": 77
+                        },
+                        {
+                            /* Flayer Jungle */
+                            "level_id": 78,
+                            /* Flayer Jungle */
+                            "waypoint_level_id": 78
                         },
                         {
                             /* Flayer Dungeon Level 1 */
@@ -324,8 +322,16 @@
                             "level_id": 91
                         },
                         {
-                            /* Sewers Level 1 */
-                            "level_id": 92
+                            /* Lower Kurast */
+                            "level_id": 79,
+                            /* Lower Kurast */
+                            "waypoint_level_id": 79
+                        },
+                        {
+                            /* Kurast Bazaar */
+                            "level_id": 80,
+                            /* Kurast Bazaar */
+                            "waypoint_level_id": 80
                         },
                         {
                             /* Ruined Temple */
@@ -336,20 +342,40 @@
                             "level_id": 95
                         },
                         {
+                            /* Sewers Level 1 */
+                            "level_id": 92
+                        },
+                        {
+                            /* Sewers Level 2 */
+                            "level_id": 93
+                        },
+                        {
+                            /* Upper Kurast */
+                            "level_id": 81,
+                            /* Upper Kurast */
+                            "waypoint_level_id": 81
+                        },
+                        {
+                            /* Forgotten Temple */
+                            "level_id": 97
+                        },
+                        {
                             /* Forgotten Reliquary */
                             "level_id": 96
                         },
                         {
-                            /* Forgotten Temple */
-                            "level_id": 97 
-                        },
-                        {
                             /* Ruined Fane */
-                            "level_id": 98 
+                            "level_id": 98
                         },
                         {
                             /* Disused Reliquary */
                             "level_id": 99
+                        },
+                        {
+                            /* Travincal */
+                            "level_id": 83,
+                            /* Travincal */
+                            "waypoint_level_id": 83
                         },
                         {
                             /* Durance of Hate Level 1 */
@@ -420,10 +446,18 @@
                             "waypoint_level_id": 111
                         },
                         {
+                            /* Abbadon */
+                            "level_id": 125
+                        },
+                        {
                             /* Arreat Plateau */
                             "level_id": 112,
                             /* Arreat Plateau */
                             "waypoint_level_id": 112
+                        },
+                        {
+                            /* Pit of Acheron */
+                            "level_id": 126
                         },
                         {
                             /* Crystalline Passage */
@@ -434,30 +468,6 @@
                         {
                             /* Frozen River */
                             "level_id": 114
-                        },
-                        {
-                            /* Glacial Trail */
-                            "level_id": 115,
-                            /* Glacial Trail */
-                            "waypoint_level_id": 115
-                        },
-                        {
-                            /* Drifter Cavern */
-                            "level_id": 116
-                        },
-                        {
-                            /* Frozen Tundra */
-                            "level_id": 117
-                        },
-                        {
-                            /* Ancient's Way */
-                            "level_id": 118,
-                            /* Ancient's Way */
-                            "waypoint_level_id": 118
-                        },
-                        {
-                            /* Icy Cellar */
-                            "level_id": 119
                         },
                         {
                             /* Nihlathak's Temple */
@@ -471,23 +481,43 @@
                         },
                         {
                             /* Halls of Pain */
-                            "level_id": 123
+                            "level_id": 123,
+                            /* Halls of Pain */
+                            "waypoint_level_id": 123
                         },
                         {
                             /* Halls of Vaught */
                             "level_id": 124
                         },
                         {
-                            /* Abbadon */
-                            "level_id": 125
+                            /* Glacial Trail */
+                            "level_id": 115,
+                            /* Glacial Trail */
+                            "waypoint_level_id": 115
                         },
                         {
-                            /* Pit of Acheron */
-                            "level_id": 126
+                            /* Drifter Cavern */
+                            "level_id": 116
+                        },
+                        {
+                            /* Frozen Tundra */
+                            "level_id": 117,
+                            /* Frozen Tundra */
+                            "waypoint_level_id": 117
                         },
                         {
                             /* Infernal Pit */
                             "level_id": 127
+                        },
+                        {
+                            /* Ancient's Way */
+                            "level_id": 118,
+                            /* Ancient's Way */
+                            "waypoint_level_id": 118
+                        },
+                        {
+                            /* Icy Cellar */
+                            "level_id": 119
                         },
                         {
                             /* Worldstone Keep Level 1 */

--- a/data/hd/global/excel/desecratedzones.json
+++ b/data/hd/global/excel/desecratedzones.json
@@ -62,6 +62,10 @@
                             "waypoint_level_id": 4
                         },
                         {
+                            /* Tristram */
+                            "level_id": 38
+                        },
+                        {
                             /* Burial Grounds */
                             "level_id": 17
                         },
@@ -160,10 +164,6 @@
                         {
                             /* Catacombs Level 4 */
                             "level_id": 37
-                        },
-                        {
-                            /* Tristram */
-                            "level_id": 38
                         }
                     ]
                 },

--- a/data/hd/global/ui/panel/waypoints/terror_zone_icon.lowend.sprite
+++ b/data/hd/global/ui/panel/waypoints/terror_zone_icon.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c13dcd10edbf27e05070e534a391abc1b0b66c54001432588ddedb90b2e6f79f
+size 18520

--- a/data/hd/global/ui/panel/waypoints/terror_zone_icon.sprite
+++ b/data/hd/global/ui/panel/waypoints/terror_zone_icon.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b40d016fd76ba17e46aaa14d78de88c1a6cd1c567d2e539e0225fc8dd2617f5f
+size 73960

--- a/data/hd/global/ui/panel/waypoints/waypoints_button.lowend.sprite
+++ b/data/hd/global/ui/panel/waypoints/waypoints_button.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40d5f549e10f3205b3446f504ddde27245ce45bb4cf26cab27183bcecf0d0608
-size 122120
+oid sha256:a351cd7f399c52472b98c07ea5f37e5140c1695cfa7266c6cf50debbdc77acdd
+size 372080

--- a/data/hd/global/ui/panel/waypoints/waypoints_button.sprite
+++ b/data/hd/global/ui/panel/waypoints/waypoints_button.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f3f5be42148fc9856a7fe1eeccfce25a31fc8176d5c7f035a1421cdfb9f9bc3
-size 492412
+oid sha256:4db36621134102f5daea25288d4961c9063b02d9e155ec0e1b9c1237aee7a21c
+size 1488200

--- a/data/hd/global/ui/panel/waypoints/waypoints_button_active.lowend.sprite
+++ b/data/hd/global/ui/panel/waypoints/waypoints_button_active.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fd2bf8a6987b37707dbe4f0facefc879fd1faf506d2fe3de887bcbff68f7e0b
-size 244480
+oid sha256:1444663bb9bb46d40bae3bd75dbf449ba1393509d7c698c287530e6c8003d02a
+size 372080

--- a/data/hd/global/ui/panel/waypoints/waypoints_button_active.sprite
+++ b/data/hd/global/ui/panel/waypoints/waypoints_button_active.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76dfe3ac140f25c274a46e39526dd881200478e6a71babbef5d931b0dc57385d
-size 984784
+oid sha256:234b3a8af43cc7aa0bfef3b0a4d9860f1dcd28b7cc74b1a1e5a655b90e774977
+size 1488200


### PR DESCRIPTION
Waypoint button sprites updated so that when you click them there is an animation and the icons and text no longer disappear.
- Nothing selected
![image](https://github.com/user-attachments/assets/bc89a00d-9286-4536-b2c7-99eee899f583)
- Spider Forest Selected (Can't SS cursor in sadly.)
![image](https://github.com/user-attachments/assets/8e5aa680-6ecb-4e41-acb2-1c9262874326)

WPs updated to include Terror Zone Icon and Text coloring to indicate Terror Zone
- Redundant I know, but Alice and her white rabbit beckoned, it's a simple flag change to disable if unpopular.
- Created a Terror Zone Sprite out of the Vanilla sprite to match our waypoint icon.
![image](https://github.com/user-attachments/assets/6f51933a-158e-4f2c-a669-6c4ef4588b68)


desecratedzones.json re-ordered so that zones are displayed in order by adjacency to other zones instead of by level ID.
- Multiple waypoint ID's added/fixed in order to make the shiny new sprite and text work.
- Den of evil replaced by Dark Woods because Den was lonely and didn't make sense.
- Black Marsh re-added cause it looks like it was removed by accident.
- Canyon of the Magi added because there is space in A2 for it.
- Sewers Level 2 added because there is space in A3 for it.

