### PR TITLE
Vendor Panel Confirm Removal

### DIFF
--- a/data/global/ui/layouts/vendorpanellayouthd.json
+++ b/data/global/ui/layouts/vendorpanellayouthd.json
@@ -11,7 +11,7 @@
             "type": "TimerWidget", "name": "timer",
             "fields": {
                 "time": 0,
-                "message": "DialogMessage:ListItemClicked",
+                "message": "DialogMessage:ListItemClicked"
             }
         },
         {

--- a/data/global/ui/layouts/vendorpanellayouthd.json
+++ b/data/global/ui/layouts/vendorpanellayouthd.json
@@ -8,6 +8,13 @@
     },
     "children": [
         {
+            "type": "TimerWidget", "name": "timer",
+            "fields": {
+                "time": 0,
+                "message": "DialogMessage:ListItemClicked",
+            }
+        },
+        {
             "type": "ClickCatcherWidget", "name": "click_catcher",
             "fields": {
                 "rect": "$PanelClickCatcherRect"


### PR DESCRIPTION
This update removes the Yes/No confirmation from vendor panels, it just autoselects yes with no delay so you can fill your inventory with a left click macro with potions/gambling, etc.

Side Effects: Removes "Not Enough Gold" from buying items or repairing as a clickable confirmation but it is pretty obvious when a vendor action fails due to a lack of gold. Item doesn't appear in inventory, repair doesn't happen and Repair All cost stays the same.


https://github.com/user-attachments/assets/06b67faa-568c-49e1-a117-617e74718908