### PR TITLE
Feature/unique nerfs

### DIFF
--- a/data/global/excel/setitems.txt
+++ b/data/global/excel/setitems.txt
@@ -360,7 +360,7 @@ Bound by Honor	356	Servitude or Rebellion	7tr	Stygian Pike	7	60	70	lgld	lgld				
 Equilibrium	357	Servitude or Rebellion	zmb	Mesh Belt	7	30	43	lgld	lgld						5	5000	2	ac/lvl	12			mag%		20	25	vit		15	20	enr		15	20																					regen		3	5																																						0
 Firecam Gilded Plate	358	Kaldorn's Majesty	xar	Ornate Plate	7	30	63		dred						5	5000	2	ac%		150	180	res-all		30	50	balance2		20	20																																									res-all		50	50																						0
 Axe of Arvoreen	359	Kaldorn's Majesty	7o7	Ogre Axe	7	60	70	oran	oran						5	5000	2	dmg%		220	270	dmg-max		200	300	swing3		20	20	sock		1	3	oskill_hide	393	1	1																																																										0
-Windspar Mask	360	Kaldorn's Majesty	uhm	Spired Helm	7	60	74								5	5000	2	red-dmg%		15	25	ac%		155	185	hp		30	50																																																																		0
+Windspar Mask	360	Kaldorn's Majesty	uhm	Spired Helm	7	60	74								5	5000	2	red-dmg%		15	25	ac%		155	185	hp		40	50																																																																		0
 Waterwyrd's Talon	361	Kaldorn's Majesty	xhg	War Gauntlets	7	30	55								5	5000	2	swing3		40	40	ac%		175	200																																																																						0
 Daystar Wrap	362	Kaldorn's Majesty	zhb	war Belt	7	30	58								5	5000	2	hp		175	200	mana		75	100																																																																						0
 Incarnadine Elven Plate	363	Warlock's Exploration	xtp	Mage Plate	7	30	59	dpur	dpur						5	5000	2	allskills		3	4	sock		2	2	ac		300	500																																																																		0

--- a/data/global/excel/setitems.txt
+++ b/data/global/excel/setitems.txt
@@ -360,7 +360,7 @@ Bound by Honor	356	Servitude or Rebellion	7tr	Stygian Pike	7	60	70	lgld	lgld				
 Equilibrium	357	Servitude or Rebellion	zmb	Mesh Belt	7	30	43	lgld	lgld						5	5000	2	ac/lvl	12			mag%		20	25	vit		15	20	enr		15	20																					regen		3	5																																						0
 Firecam Gilded Plate	358	Kaldorn's Majesty	xar	Ornate Plate	7	30	63		dred						5	5000	2	ac%		150	180	res-all		30	50	balance2		20	20																																									res-all		50	50																						0
 Axe of Arvoreen	359	Kaldorn's Majesty	7o7	Ogre Axe	7	60	70	oran	oran						5	5000	2	dmg%		220	270	dmg-max		200	300	swing3		20	20	sock		1	3	oskill_hide	393	1	1																																																										0
-Windspar Mask	360	Kaldorn's Majesty	uhm	Spired Helm	7	60	74								5	5000	2	red-dmg%		35	50	ac%		155	185																																																																						0
+Windspar Mask	360	Kaldorn's Majesty	uhm	Spired Helm	7	60	74								5	5000	2	red-dmg%		15	25	ac%		155	185	hp		30	50																																																																		0
 Waterwyrd's Talon	361	Kaldorn's Majesty	xhg	War Gauntlets	7	30	55								5	5000	2	swing3		40	40	ac%		175	200																																																																						0
 Daystar Wrap	362	Kaldorn's Majesty	zhb	war Belt	7	30	58								5	5000	2	hp		175	200	mana		75	100																																																																						0
 Incarnadine Elven Plate	363	Warlock's Exploration	xtp	Mage Plate	7	30	59	dpur	dpur						5	5000	2	allskills		3	4	sock		2	2	ac		300	500																																																																		0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -906,7 +906,7 @@ Royal Plate	901	100	1			1	1	51	60	xth	embossed plate		5	5000				invbody33				ac%
 Nightcrawler	902	100	1			3	1	46	56	xth	embossed plate		5	5000	blac	blac		invgth				ac		300	500	oskill	fade	2	4	rip		1	1	sock		4	4	ease		-35	-35																														0
 Shambling Mound	903	100	1			2	1	53	61	xul	chaos armor		5	5000				invbody65				ac/lvl	40			ac%		50	75	res-pois		40	70	dmg-pois	200	400	400	extra-pois		15	15	move1		10	10	sock		2	2																						0
 Evening Sky	904	100	1			1	1	47	57	xcl	tigulated mail		5	5000		oran		invbody61				ac%		175	210	dmg-fire		75	150	res-fire		75	75	move3		30	30	cast2		20	20	mana		50	50	hp		50	50																						0
