### PR TITLE
giant skull - tec slam oskill helm

### DIFF
--- a/data/global/excel/uniqueitems.txt
+++ b/data/global/excel/uniqueitems.txt
@@ -379,7 +379,7 @@ Metalgrid	375	100	1			2	1	85	81	amu	amulet		5	5000								ac		300	350	res-all		2
 Verdungo's Hearty Cord	376	100	1			1	1	71	63	umc	mithril coil		5	5000	blac	blac						ac%		90	140	vit		30	40					balance2		10	10	red-dmg%		10	15	regen		10	13																										0
 Siggard's Stealth	377	100				1	1						5	5000																																																									0
 Carrion Wind	378	100	1			3	1	67	60	rin	ring		3	5000								ac-miss		100	160	lifesteal		6	9	res-pois		55	55	gethit-skill	Poison Nova	10	10	charged	Plague Poppy	15	21	hit-skill	Twister	8	13	dmg-to-mana		10	10	dex		10	15																		0
-Giant Skull	379	100	1			1	1	73	65	uh9	bone visage		3	5000	lgry	lgry		invbhm				ac		250	320	str		25	35	crush		10	10	sock		1	2	knock		1	1																														0
+Giant Skull	379	100	1			1	1	73	65	uh9	bone visage		3	5000	lgry	lgry		invbhm				ac		250	320	str		25	35	oskill	stun	5	5	healperhit		2	4	att		180	220																														0
 Astreon's Iron Ward	380	100	1			1	1	68	60	7ws	caduceus		3	5000	blac	blac						dmg%		240	290	slow		25	25	att%		150	200	swing2		10	10	dmg-mag		80	240	red-dmg		4	7	dmg		40	85	skilltab	9	2	4	crush		33	33	oskill_hide	393	1	1										0
 Annihilus	381	100	1			1		110	75	cm1	charm		3	5000			flpmss	invmss	item_gem	12	item_gem	allskills		1	1	all-stats		10	10	res-all		10	10	addxp		5	5	charm-property		1	1	uberstone-property		1	1																										0
 Arioc's Needle	382	100	1			1	1	85	81	7sr	hyperion spear		3	5000								dmg%		180	230	dmg-pois	250	403	403	deadly		50	50	ignore-ac		1	1	allskills		2	4	swing2		30	30	oskill_hide	393	1	1																						0


### PR DESCRIPTION
# giant skull 
- removed
  - crushing blow
  - knockback
  - sockets
- added:
  - +5 Tectonic Slam Oskill
  - +180-220 Attack Rating
  - +2-4 Life on hit
  
  
![image](https://github.com/user-attachments/assets/edf66d6f-3c8d-476a-b4e7-676f5f31b78e)

  