### PR TITLE
oksill Value Fix

### DIFF
--- a/data/global/excel/properties.txt
+++ b/data/global/excel/properties.txt
@@ -240,7 +240,7 @@ skill-rand	1	+# to [Skill] ([Class] only)	12	item_singleskill																			
 fade	1		17	fade																												Min #	Max #	Visuals Only	0
 levelreq	1	Required Level: #	1	item_levelreq																												Min #	Max #		0
 ethereal	1	Ethereal	23																													1	1		0
-oskill	1	+# to [Skill]	22	item_nonclassskill_display			22	item_nonclassskill																							Skill	Min #	Max #		0
+oskill	1	+# to [Skill]	22	item_nonclassskill_display			24	item_nonclassskill																							Skill	Min #	Max #		0
 state	1		24	state																											State	1	1	Applies a State on the unit	0
 randclassskill	1	+# to [Class] Skill Levels	36	item_addclassskills		3																										Min Class ID	Max Class ID	val1 = # of Skill levels	0
 str%	1		1	item_strength_percent																															0


### PR DESCRIPTION
oskill with a range are currently rolling seperate values for the display string and the actual value given. This corrects that.

This fix is not retroactive, runewords such as CTA will need to be re-created, items such as Hellhunger will need to be refound in order for the correct +skill to display.