-Adamantine Plate	905	100	1			1	1	53	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		30	30	res-all		50	75	rep-dur	20																																				0
+Adamantine Plate	905	100	1			1	1	53	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		15	20	res-all		30	40	rep-dur	20																																				0
 Iceskin	906	100	1			3	1	48	58	xar	ornate armor		5	5000	cblu	cblu		invaar				ac%		180	215	gethit-skill	Chilling Armor	50	8	gethit-skill	Frozen Orb	5	5	res-cold		100	100	extra-cold		15	20	allskills		1	1	block2		25	25																						0
 Plate of Fistandantilus	907	100	1			1	1	55	63	xtp	mage plate		5	5000				invbody54				ac		400	600	ac%		50	75	allskills		1	1	mana/lvl	8			hp/lvl	8			addxp		1	3	sock		2	3																						0
 Serendipity	908	100	1			3	1	50	59	xtp	mage plate		5	5000				invbody47				ac%		185	225	ac/lvl	16			allskills		1	1	cast3		30	30	mana		75	75	mag%		30	30	light		1	3	addxp		5	5																		0

--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -906,7 +906,7 @@ Royal Plate	901	100	1			1	1	51	60	xth	embossed plate		5	5000				invbody33				ac%
 Nightcrawler	902	100	1			3	1	46	56	xth	embossed plate		5	5000	blac	blac		invgth				ac		300	500	oskill	fade	2	4	rip		1	1	sock		4	4	ease		-35	-35																														0
 Shambling Mound	903	100	1			2	1	53	61	xul	chaos armor		5	5000				invbody65				ac/lvl	40			ac%		50	75	res-pois		40	70	dmg-pois	200	400	400	extra-pois		15	15	move1		10	10	sock		2	2																						0
 Evening Sky	904	100	1			1	1	47	57	xcl	tigulated mail		5	5000		oran		invbody61				ac%		175	210	dmg-fire		75	150	res-fire		75	75	move3		30	30	cast2		20	20	mana		50	50	hp		50	50																						0
-Adamantine Plate	905	100	1			1	1	53	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		15	20	res-all		30	40	rep-dur	20																																				0
+Adamantine Plate	905	100	1			1	1	53	62	xar	ornate armor		5	5000	whit	whit		invbody62				ac%		200	250	red-dmg%		15	20	res-all		30	40	rep-dur	20			balance2		20	30																														0
 Iceskin	906	100	1			3	1	48	58	xar	ornate armor		5	5000	cblu	cblu		invaar				ac%		180	215	gethit-skill	Chilling Armor	50	8	gethit-skill	Frozen Orb	5	5	res-cold		100	100	extra-cold		15	20	allskills		1	1	block2		25	25																						0
 Plate of Fistandantilus	907	100	1			1	1	55	63	xtp	mage plate		5	5000				invbody54				ac		400	600	ac%		50	75	allskills		1	1	mana/lvl	8			hp/lvl	8			addxp		1	3	sock		2	3																						0
 Serendipity	908	100	1			3	1	50	59	xtp	mage plate		5	5000				invbody47				ac%		185	225	ac/lvl	16			allskills		1	1	cast3		30	30	mana		75	75	mag%		30	30	light		1	3	addxp		5	5																		0


### PR DESCRIPTION
## unique/set item adjustments

- adamantine plate ornate plate (unique)
  - all res changes from 50-75 -> 30-40
  - physical damage reduction changed from 30 -> 15-20
  - 20-30 faster hit recovery added to compensate stat nerfs

- Windspar Mask Spired helm (set)
  - Physical damage reduction changed from 30-50 -> 15-25
  - 40-50 HP added to compensate the PDR nerf as the helm does not do much else due to it being part of a set 


![image](https://github.com/user-attachments/assets/9084177c-4cc7-4405-835b-97582702ec55)

![image](https://github.com/user-attachments/assets/670fae4e-94ab-4f65-a45c-a922a3690de1)
