### PR TITLE
'Slower Stamina Drain' Rollable Affix

### DIFF
--- a/data/global/excel/magicsuffix.txt
+++ b/data/global/excel/magicsuffix.txt
@@ -318,7 +318,7 @@ of the Soul2	+# Life after each Kill	100	1	1	75		75				24	67	heal-kill		16	25			
 of Pacing	+#% Faster Run/Walk	100	1	1	12	50	8				36	35	move1		10	10										boot	circ											0	0
 of Haste	+#% Faster Run/Walk	100	1	1	22		16				48	35	move2		20	20										boot	circ											0	0
 of Speed	+#% Faster Run/Walk	100	1	1	37		29				48	35	move3		30	30										boot	circ											0	0
-of Traveling	+#% Faster Run/Walk	100	1	1	65		57				48	35	move3		30	30	stamdrain		80	90						boot												0	0
+of Traveling	+#% Faster Run/Walk	100	0	1	65		57				48	35	move3		30	30	stamdrain		80	90						boot												0	0
 of Acceleration	+#% Faster Run/Walk	100	1	1	51		43				48	35	move3		40	40										boot												0	0
 of Balance	+#% Faster Hit Recovery	100	1	1	5		3				48	18	balance1		10	10										armo							glov					0	0
 of Equilibrium	+#% Faster Hit Recovery	100	1	1	9		6				48	18	balance2		20	20										tors	belt	shld										0	0


### PR DESCRIPTION
Fixes #664

Magic Suffix 'Of Traveling' gives stam drain reduction in addition to FRW. Without this affix its just a copy of the suffix 'Of Speed' with a higher level requirement. Disabling this as a spawnable affix.