### PR TITLE
ItemNerfs

### DIFF
--- a/data/global/excel/magicsuffix.txt
+++ b/data/global/excel/magicsuffix.txt
@@ -127,7 +127,7 @@ of Health	Damage Reduced by #	100	1	1	7	20	5				48	1	red-dmg		1	1										tors	
 of Protection	Damage Reduced by #	100	1	1	18	40	13				48	1	red-dmg		2	2										ring	amul	circ										0	0
 of Absorption	Damage Reduced by #	100	1	1	26	50	19				48	1	red-dmg		3	5										amul	circ	ring										0	0
 of Life	Damage Reduced by #	100	1	1	35		26				48	1	red-dmg		6	10									dblu	amul	circ	ring										0	0
-of Life Everlasting	Damage Reduced by #	100	1	1	45		37				48	1	red-dmg		10	25										amul	circ	ring										0	0
+of Life Everlasting	Damage Reduced by #	100	1	1	45		37				48	1	red-dmg		10	25										amul	circ											0	0
 of Protection	Damage Reduced by #	100	1	1	24	25	18				48	1	red-dmg		2	3										tors	shld	circ										0	0
 of Absorption	Damage Reduced by #	100	1	1	32	55	24				48	1	red-dmg		4	5										tors	shld	circ										0	0
 of Life	Damage Reduced by #	100	1	1	41		33				48	1	red-dmg		6	7										tors	shld	circ										0	0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1104,7 +1104,7 @@ Duskwreath	1099	100	1			1	1	52	60	ulc	spiderweb sash		5	5000				invbelt10				ac	
 Dreadfury	1100	100	1			1	1	56	64	uvc	vampirefang belt		5	5000				invbelt7				ac%		120	150	dru		1	1	swing1		10	10	howl		33	33	skill-rand	2	221	250	extra-fire		10	15																										0
 Kashya's Ward	1101	100	1			1	1	85	85	umc	mithril coil		5	5000				invbelt9				ac%		100	150	red-dmg%		15	15	res-mag		15	15	abs-fire/lvl	3			abs-ltng/lvl	3			abs-cold/lvl	3			regen-mana		50	50																						0
 Wisdom's Wrap	1102	100	1			1	1	72	78	utc	troll belt		5	5000								ac%		150	200	addxp		3	3	enr/lvl	5			allskills		1	1	rep-dur	30			dmg-to-mana		15	15	res-all		15	20																						0
-Ecstacy of Ishtar	1103	100	1			2	1	65	71	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		25	25	mana%		25	25	red-dmg		25	30	red-mag		25	30	pierce		50	50																										0
+Ecstacy of Ishtar	1103	100	1			2	1	65	71	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		10	10	mana%		10	10	red-dmg		10	15	red-mag		10	15	pierce		50	50																										0
 Lachdanan's Wrap	1104	100	1			1	1	80	85	uhc	colossus girdle		5	5000								ac		200	300	ease		20	20	lifesteal		8	8	manasteal		8	8	res-all		30	40	block2		20	20	allskills		1	1	dmg%		20	25																		0
 Ogre's Embrace	1105	100	1			2	1	76	80	uhc	Colossus Girdle		5	5000	dgrn	dgrn						ac%		175	200	ac		75	125	red-dmg%		10	15	str/lvl	8			vit/lvl	8			res-pois		100	100	rep-dur	25			oskill	iron skin	1	1																		0
 Damsel of Destruction	1106	100	1			1	1	6	26	am1	stag bow		5	5000	blac	blac		invam1				dmg%		80	120	dmg-norm		20	40	skilltab	0	1	3	swing1		15	15	dmg-elem	200	10	25	mana-kill		5	5	balance2		20	20	oskill_hide	393	1	1																		0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1104,7 +1104,7 @@ Duskwreath	1099	100	1			1	1	52	60	ulc	spiderweb sash		5	5000				invbelt10				ac	
 Dreadfury	1100	100	1			1	1	56	64	uvc	vampirefang belt		5	5000				invbelt7				ac%		120	150	dru		1	1	swing1		10	10	howl		33	33	skill-rand	2	221	250	extra-fire		10	15																										0
 Kashya's Ward	1101	100	1			1	1	85	85	umc	mithril coil		5	5000				invbelt9				ac%		100	150	red-dmg%		15	15	res-mag		15	15	abs-fire/lvl	3			abs-ltng/lvl	3			abs-cold/lvl	3			regen-mana		50	50																						0
 Wisdom's Wrap	1102	100	1			1	1	72	78	utc	troll belt		5	5000								ac%		150	200	addxp		3	3	enr/lvl	5			allskills		1	1	rep-dur	30			dmg-to-mana		15	15	res-all		15	20																						0
-Ecstacy of Ishtar	1103	100	1			2	1	65	71	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		10	10	mana%		10	10	red-dmg		10	15	red-mag		10	15	pierce		50	50																										0
+Ecstacy of Ishtar	1103	100	1			2	1	86	80	utc	Troll Belt		5	5000	cblu	cblu						ac%		100	200	hp%		10	10	mana%		10	10	red-dmg		18	25	red-mag		10	15	pierce		50	50																										0
 Lachdanan's Wrap	1104	100	1			1	1	80	85	uhc	colossus girdle		5	5000								ac		200	300	ease		20	20	lifesteal		8	8	manasteal		8	8	res-all		30	40	block2		20	20	allskills		1	1	dmg%		20	25																		0
 Ogre's Embrace	1105	100	1			2	1	76	80	uhc	Colossus Girdle		5	5000	dgrn	dgrn						ac%		175	200	ac		75	125	red-dmg%		10	15	str/lvl	8			vit/lvl	8			res-pois		100	100	rep-dur	25			oskill	iron skin	1	1																		0
 Damsel of Destruction	1106	100	1			1	1	6	26	am1	stag bow		5	5000	blac	blac		invam1				dmg%		80	120	dmg-norm		20	40	skilltab	0	1	3	swing1		15	15	dmg-elem	200	10	25	mana-kill		5	5	balance2		20	20	oskill_hide	393	1	1																		0


### PR DESCRIPTION
Resolves: #639
Resolves: #640

- Reduced the %MaxLife and %MaxLife on Ecstacy of Ishtar from 25% to 10%
- Reduced the flat reduction on Ecstacy of Ishtar from 25-30 to 10-15
- Ring's can no longer roll the "of Life Everlasting" suffix (highest flat reduction tier).