### PR TITLE
Unique-Jewels-Rework

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1353,10 +1353,10 @@ Life & Death	1348	100	1			3	1	55	55	cm2	charm	1	5	5000				invscm2				allskills		
 Throne of Power	1349	100	1			1	1	81	81	cm2	charm	1	5	5000	dred	dred		invscm2				hp		30	50	mana		30	50	dmg-max		10	15	res-all		5	8	addxp		3	5	charm-property		2	2																										0
 Nightshade	1350	100	1			5	1	6	6	cm3	charm	1	5	5000				invscm3				hp		20	30	dmg-cold	200	5	15	freeze		1	2	move1		15	15	charm-property		3	3																														0
 Queen's Call	1351	100	1			1	1	81	85	cm3	charm	1	5	5000				invscm3				allskills		1	2	hp		50	75	res-all		10	15	block1		10	10	move1		10	10	swing1		10	10	charm-property		3	3																						0
-Tiger Eye	1352	100	1			5	1	5	5	jew	jewel		3	5000								dmg%		15	20	dmg-max		5	8																																										0
-Jade Facet	1353	100	1			5	1	18	18	jew	jewel		3	5000		lgrn						dmg%		20	29	dmg-max		8	10																																										0
-Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						gold%		25	25	mag%		10	15	ac		25	50																																						0
-Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						dmg%		27	34	swing1		15	15																																										0
+Tiger Eye	1352	100	1			5	1	5	5	jew	jewel		3	5000								dmg%		40	40	dmg-min		15	15	deadly		5	8																																						0
+Jade Facet	1353	100	1			5	1	18	18	jew	jewel		3	5000		lgrn						dmg%		40	40	dmg-max		15	15	crush		5	8																																						0
+Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						dmg-ltng		1	80	mag%		24	28	res-ltng		10	15	res-ltng-max		1	1																																		0
+Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		10	15	res-pois-max		1	1																																		0
 Quartz Facet	1356	100	1			5	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
 Rainbow Facet	1357	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
 Rainbow Facet	1358	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
@@ -1365,8 +1365,8 @@ Rainbow Facet	1360	100	0			1	1	49	49	jew	jewel		3	5000								dmg-ltng		1	74	pie
 Rainbow Facet	1361	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
 Rainbow Facet	1362	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
 Rainbow Facet	1363	100	0			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		37	40	swing1		15	15																																										0
-Spinel Facet	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		37	40	dmg-max		12	15																																										0
+Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	30	40	mana		35	40	res-cold		10	15	res-cold-max		1	1	mana%		2	2																														0
+Spinel Facet	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		40	40	dmg-min		15	15	pierce		5	8																																						0
 Diamond Facet	1366	100	1			1	1	67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
 Adamantine Facet	1367	100	1			1	1	71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0
 Star Facet	1368	100	1			1	1	76	76	jew	jewel		3	5000								dmg%		40	40	swing1		15	15	dmg-max		15	15																																						0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1355,8 +1355,8 @@ Nightshade	1350	100	1			5	1	6	6	cm3	charm	1	5	5000				invscm3				hp		20	30	dmg-c
 Queen's Call	1351	100	1			1	1	81	85	cm3	charm	1	5	5000				invscm3				allskills		1	2	hp		50	75	res-all		10	15	block1		10	10	move1		10	10	swing1		10	10	charm-property		3	3																						0
 Tiger Eye	1352	100	1			5	1	5	5	jew	jewel		3	5000								dmg%		40	40	dmg-min		15	15	deadly		5	8																																						0
 Jade Facet	1353	100	1			5	1	18	18	jew	jewel		3	5000		lgrn						dmg%		40	40	dmg-max		15	15	crush		5	8																																						0
-Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						dmg-ltng		1	80	mag%		24	28	res-ltng		10	15	res-ltng-max		1	1																																		0
-Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		10	15	res-pois-max		1	1																																		0
+Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						dmg-ltng		1	80	mag%		24	28	res-ltng		25	35	res-ltng-max		1	1																																		0
+Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		25	35	res-pois-max		1	1																																		0
 Quartz Facet	1356	100	1			5	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
 Rainbow Facet	1357	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
 Rainbow Facet	1358	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	death-skill	Meteor	100	31																																		0
@@ -1365,7 +1365,7 @@ Rainbow Facet	1360	100	0			1	1	49	49	jew	jewel		3	5000								dmg-ltng		1	74	pie
 Rainbow Facet	1361	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
 Rainbow Facet	1362	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
 Rainbow Facet	1363	100	0			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	30	40	mana		35	40	res-cold		10	15	res-cold-max		1	1	mana%		2	2																														0
+Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	30	40	mana		35	40	res-cold		25	35	res-cold-max		1	1	mana%		2	2																														0
 Spinel Facet	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		40	40	dmg-min		15	15	pierce		5	8																																						0
 Diamond Facet	1366	100	1			1	1	67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
 Adamantine Facet	1367	100	1			1	1	71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -1355,7 +1355,7 @@ Nightshade	1350	100	1			5	1	6	6	cm3	charm	1	5	5000				invscm3				hp		20	30	dmg-c
 Queen's Call	1351	100	1			1	1	81	85	cm3	charm	1	5	5000				invscm3				allskills		1	2	hp		50	75	res-all		10	15	block1		10	10	move1		10	10	swing1		10	10	charm-property		3	3																						0
 Tiger Eye	1352	100	1			5	1	5	5	jew	jewel		3	5000								dmg%		40	40	dmg-min		15	15	deadly		5	8																																						0
 Jade Facet	1353	100	1			5	1	18	18	jew	jewel		3	5000		lgrn						dmg%		40	40	dmg-max		15	15	crush		5	8																																						0
-Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						dmg-ltng		1	80	mag%		24	28	res-ltng		25	35	res-ltng-max		1	1																																		0
+Topaz Facet	1354	100	1			5	1	27	27	jew	jewel		3	5000		lyel						dmg-ltng		1	140	mag%		24	28	res-ltng		25	35	res-ltng-max		1	1																																		0
 Emerald Facet	1355	100	1			5	1	38	38	jew	jewel		3	5000		cgrn						extra-pois		3	5	dex		10	15	res-pois		25	35	res-pois-max		1	1																																		0
 Quartz Facet	1356	100	1			5	1	43	43	jew	jewel		3	5000								hp		30	40	mana		25	35	cast1		10	10																																						0
 Rainbow Facet	1357	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	death-skill	Blizzard	100	37																																		0
@@ -1365,7 +1365,7 @@ Rainbow Facet	1360	100	0			1	1	49	49	jew	jewel		3	5000								dmg-ltng		1	74	pie
 Rainbow Facet	1361	100	0			1	1	49	49	jew	jewel		3	5000								dmg-cold	3	24	38	pierce-cold		3	5	extra-cold		3	5	levelup-skill	Frost Nova	100	43																																		0
 Rainbow Facet	1362	100	0			1	1	49	49	jew	jewel		3	5000								dmg-fire		17	45	pierce-fire		3	5	extra-fire		3	5	levelup-skill	Blaze	100	29																																		0
 Rainbow Facet	1363	100	0			1	1	49	49	jew	jewel		3	5000								dmg-pois	50	187	187	pierce-pois		3	5	extra-pois		3	5	levelup-skill	Venom	100	23																																		0
-Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	30	40	mana		35	40	res-cold		25	35	res-cold-max		1	1	mana%		2	2																														0
+Sapphire Facet	1364	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg-cold	3	60	80	mana		35	40	res-cold		25	35	res-cold-max		1	1	mana%		2	2																														0
 Spinel Facet	1365	100	1			1	1	58	58	jew	jewel		3	5000		cblu						dmg%		40	40	dmg-min		15	15	pierce		5	8																																						0
 Diamond Facet	1366	100	1			1	1	67	67	jew	jewel		3	5000		whit						res-all		12	15	cast1		10	10	red-dmg%		3	5	block		6	8																																		0
 Adamantine Facet	1367	100	1			1	1	71	71	jew	jewel		3	5000								red-dmg%		5	7	red-dmg		8	12	red-mag		8	10	ac%		25	35																																		0


### PR DESCRIPTION
- Reworked some under performing unique jewels 
### Tiger Eye
- Previously rolled 15-20% ED, 5-8 Max Damage
- Now rolls 40% ED, 15 Min Damage, 5-8% Deadly Strike 
### Jade Facet
- Previously rolled 20-29 %ED, 8-10 Max Damage
- Now rolls 40% ED, 15 Max Damage, 5-8% Crushing Blow 
### Topaz Facet
- Previously rolled 25% Gold Find, 10-15% Magic Find, 25-50 Defense
- Now rolls +1-140 Lightning Weapon Damage, 24-28% Magic Find, 25-35% Lightning Resist, +1% Max Lightning Resist 
### Emerald Facet
- Previously rolled 27-34% ED, 15% IAS
- Now rolls +3-5% Increased Poison Skill Damage, +10-15 Dexterity, +25-35% Poison Resist, +1% Max Poison Resist 
### Sapphire Facet
- Previously rolled 37-40% ED, 15% IAS
- Now rolls +60-80 Cold Weapon Damage, +35-40 Mana, +2% Maximum Mana, +25-35% Cold Resist, +1% Max Cold Resist 
### Spinal Facet
- Previously rolled +37-40% ED, +12-15 Max Damage
- Now rolls +40% ED, +15 Min Damage, +5-8% Pierce