### PR TITLE
switching for oskill to skill for druid specific set

### DIFF
--- a/data/global/excel/sets.txt
+++ b/data/global/excel/sets.txt
@@ -46,7 +46,7 @@ Forgotten Treasures	Forgotten Treasures	100	str		15	15					dex		15	15					enr		1
 Insight of Brother Laz	Insight of Brother Laz	100	mag%		50	50					str		20	20					dex		20	20													pal		2	2	res-all		60	60	mag%		50	50	hp		100	100	mana		50	50	half-freeze												0
 Hades' Underworld	Hades' Underworld	100	oskill	revive	2	2					oskill	skeleton mastery	7	7					oskill	shout	4	4													nec		2	2	abs-fire%		20	20	abs-cold%		20	20	abs-ltng%		20	20	mag%		50	50													0
 Darque's Cabal	Darque's Cabal	100	dmg-undead		200	200					dmg-demon		200	200																					bar		2	2	res-all		40	40	all-stats		25	25	addxp		3	3	mag%		125	125													0
-Red Havoc's Challenge	Red Havoc's Challenge	100	oskill	wearwolf	8	8	oskill	shape shifting	6	6	oskill	fury	5	5																					dru		2	2	res-all		50	50	att%		30	30	addxp		3	3	mag%		60	60													0
+Red Havoc's Challenge	Red Havoc's Challenge	100	skill	Wearwolf	8	8	skill	Shape Shifting	6	6	skill	Fury	5	5																					dru		2	2	res-all		50	50	att%		30	30	addxp		3	3	mag%		60	60													0
 Mishy's Avatar	Mishy's Avatar	100	att		150	150					dmg%		40	40					dex		10	10					dex		10	10					ama		2	2	res-all		50	50	addxp		3	3	hp		75	75	mag%		50	50													0
 Joel's Sanctuary	Joel's Sanctuary	100	mana		50	50					regen-mana		50	50																					sor		2	2	res-all		50	50	addxp		3	3	mag%		50	50	mana-kill		7	7													0
 JBouley's Scion	JBouley's Scion	100	deadly		33	33					swing2		20	20																					ass		2	2	res-all		40	40	addxp		3	3	openwounds		100	100	mag%		50	50													0


### PR DESCRIPTION
fixes issue https://github.com/D2R-Reimagined/d2r-reimagined-mod/issues/535

switched oskill to skill, and capitalized skill names because it matter/crashes the game otherwise.

![image](https://github.com/user-attachments/assets/b2fbb59c-5bd7-45ff-8dd6-b469d58cde7f)

22 werewolf before set bonus
![image](https://github.com/user-attachments/assets/e03fc632-516b-4ae3-a7a9-6c6fb59fe019)


30 after
![image](https://github.com/user-attachments/assets/5d059a74-500b-4dea-962c-87b7e9d6b79a)
