### PR TITLE
TC Tweaks

### DIFF
--- a/data/global/excel/treasureclassex.txt
+++ b/data/global/excel/treasureclassex.txt
@@ -4,7 +4,7 @@ Gold 1.5x			1					4	"gld,mul=1536"	1																									0
 Gold 2x			1					4	"gld,mul=2048"	1																									0
 Gold 2.5x			1					4	"gld,mul=2560"	1																									0
 Conversion Orb			1					0	1oc	1	1oa	1																						1	0
-Socket Orb			1					98	1os	1																								1	0
+Socket Orb			1					128	1os	1																								1	0
 Corruption Orb			1					98	1ka	1																								1	0
 Shadow Orb			1					800	1oe	1																								1	0
 Jewelry A			1					10	rin	160	amu	80	jew	40	cm3	40	cm2	40	cm1	40	1oi	8	Conversion Orb	4											0
@@ -693,23 +693,23 @@ Swarm 2 (N)	17	46	1					80	Potion 6	12	Misc 2	6	Act 3 (N) Good	1	Act 3 (N) Magic
 Swarm 1 (H)	17	68	1					80	Potion 6	12	Misc 2	6	Act 2 (H) Good	1	Act 2 (H) Magic A	6																			0
 Swarm 2 (H)	17	74	1					80	Potion 6	12	Misc 2	6	Act 3 (H) Good	1	Act 3 (H) Magic A	6																			0
 Sunder Charms			1					1600	Cold Rupture	1	Flame Rift	1	Crack of the Heavens	1	Rotting Fissure	1	Bone Break	1	Black Cleft	1												2	2	1	0
-Andarielq Item			7					6	Act 2 Equip A	19	Act 2 Good	3																							0
-Andarielq Item Desecrated A			7					20	Act 2 Equip A	19	Act 2 Good	3																							0
-Andarielq Item Desecrated B			7					20	Act 4 Equip B	19	Act 4 Good	3																							0
-Andarielq Item Desecrated C			7					20	Act 3 (N) Equip A	19	Act 3 (N) Good	3																							0
-Andarielq Item (N)			7					6	Act 2 (N) Equip A	19	Act 2 (N) Good	3																							0
-Andarielq Item (N) Desecrated A			7					20	Act 2 (N) Equip A	19	Act 2 (N) Good	3																							0
-Andarielq Item (N) Desecrated B			7					20	Act 4 (N) Equip B	19	Act 4 (N) Good	3																							0
-Andarielq Item (N) Desecrated C			7					20	Act 3 (H) Equip A	19	Act 3 (H) Good	3																							0
-Andarielq Item (H)			7					6	Act 2 (H) Equip A	19	Act 2 (H) Good	3																							0
-Andarielq Item (H) Desecrated A			7					20	Act 3 (H) Equip B	19	Act 3 (H) Good	3																							0
-Andarielq Item (H) Desecrated B			7					20	Act 3 (H) Equip C	19	Act 3 (H) Good	3																							0
-Andarielq Item (H) Desecrated C			7					20	Act 4 (H) Equip A	19	Act 4 (H) Good	3																							0
-Andarielq Item (H) Desecrated D			7					20	Act 4 (H) Equip B	19	Act 4 (H) Good	3																							0
-Andarielq Item (H) Desecrated E			7					20	Act 4 (H) Equip C	19	Act 4 (H) Good	3																							0
-Andarielq Item (H) Desecrated F			7					20	Act 5 (H) Equip A	19	Act 5 (H) Good	3																							0
-Andarielq Item (H) Desecrated G			7					20	Act 5 (H) Equip B	19	Act 5 (H) Good	3																							0
-Andarielq Item (H) Desecrated H			7					20	Act 5 (H) Equip C	19	Act 5 (H) Good	3																							0
+Andarielq Item			7					5	Act 2 Equip A	19	Act 2 Good	3																							0
+Andarielq Item Desecrated A			7					5	Act 2 Equip A	19	Act 2 Good	3																							0
+Andarielq Item Desecrated B			7					5	Act 4 Equip B	19	Act 4 Good	3																							0
+Andarielq Item Desecrated C			7					5	Act 3 (N) Equip A	19	Act 3 (N) Good	3																							0
+Andarielq Item (N)			7					5	Act 2 (N) Equip A	19	Act 2 (N) Good	3																							0
+Andarielq Item (N) Desecrated A			7					5	Act 2 (N) Equip A	19	Act 2 (N) Good	3																							0
+Andarielq Item (N) Desecrated B			7					5	Act 4 (N) Equip B	19	Act 4 (N) Good	3																							0
+Andarielq Item (N) Desecrated C			7					5	Act 3 (H) Equip A	19	Act 3 (H) Good	3																							0
+Andarielq Item (H)			7					5	Act 2 (H) Equip A	19	Act 2 (H) Good	3																							0
+Andarielq Item (H) Desecrated A			7					5	Act 3 (H) Equip B	19	Act 3 (H) Good	3																							0
+Andarielq Item (H) Desecrated B			7					5	Act 3 (H) Equip C	19	Act 3 (H) Good	3																							0
+Andarielq Item (H) Desecrated C			7					5	Act 4 (H) Equip A	19	Act 4 (H) Good	3																							0
+Andarielq Item (H) Desecrated D			7					5	Act 4 (H) Equip B	19	Act 4 (H) Good	3																							0
+Andarielq Item (H) Desecrated E			7					5	Act 4 (H) Equip C	19	Act 4 (H) Good	3																							0
+Andarielq Item (H) Desecrated F			7					5	Act 5 (H) Equip A	19	Act 5 (H) Good	3																							0
+Andarielq Item (H) Desecrated G			7					5	Act 5 (H) Equip B	19	Act 5 (H) Good	3																							0
+Andarielq Item (H) Desecrated H			7					5	Act 5 (H) Equip C	19	Act 5 (H) Good	3																							0
 Andarielq			-1	995	995	1024	1024	0	Andarielq Item	1																									0
 Andarielq Desecrated A	20	13	-2	995	995	1024	1024	0	Corruption Orb	1	Andarielq Item Desecrated A	1																							0
 Andarielq Desecrated B	20	32	-2	995	995	1024	1024	0	Corruption Orb	1	Andarielq Item Desecrated B	1																							0
@@ -728,18 +728,18 @@ Andarielq (H) Desecrated F	20	90	-4	995	995	1024	1024	0	Corruption Orb	1	Socket 
 Andarielq (H) Desecrated G	20	93	-4	995	995	1024	1024	0	Corruption Orb	1	Socket Orb	1	Sunder Charms	1	Andarielq Item (H) Desecrated G	1																			0
 Andarielq (H) Desecrated H	20	96	-4	995	995	1024	1024	0	Corruption Orb	1	Socket Orb	1	Sunder Charms	1	Andarielq Item (H) Desecrated H	1																			0
 Radament Item			5					5	Gold 1.5x	5	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
-Radament Item Desecrated A			5					19	Gold 1.5x	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
-Radament Item Desecrated B			5					19	Gold 1.5x	11	Act 4 Equip B	19	Act 4 Junk	15	Act 4 Good	3																			0
-Radament Item Desecrated C			5					19	Gold 1.5x	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
+Radament Item Desecrated A			5					5	Gold 1.5x	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
+Radament Item Desecrated B			5					5	Gold 1.5x	11	Act 4 Equip B	19	Act 4 Junk	15	Act 4 Good	3																			0
+Radament Item Desecrated C			5					5	Gold 1.5x	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
 Radament Item (N)			5					5	Gold 2x	5	Act 3 (N) Equip B	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
-Radament Item (N) Desecrated A			5					19	Gold 1.5x	11	Act 3 (N) Equip C	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
-Radament Item (N) Desecrated B			5					19	Gold 1.5x	11	Act 5 (N) Equip A	19	Act 5 (N) Junk	15	Act 5 (N) Good	3																			0
-Radament Item (N) Desecrated C			5					19	Gold 1.5x	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3																			0
+Radament Item (N) Desecrated A			5					5	Gold 1.5x	11	Act 3 (N) Equip C	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
+Radament Item (N) Desecrated B			5					5	Gold 1.5x	11	Act 5 (N) Equip A	19	Act 5 (N) Junk	15	Act 5 (N) Good	3																			0
+Radament Item (N) Desecrated C			5					5	Gold 1.5x	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3																			0
 Radament Item (H)			5					5	Gold 2.5x	5	Act 3 (H) Equip C	19	Act 3 (H) Junk	10	Act 3 (H) Good	3																			0
-Radament Item (H) Desecrated A			5					19	Gold 2x	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3																			0
-Radament Item (H) Desecrated B			5					19	Gold 2x	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
-Radament Item (H) Desecrated C			5					19	Gold 2x	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
-Radament Item (H) Desecrated D			5					19	Gold 2x	11	Act 5 (H) Equip C	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Radament Item (H) Desecrated A			5					5	Gold 2x	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3																			0
+Radament Item (H) Desecrated B			5					5	Gold 2x	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Radament Item (H) Desecrated C			5					5	Gold 2x	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Radament Item (H) Desecrated D			5					5	Gold 2x	11	Act 5 (H) Equip C	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
 Radament			-1	900	900	900	1024	0	Radament Item	1																									0
 Radament Desecrated A	21	19	-2	900	900	900	1024	0	Corruption Orb	1	Radament Item Desecrated A	1																							0
 Radament Desecrated B	21	33	-2	900	900	900	1024	0	Corruption Orb	1	Radament Item Desecrated B	1																							0
@@ -753,21 +753,21 @@ Radament (H) Desecrated A	21	86	-4	900	900	900	1024	0	Corruption Orb	1	Sunder Ch
 Radament (H) Desecrated B	21	90	-4	900	900	900	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Radament Item (H) Desecrated B	1																			0
 Radament (H) Desecrated C	21	93	-4	900	900	900	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Radament Item (H) Desecrated C	1																			0
 Radament (H) Desecrated D	21	96	-4	900	900	900	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Radament Item (H) Desecrated D	1																			0
-Bloodwitch Rune			2					0	Runes 2	30	Runes 3	15	Runes 4	15																					0
-Bloodwitch Rune (N)			2					0	Runes 7	15	Runes 8	15	Runes 9	15																					0
-Bloodwitch Rune (H)			2					0	Runes 10	15	Runes 11	15	Runes 12	15																					0
-Bloodwitch Rune Desecrated			2					0	Runes 3	30	Runes 4	15	Runes 5	15																					0
-Bloodwitch Rune (N) Desecrated			2					0	Runes 8	15	Runes 9	15	Runes 10	15																					0
-Bloodwitch Rune (H) Desecrated			2					0	Runes 11	15	Runes 12	15	Runes 13	15																					0
-Bloodwitch Item			5					5	Gold 1.5x	7	Act 2 Equip A	19	Act 2 Junk	5	Act 2 Good	3																			0
+Bloodwitch Rune			2					2	Runes 2	30	Runes 3	15	Runes 4	15																					0
+Bloodwitch Rune (N)			2					2	Runes 7	15	Runes 8	15	Runes 9	15																					0
+Bloodwitch Rune (H)			2					2	Runes 10	15	Runes 11	15	Runes 12	15																					0
+Bloodwitch Rune Desecrated			2					2	Runes 3	30	Runes 4	15	Runes 5	15																					0
+Bloodwitch Rune (N) Desecrated			2					2	Runes 8	15	Runes 9	15	Runes 10	15																					0
+Bloodwitch Rune (H) Desecrated			2					2	Runes 11	15	Runes 12	15	Runes 13	15																					0
+Bloodwitch Item			5					10	Gold 1.5x	7	Act 2 Equip A	19	Act 2 Junk	5	Act 2 Good	3																			0
 Bloodwitch Item Desecrated A			5					10	Gold 1.5x	14	Act 2 Equip A	19	Act 2 Junk	5	Act 2 Good	3																			0
 Bloodwitch Item Desecrated B			5					10	Gold 1.5x	14	Act 2 Equip C	19	Act 2 Junk	5	Act 2 Good	3																			0
 Bloodwitch Item Desecrated C			5					10	Gold 1.5x	14	Act 3 (N) Equip C	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
-Bloodwitch Item (N)			5					5	Gold 2x	7	Act 2 (N) Equip A	19	Act 2 (N) Junk	5	Act 2 (N) Good	3																			0
+Bloodwitch Item (N)			5					10	Gold 2x	7	Act 2 (N) Equip A	19	Act 2 (N) Junk	5	Act 2 (N) Good	3																			0
 Bloodwitch Item (N) Desecrated A			5					10	Gold 1.5x	14	Act 2 (N) Equip A	19	Act 2 (N) Junk	5	Act 2 (N) Good	3																			0
 Bloodwitch Item (N) Desecrated B			5					10	Gold 1.5x	14	Act 2 (N) Equip C	19	Act 2 (N) Junk	5	Act 2 (N) Good	3																			0
 Bloodwitch Item (N) Desecrated C			5					10	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
-Bloodwitch Item (H)			5					5	Gold 2.5x	7	Act 2 (H) Equip A	19	Act 2 (H) Junk	5	Act 2 (H) Good	3																			0
+Bloodwitch Item (H)			5					10	Gold 2.5x	7	Act 2 (H) Equip A	19	Act 2 (H) Junk	5	Act 2 (H) Good	3																			0
 Bloodwitch Item (H) Desecrated A			5					10	Gold 2x	14	Act 2 (H) Equip A	19	Act 2 (H) Junk	5	Act 2 (H) Good	3																			0
 Bloodwitch Item (H) Desecrated B			5					10	Gold 2x	14	Act 2 (H) Equip B	19	Act 2 (H) Junk	5	Act 2 (H) Good	3																			0
 Bloodwitch Item (H) Desecrated C			5					10	Gold 2x	14	Act 2 (H) Equip C	19	Act 2 (H) Junk	5	Act 2 (H) Good	3																			0
@@ -792,21 +792,21 @@ Bloodwitch (H) Desecrated F	27	96	-5	883	883	983	1024	0	Corruption Orb	1	Sunder 
 Flying Scimitar			1					60	Act 2 Good	3	scm	57																							0
 Flying Scimitar (N)			1					60	Act 2 (N) Good	3	scm	25	9sm	32																					0
 Flying Scimitar (H)			1					60	Act 2 (H) Good	3	scm	7	9sm	18	7sm	32																			0
-Battlemaiden Rune			1					0	Runes 2	30	Runes 3	15	Runes 4	15																					0
-Battlemaiden Rune (N)			1					0	Runes 7	15	Runes 8	15	Runes 9	15																					0
-Battlemaiden Rune (H)			1					0	Runes 10	15	Runes 11	15	Runes 12	15																					0
-Battlemaiden Rune Desecrated			1					0	Runes 3	30	Runes 4	15	Runes 5	15																					0
-Battlemaiden Rune (N) Desecrated			1					0	Runes 8	15	Runes 9	15	Runes 10	15																					0
-Battlemaiden Rune (H) Desecrated			1					0	Runes 11	15	Runes 12	15	Runes 13	15																					0
-Battlemaiden Item			5					5	Gold 1.5x	7	Act 3 Equip A	19	Act 3 Junk	5	Act 3 Good	3																			0
+Battlemaiden Rune			1					2	Runes 2	30	Runes 3	15	Runes 4	15																					0
+Battlemaiden Rune (N)			1					2	Runes 7	15	Runes 8	15	Runes 9	15																					0
+Battlemaiden Rune (H)			1					2	Runes 10	15	Runes 11	15	Runes 12	15																					0
+Battlemaiden Rune Desecrated			1					2	Runes 3	30	Runes 4	15	Runes 5	15																					0
+Battlemaiden Rune (N) Desecrated			1					2	Runes 8	15	Runes 9	15	Runes 10	15																					0
+Battlemaiden Rune (H) Desecrated			1					2	Runes 11	15	Runes 12	15	Runes 13	15																					0
+Battlemaiden Item			5					10	Gold 1.5x	7	Act 3 Equip A	19	Act 3 Junk	5	Act 3 Good	3																			0
 Battlemaiden Item Desecrated A			5					10	Gold 1.5x	14	Act 3 Equip A	19	Act 3 Junk	5	Act 3 Good	3																			0
 Battlemaiden Item Desecrated B			5					10	Gold 1.5x	14	Act 3 Equip C	19	Act 3 Junk	5	Act 3 Good	3																			0
 Battlemaiden Item Desecrated C			5					10	Gold 1.5x	14	Act 3 (N) Equip C	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
-Battlemaiden Item (N)			5					5	Gold 2x	7	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Battlemaiden Item (N)			5					10	Gold 2x	7	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Battlemaiden Item (N) Desecrated A			5					10	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Battlemaiden Item (N) Desecrated B			5					10	Gold 1.5x	14	Act 3 (N) Equip C	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Battlemaiden Item (N) Desecrated C			5					10	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
-Battlemaiden Item (H)			5					5	Gold 2.5x	7	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Battlemaiden Item (H)			5					10	Gold 2.5x	7	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Battlemaiden Item (H) Desecrated A			5					10	Gold 2x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Battlemaiden Item (H) Desecrated B			5					10	Gold 2x	14	Act 3 (H) Equip B	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Battlemaiden Item (H) Desecrated C			5					10	Gold 2x	14	Act 3 (H) Equip C	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
@@ -829,18 +829,18 @@ Battlemaiden (H) Desecrated D	27	90	-5	883	883	983	1024	0	Corruption Orb	1	Sunde
 Battlemaiden (H) Desecrated E	27	93	-5	883	883	983	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Battlemaiden Item (H) Desecrated E	1	Battlemaiden Rune (H) Desecrated	1																	0
 Battlemaiden (H) Desecrated F	27	96	-5	883	883	983	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Battlemaiden Item (H) Desecrated F	1	Battlemaiden Rune (H) Desecrated	1																	0
 Mephisto Item			7					5	Gold 1.5x	2	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3																			0
-Mephisto Item Desecrated A	22	26	7					15	Gold 1.5x	5	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3																			0
-Mephisto Item Desecrated B	22	38	7					15	Gold 1.5x	5	Act 5 Equip C	52	Act 5 Junk	5	Act 5 Good	3																			0
-Mephisto Item Desecrated C	22	48	7					15	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Mephisto Item Desecrated A	22	26	7					5	Gold 1.5x	5	Act 4 Equip A	52	Act 4 Junk	5	Act 4 Good	3																			0
+Mephisto Item Desecrated B	22	38	7					5	Gold 1.5x	5	Act 5 Equip C	52	Act 5 Junk	5	Act 5 Good	3																			0
+Mephisto Item Desecrated C	22	48	7					5	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Mephisto Item (N)			7					5	Gold 2x	2	Act 4 (N) Equip A	52	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
-Mephisto Item (N) Desecrated A	22	59	7					15	Gold 1.5x	5	Act 4 (N) Equip B	52	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
-Mephisto Item (N) Desecrated B	22	66	7					15	Gold 1.5x	5	Act 5 (N) Equip C	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Mephisto Item (N) Desecrated C	22	73	7					15	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Mephisto Item (N) Desecrated A	22	59	7					5	Gold 1.5x	5	Act 4 (N) Equip B	52	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
+Mephisto Item (N) Desecrated B	22	66	7					5	Gold 1.5x	5	Act 5 (N) Equip C	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Mephisto Item (N) Desecrated C	22	73	7					5	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Mephisto Item (H)			7					5	Gold 2x	2	Act 4 (H) Equip A	52	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
-Mephisto Item (H) Desecrated A			7					15	Gold 2x	5	Act 4 (H) Equip B	52	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
-Mephisto Item (H) Desecrated B			7					15	Gold 2x	5	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Mephisto Item (H) Desecrated C			7					15	Gold 2x	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Mephisto Item (H) Desecrated D			7					15	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Mephisto Item (H) Desecrated A			7					5	Gold 2x	5	Act 4 (H) Equip B	52	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
+Mephisto Item (H) Desecrated B			7					5	Gold 2x	5	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Mephisto Item (H) Desecrated C			7					5	Gold 2x	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Mephisto Item (H) Desecrated D			7					5	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Mephisto			-1	983	983	983	1024	0	Mephisto Item	1																									0
 Mephisto Desecrated A	22	26	-2	983	983	983	1024	0	Corruption Orb	1	Mephisto Item Desecrated A	1																							0
 Mephisto Desecrated B	22	38	-2	983	983	983	1024	0	Corruption Orb	1	Mephisto Item Desecrated B	1																							0
@@ -861,15 +861,15 @@ Mephistoq			-1	993	993	1024	1024	0	Mephistoq Item	1																									0
 Mephistoq (N)			-2	993	993	1024	1024	0	Socket Orb	1	Mephistoq Item (N)	1																							0
 Mephistoq (H)			-2	993	993	1024	1024	0	Socket Orb	1	Mephistoq Item (H)	1																							0
 Diablo Item			7					5	Gold 1.5x	2	Act 5 Equip A	52	Act 5 Junk	5	Act 5 Good	3																			0
-Diablo Item Desecrated A	23	40	7					15	Gold 1.5x	5	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
-Diablo Item Desecrated B	23	48	7					15	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Diablo Item Desecrated A	23	40	7					5	Gold 1.5x	5	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
+Diablo Item Desecrated B	23	48	7					5	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Diablo Item (N)			7					5	Gold 2x	2	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Diablo Item (N) Desecrated A	23	62	7					15	Gold 1.5x	5	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Diablo Item (N) Desecrated B	23	67	7					15	Gold 1.5x	5	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
-Diablo Item (N) Desecrated C	23	73	7					15	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Diablo Item (N) Desecrated A	23	62	7					5	Gold 1.5x	5	Act 5 (N) Equip A	52	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Diablo Item (N) Desecrated B	23	67	7					5	Gold 1.5x	5	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
+Diablo Item (N) Desecrated C	23	73	7					5	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Diablo Item (H)			7					5	Gold 2.5x	2	Act 5 (H) Equip A	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Diablo Item (H) Desecrated A			7					15	Gold 2x	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Diablo Item (H) Desecrated B			7					15	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Diablo Item (H) Desecrated A			7					5	Gold 2x	5	Act 5 (H) Equip B	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Diablo Item (H) Desecrated B			7					5	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Diablo			-1	983	983	983	1024	0	Diablo Item	1																									0
 Diablo Desecrated A	23	40	-2	983	983	983	1024	0	Corruption Orb	1	Diablo Item Desecrated A	1																							0
 Diablo Desecrated B	23	48	-2	983	983	983	1024	0	Corruption Orb	1	Diablo Item Desecrated B	1																							0
@@ -887,20 +887,20 @@ Diabloq			-1	993	993	1024	1024	0	Diabloq Item	1																									0
 Diabloq (N)			-2	993	993	1024	1024	0	Socket Orb	1	Diabloq Item (N)	1																							0
 Diabloq (H)			-2	993	993	1024	1024	0	Socket Orb	1	Diabloq Item (H)	1																							0
 Summoner Item			5	900	900	972	1024	5	Gold 1.5x	4	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4																	0
-Summoner Item Desecrated A			5	900	900	972	1024	19	Gold 1.5x	9	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4																	0
-Summoner Item Desecrated B			5	900	900	972	1024	19	Gold 1.5x	9	Act 4 Equip B	15	Act 5 Junk	5	Act 4 Good	3	Act 5 Magic A	4																	0
-Summoner Item Desecrated C			5	900	900	972	1024	19	Gold 1.5x	9	Act 3 (N) Equip C	15	Act 4 (N) Junk	5	Act 3 (N) Good	3	Act 4 (N) Magic A	4																	0
+Summoner Item Desecrated A			5	900	900	972	1024	5	Gold 1.5x	9	Act 2 Equip C	15	Act 3 Junk	5	Act 2 Good	3	Act 3 Magic A	4																	0
+Summoner Item Desecrated B			5	900	900	972	1024	5	Gold 1.5x	9	Act 4 Equip B	15	Act 5 Junk	5	Act 4 Good	3	Act 5 Magic A	4																	0
+Summoner Item Desecrated C			5	900	900	972	1024	5	Gold 1.5x	9	Act 3 (N) Equip C	15	Act 4 (N) Junk	5	Act 3 (N) Good	3	Act 4 (N) Magic A	4																	0
 Summoner Item (N)			5	900	900	972	1024	5	Gold 2x	4	Act 2 (N) Equip C	15	Act 3 (N) Junk	5	Act 2 (N) Good	3	Act 3 (N) Magic A	4																	0
-Summoner Item (N) Desecrated A			5	900	900	972	1024	19	Gold 1.5x	9	Act 4 (N) Equip A	15	Act 5 (N) Junk	5	Act 4 (N) Good	3	Act 5 (N) Magic A	4																	0
-Summoner Item (N) Desecrated B			5	900	900	972	1024	19	Gold 1.5x	9	Act 5 (N) Equip A	15	Act 1 (H) Junk	5	Act 5 (N) Good	3	Act 1 (H) Magic A	4																	0
-Summoner Item (N) Desecrated C			5	900	900	972	1024	19	Gold 1.5x	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4																	0
+Summoner Item (N) Desecrated A			5	900	900	972	1024	5	Gold 1.5x	9	Act 4 (N) Equip A	15	Act 5 (N) Junk	5	Act 4 (N) Good	3	Act 5 (N) Magic A	4																	0
+Summoner Item (N) Desecrated B			5	900	900	972	1024	5	Gold 1.5x	9	Act 5 (N) Equip A	15	Act 1 (H) Junk	5	Act 5 (N) Good	3	Act 1 (H) Magic A	4																	0
+Summoner Item (N) Desecrated C			5	900	900	972	1024	5	Gold 1.5x	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4																	0
 Summoner Item (H)			5	900	900	972	1024	5	Gold 2.5x	4	Act 2 (H) Equip C	15	Act 3 (H) Junk	5	Act 2 (H) Good	3	Act 3 (H) Magic A	4	pk2	2															0
-Summoner Item (H) Desecrated A			5	900	900	972	1024	19	Gold 2x	9	Act 4 (H) Equip A	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	2															0
-Summoner Item (H) Desecrated B			5	900	900	972	1024	19	Gold 2x	9	Act 4 (H) Equip B	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic B	4	pk2	2															0
-Summoner Item (H) Desecrated C			5	900	900	972	1024	19	Gold 2x	9	Act 4 (H) Equip C	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	2															0
-Summoner Item (H) Desecrated D			5	900	900	972	1024	19	Gold 2x	9	Act 5 (H) Equip A	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
-Summoner Item (H) Desecrated E			5	900	900	972	1024	19	Gold 2x	9	Act 5 (H) Equip B	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
-Summoner Item (H) Desecrated F			5	900	900	972	1024	19	Gold 2x	9	Act 5 (H) Equip C	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
+Summoner Item (H) Desecrated A			5	900	900	972	1024	5	Gold 2x	9	Act 4 (H) Equip A	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	2															0
+Summoner Item (H) Desecrated B			5	900	900	972	1024	5	Gold 2x	9	Act 4 (H) Equip B	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic B	4	pk2	2															0
+Summoner Item (H) Desecrated C			5	900	900	972	1024	5	Gold 2x	9	Act 4 (H) Equip C	15	Act 5 (H) Junk	5	Act 4 (H) Good	3	Act 5 (H) Magic A	4	pk2	2															0
+Summoner Item (H) Desecrated D			5	900	900	972	1024	5	Gold 2x	9	Act 5 (H) Equip A	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
+Summoner Item (H) Desecrated E			5	900	900	972	1024	5	Gold 2x	9	Act 5 (H) Equip B	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
+Summoner Item (H) Desecrated F			5	900	900	972	1024	5	Gold 2x	9	Act 5 (H) Equip C	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4	pk2	2															0
 Summoner			-1	900	900	972	1024	0	Summoner Item	1																									0
 Summoner Desecrated A	24	18	-2	900	900	972	1024	0	Corruption Orb	1	Summoner Item Desecrated A	1																							0
 Summoner Desecrated B	24	32	-2	900	900	972	1024	0	Corruption Orb	1	Summoner Item Desecrated B	1																							0
@@ -917,19 +917,19 @@ Summoner (H) Desecrated D	24	90	-4	900	900	972	1024	0	Corruption Orb	1	Sunder Ch
 Summoner (H) Desecrated E	24	93	-4	900	900	972	1024	0	Corruption Orb	1	Sunder Charms	1	Socket Orb	1	Summoner Item (H) Desecrated E	1																			0
 Summoner (H) Desecrated F	24	96	-4	900	900	972	1024	0	Corruption Orb	1	Sunder Charms	1	Socket Orb	1	Summoner Item (H) Desecrated F	1																			0
 Council Item			3					5	Gold 1.5x	4	Act 4 Equip A	15	Act 4 Junk	5	Act 4 Good	3	Act 4 Magic A	4																	0
-Council Item Desecrated A			3					38	Gold 1.5x	18	Act 4 Equip B	30	Act 4 Junk	10	Act 4 Good	6	Act 4 Magic B	8																	0
-Council Item Desecrated B			3					38	Gold 1.5x	18	Act 5 Equip C	30	Act 5 Junk	10	Act 5 Good	6	Act 5 Magic C	8																	0
-Council Item Desecrated C			3					38	Gold 1.5x	18	Act 3 (N) Equip A	30	Act 3 (N) Junk	10	Act 3 (N) Good	6	Act 3 (N) Magic A	8																	0
+Council Item Desecrated A			3					5	Gold 1.5x	18	Act 4 Equip B	30	Act 4 Junk	10	Act 4 Good	6	Act 4 Magic B	8																	0
+Council Item Desecrated B			3					5	Gold 1.5x	18	Act 5 Equip C	30	Act 5 Junk	10	Act 5 Good	6	Act 5 Magic C	8																	0
+Council Item Desecrated C			3					5	Gold 1.5x	18	Act 3 (N) Equip A	30	Act 3 (N) Junk	10	Act 3 (N) Good	6	Act 3 (N) Magic A	8																	0
 Council Item (N)			3					5	Gold 2x	4	Act 4 (N) Equip A	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic A	4																	0
-Council Item (N) Desecrated A			3					19	Gold 1.5x	9	Act 4 (N) Equip B	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic B	4																	0
-Council Item (N) Desecrated B			3					19	Gold 1.5x	9	Act 5 (N) Equip C	15	Act 5 (N) Junk	5	Act 5 (N) Good	3	Act 5 (N) Magic C	4																	0
-Council Item (N) Desecrated C			3					19	Gold 1.5x	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4																	0
+Council Item (N) Desecrated A			3					5	Gold 1.5x	9	Act 4 (N) Equip B	15	Act 4 (N) Junk	5	Act 4 (N) Good	3	Act 4 (N) Magic B	4																	0
+Council Item (N) Desecrated B			3					5	Gold 1.5x	9	Act 5 (N) Equip C	15	Act 5 (N) Junk	5	Act 5 (N) Good	3	Act 5 (N) Magic C	4																	0
+Council Item (N) Desecrated C			3					5	Gold 1.5x	9	Act 3 (H) Equip A	15	Act 3 (H) Junk	5	Act 3 (H) Good	3	Act 3 (H) Magic A	4																	0
 Council Item (H)			3					5	Gold 2.5x	4	Act 4 (H) Equip A	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic A	4																	0
-Council Item (H) Desecrated A			3					19	Gold 2x	9	Act 4 (H) Equip B	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4																	0
-Council Item (H) Desecrated B			3					19	Gold 2x	9	Act 4 (H) Equip C	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4																	0
-Council Item (H) Desecrated C			3					19	Gold 2x	9	Act 5 (H) Equip A	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic A	4																	0
-Council Item (H) Desecrated D			3					19	Gold 2x	9	Act 5 (H) Equip B	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic B	4																	0
-Council Item (H) Desecrated E			3					19	Gold 2x	9	Act 5 (H) Equip C	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4																	0
+Council Item (H) Desecrated A			3					5	Gold 2x	9	Act 4 (H) Equip B	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4																	0
+Council Item (H) Desecrated B			3					5	Gold 2x	9	Act 4 (H) Equip C	15	Act 4 (H) Junk	5	Act 4 (H) Good	3	Act 4 (H) Magic B	4																	0
+Council Item (H) Desecrated C			3					5	Gold 2x	9	Act 5 (H) Equip A	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic A	4																	0
+Council Item (H) Desecrated D			3					5	Gold 2x	9	Act 5 (H) Equip B	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic B	4																	0
+Council Item (H) Desecrated E			3					5	Gold 2x	9	Act 5 (H) Equip C	15	Act 5 (H) Junk	5	Act 5 (H) Good	3	Act 5 (H) Magic C	4																	0
 Council			-1	650	800	800	1024	0	Council Item	1																									0
 Council Desecrated A	25	28	-2	650	800	800	1024	0	Corruption Orb	1	Council Item Desecrated A	1																							0
 Council Desecrated B	25	38	-2	650	800	800	1024	0	Corruption Orb	1	Council Item Desecrated B	1																							0
@@ -944,19 +944,19 @@ Council (H) Desecrated B	25	87	-4	650	800	800	1024	0	Corruption Orb	1	Sunder Cha
 Council (H) Desecrated C	25	90	-4	650	800	800	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Council Item (H) Desecrated C	1																			0
 Council (H) Desecrated D	25	93	-4	650	800	800	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Council Item (H) Desecrated D	1																			0
 Council (H) Desecrated E	25	96	-4	650	800	800	1024	0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Council Item (H) Desecrated E	1																			0
-Griswold Item			6					0	Act 1 Uitem C	1	Act 1 Melee B	2																							0
-Griswold Item Desecrated A			6					20	Act 1 Uitem C	2	Act 1 Melee B	4																							0
-Griswold Item Desecrated B			6					20	Act 4 Uitem B	2	Act 4 Melee A	4																							0
-Griswold Item Desecrated C			6					20	Act 3 (N) Uitem A	2	Act 2 (N) Melee B	4																							0
-Griswold Item (N)			6					0	Act 1 (H) Uitem C	1	Act 1 (N) Melee B	2																							0
-Griswold Item (N) Desecrated A			6					20	Act 1 (H) Uitem C	3	Act 1 (N) Melee B	4																							0
-Griswold Item (N) Desecrated B			6					20	Act 1 (H) Uitem C	3	Act 3 (N) Melee B	4																							0
-Griswold Item (N) Desecrated C			6					20	Act 3 (H) Uitem C	3	Act 3 (H) Melee B	4																							0
-Griswold Item (H)			6					0	Act 1 (H) Uitem C	1	Act 1 (H) Melee B	2																							0
-Griswold Item (H) Desecrated A			6					20	Act 4 (H) Uitem B	3	Act 4 (H) Melee A	6																							0
-Griswold Item (H) Desecrated B			6					20	Act 5 (H) Uitem A	3	Act 4 (H) Melee B	6																							0
-Griswold Item (H) Desecrated C			6					20	Act 5 (H) Uitem B	3	Act 5 (H) Melee A	6																							0
-Griswold Item (H) Desecrated D			6					20	Act 5 (H) Uitem C	3	Act 5 (H) Melee B	6																							0
+Griswold Item			6					5	Act 1 Uitem C	1	Act 1 Melee B	2																							0
+Griswold Item Desecrated A			6					5	Act 1 Uitem C	2	Act 1 Melee B	4																							0
+Griswold Item Desecrated B			6					5	Act 4 Uitem B	2	Act 4 Melee A	4																							0
+Griswold Item Desecrated C			6					5	Act 3 (N) Uitem A	2	Act 2 (N) Melee B	4																							0
+Griswold Item (N)			6					5	Act 1 (H) Uitem C	1	Act 1 (N) Melee B	2																							0
+Griswold Item (N) Desecrated A			6					5	Act 1 (H) Uitem C	3	Act 1 (N) Melee B	4																							0
+Griswold Item (N) Desecrated B			6					5	Act 1 (H) Uitem C	3	Act 3 (N) Melee B	4																							0
+Griswold Item (N) Desecrated C			6					5	Act 3 (H) Uitem C	3	Act 3 (H) Melee B	4																							0
+Griswold Item (H)			6					5	Act 1 (H) Uitem C	1	Act 1 (H) Melee B	2																							0
+Griswold Item (H) Desecrated A			6					5	Act 4 (H) Uitem B	3	Act 4 (H) Melee A	6																							0
+Griswold Item (H) Desecrated B			6					5	Act 5 (H) Uitem A	3	Act 4 (H) Melee B	6																							0
+Griswold Item (H) Desecrated C			6					5	Act 5 (H) Uitem B	3	Act 5 (H) Melee A	6																							0
+Griswold Item (H) Desecrated D			6					5	Act 5 (H) Uitem C	3	Act 5 (H) Melee B	6																							0
 Griswold			-1					0	Griswold Item	1																									0
 Griswold Desecrated A	26	8	-2					0	Corruption Orb	1	Griswold Item Desecrated A	1																							0
 Griswold Desecrated B	26	29	-2					0	Corruption Orb	1	Griswold Item Desecrated B	1																							0
@@ -972,25 +972,25 @@ Griswold (H) Desecrated C	26	93	-4					0	Corruption Orb	1	Sunder Charms	1	Shadow
 Griswold (H) Desecrated D	26	96	-4					0	Corruption Orb	1	Sunder Charms	1	Shadow Orb	1	Griswold Item (H) Desecrated D	1																			0
 Cow			1					60	Gold	9	Act 5 Equip A	19	Act 5 Junk	19	Act 5 Good	3																			0
 Cow (N)			1					60	Gold	9	Act 5 (N) Equip A	19	Act 5 (N) Junk	19	Act 5 (N) Good	3																			0
-Cow (H)			1	3	5	7	9	60	Gold	9	Act 5 (H) Equip B	25	Act 5 (H) Junk	11	Act 5 (H) Good	5																			0
+Cow (H)			1	3	5	7	9	60	Gold	9	Act 5 (H) Equip B	25	Act 5 (H) Junk	11	Act 5 (H) Good	8																			0
 Trapped Soul			1					60	Gold	9	Act 4 Equip A	8	Act 4 Junk	33																					0
 Trapped Soul (N)			1					60	Gold	9	Act 4 (N) Equip A	8	Act 4 (N) Junk	33																					0
 Trapped Soul (H)			1					60	Gold	9	Act 4 (H) Equip A	8	Act 4 (H) Junk	33																					0
-Hephasto Rune			2					0	Runes 3	30	Runes 4	15	Runes 5	15																					0
-Hephasto Rune (N)			2					0	Runes 8	15	Runes 9	15	Runes 10	15																					0
-Hephasto Rune (H)			2					0	Runes 11	15	Runes 12	15	Runes 13	15																					0
-Hephasto Rune Desecrated			2					0	Runes 4	30	Runes 5	15	Runes 6	15																					0
-Hephasto Rune (N) Desecrated			2					0	Runes 9	15	Runes 10	15	Runes 11	15																					0
-Hephasto Rune (H) Desecrated			2					0	Runes 12	15	Runes 13	15	Runes 14	15																					0
-Hephasto Item			5					5	Gold 1.5x	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
+Hephasto Rune			2					2	Runes 3	30	Runes 4	15	Runes 5	15																					0
+Hephasto Rune (N)			2					2	Runes 8	15	Runes 9	15	Runes 10	15																					0
+Hephasto Rune (H)			2					2	Runes 11	15	Runes 12	15	Runes 13	15																					0
+Hephasto Rune Desecrated			2					2	Runes 4	30	Runes 5	15	Runes 6	15																					0
+Hephasto Rune (N) Desecrated			2					2	Runes 9	15	Runes 10	15	Runes 11	15																					0
+Hephasto Rune (H) Desecrated			2					2	Runes 12	15	Runes 13	15	Runes 14	15																					0
+Hephasto Item			5					10	Gold 1.5x	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
 Hephasto Item Desecrated A			5					10	Gold 1.5x	14	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
 Hephasto Item Desecrated B			5					10	Gold 1.5x	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3																			0
 Hephasto Item Desecrated C			5					10	Gold 1.5x	14	Act 3 (N) Equip C	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
-Hephasto Item (N)			5					5	Gold 2x	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Hephasto Item (N)			5					10	Gold 2x	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Hephasto Item (N) Desecrated A			5					10	Gold 1.5x	14	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Hephasto Item (N) Desecrated B			5					10	Gold 1.5x	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Hephasto Item (N) Desecrated C			5					10	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
-Hephasto Item (H)			5					5	Gold 2.5x	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Hephasto Item (H)			5					10	Gold 2.5x	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Hephasto Item (H) Desecrated A			5					10	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Hephasto Item (H) Desecrated B			5					10	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Hephasto Item (H) Desecrated C			5					10	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
@@ -1013,32 +1013,32 @@ Hephasto (H) Desecrated D	27	90	-5	883	883	983	1024	0	Sunder Charms	1	Corruption
 Hephasto (H) Desecrated E	27	93	-5	883	883	983	1024	0	Sunder Charms	1	Corruption Orb	1	Shadow Orb	1	Hephasto Item (H) Desecrated E	1	Hephasto Rune (H) Desecrated	1																	0
 Hephasto (H) Desecrated F	27	96	-5	883	883	983	1024	0	Sunder Charms	1	Corruption Orb	1	Shadow Orb	1	Hephasto Item (H) Desecrated F	1	Hephasto Rune (H) Desecrated	1																	0
 Nihlathak Item			5					5	Gold 1.5x	7	Act 5 Equip B	19	Act 5 Junk	5	Act 5 Good	3																			0
-Nihlathak Item Desecrated	28	68	5					19	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Nihlathak Item Desecrated	28	68	5					5	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Nihlathak Item (N)			5					5	Gold 2x	7	Act 5 (N) Equip B	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Nihlathak Item (N) Desecrated	28	73	5					19	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Nihlathak Item (N) Desecrated	28	73	5					5	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Nihlathak Item (H)			5					5	Gold 2.5x	7	Act 5 (H) Equip B	19	Act 5 (H) Junk	3	Act 5 (H) Good	3	pk3	2																	0
-Nihlathak Item (H) Desecrated			5					19	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	pk3	2																	0
+Nihlathak Item (H) Desecrated			5					5	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3	pk3	2																	0
 Nihlathak			-1	900	900	900	1024	0	Nihlathak Item	1																									0
 Nihlathak Desecrated	28	68	-2	900	900	900	1024	0	Corruption Orb	1	Nihlathak Item Desecrated	1																							0
 Nihlathak (N)			-2	900	900	900	1024	0	Socket Orb	1	Nihlathak Item (N)	1																							0
 Nihlathak (N) Desecrated	28	73	-4	900	900	900	1024	0	Corruption Orb	1	Socket Orb	1	Sunder Charms	1	Nihlathak Item (N) Desecrated	1																			0
 Nihlathak (H)			-2	900	900	900	1024	0	Socket Orb	1	Nihlathak Item (H)	1																							0
 Nihlathak (H) Desecrated	28	95	-4	900	900	900	1024	0	Corruption Orb	1	Socket Orb	1	Sunder Charms	1	Nihlathak Item (H) Desecrated	1																			0
-Frozenstein Rune			2					0	Runes 3	30	Runes 4	15	Runes 5	15																					0
-Frozenstein Rune (N)			2					0	Runes 8	15	Runes 9	15	Runes 10	15																					0
-Frozenstein Rune (H)			2					0	Runes 11	15	Runes 12	15	Runes 13	15																					0
-Frozenstein Rune Desecrated			2					0	Runes 4	30	Runes 5	15	Runes 6	15																					0
-Frozenstein Rune (N) Desecrated			2					0	Runes 9	15	Runes 10	15	Runes 11	15																					0
-Frozenstein Rune (H) Desecrated			2					0	Runes 12	15	Runes 13	15	Runes 14	15																					0
-Frozenstein Item			5					5	Gold 1.5x	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
+Frozenstein Rune			2					2	Runes 3	30	Runes 4	15	Runes 5	15																					0
+Frozenstein Rune (N)			2					2	Runes 8	15	Runes 9	15	Runes 10	15																					0
+Frozenstein Rune (H)			2					2	Runes 11	15	Runes 12	15	Runes 13	15																					0
+Frozenstein Rune Desecrated			2					2	Runes 4	30	Runes 5	15	Runes 6	15																					0
+Frozenstein Rune (N) Desecrated			2					2	Runes 9	15	Runes 10	15	Runes 11	15																					0
+Frozenstein Rune (H) Desecrated			2					2	Runes 12	15	Runes 13	15	Runes 14	15																					0
+Frozenstein Item			5					10	Gold 1.5x	7	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
 Frozenstein Item Desecrated A			5					10	Gold 1.5x	14	Act 5 Equip A	19	Act 5 Junk	5	Act 5 Good	3																			0
 Frozenstein Item Desecrated B			5					10	Gold 1.5x	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3																			0
 Frozenstein Item Desecrated C			5					10	Gold 1.5x	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Frozenstein Item (N)			5					5	Gold 2x	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Frozenstein Item (N)			5					10	Gold 2x	7	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Frozenstein Item (N) Desecrated A			5					10	Gold 1.5x	14	Act 5 (N) Equip A	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Frozenstein Item (N) Desecrated B			5					10	Gold 1.5x	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
 Frozenstein Item (N) Desecrated C			5					10	Gold 1.5x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Frozenstein Item (H)			5					5	Gold 2.5x	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Frozenstein Item (H)			5					10	Gold 2.5x	7	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Frozenstein Item (H) Desecrated A			5					10	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Frozenstein Item (H) Desecrated B			5					10	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Frozenstein Item (H) Desecrated C			5					10	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
@@ -1061,11 +1061,11 @@ Frozenstein (H) Desecrated D	35	90	-5	883	883	983	1024	0	Sunder Charms	1	Corrupt
 Frozenstein (H) Desecrated E	35	93	-5	883	883	983	1024	0	Sunder Charms	1	Corruption Orb	1	Shadow Orb	1	Frozenstein Item (H) Desecrated E	1	Frozenstein Rune (H) Desecrated	1																	0
 Frozenstein (H) Desecrated F	35	96	-5	883	883	983	1024	0	Sunder Charms	1	Corruption Orb	1	Shadow Orb	1	Frozenstein Item (H) Desecrated F	1	Frozenstein Rune (H) Desecrated	1																	0
 Baal Item			7					5	Gold 2x	2	Act 1 (N) Equip A	52	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
-Baal Item Desecrated			7					15	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Baal Item Desecrated			7					5	Gold 1.5x	5	Act 3 (N) Equip A	52	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Baal Item (N)			7					5	Gold 2x	2	Act 1 (H) Equip A	52	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
-Baal Item (N) Desecrated			7					15	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Baal Item (N) Desecrated			7					5	Gold 1.5x	5	Act 3 (H) Equip A	52	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Baal Item (H)			7					5	Gold 2.5x	2	Act 5 (H) Equip B	52	Act 5 (H) Junk	3	Act 5 (H) Good	3																			0
-Baal Item (H) Desecrated			7					15	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Baal Item (H) Desecrated			7					5	Gold 2x	5	Act 5 (H) Equip C	52	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Baal			-1	983	983	983	1024	0	Baal Item	1																									0
 Baal Desecrated	29	60	-3	983	983	983	1024	0	Corruption Orb	1	Socket Orb	1	Baal Item Desecrated	1																					0
 Baal (N)			-1	983	983	983	1024	0	Baal Item (N)	1																									0
@@ -1079,18 +1079,18 @@ Baalq			-1	993	993	1024	1024	0	Baalq Item	1																									0
 Baalq (N)			-2	993	993	1024	1024	0	Socket Orb	1	Baalq Item (N)	1																							0
 Baalq (H)			-2	993	993	1024	1024	0	Socket Orb	1	Baalq Item (H)	1																							0
 Blood Raven Item			5					5	Gold 2x	7	Act 1 Equip B	19	Act 1 Junk	5	Act 1 Good	3																			0
-Blood Raven Item Desecrated A			5					19	Gold 1.5x	14	Act 1 Equip C	19	Act 1 Junk	5	Act 1 Good	3																			0
-Blood Raven Item Desecrated B			5					19	Gold 1.5x	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
-Blood Raven Item Desecrated C			5					19	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Blood Raven Item Desecrated A			5					5	Gold 1.5x	14	Act 1 Equip C	19	Act 1 Junk	5	Act 1 Good	3																			0
+Blood Raven Item Desecrated B			5					5	Gold 1.5x	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
+Blood Raven Item Desecrated C			5					5	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Blood Raven Item (N)			5					5	Gold 2x	7	Act 1 (N) Equip B	19	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
-Blood Raven Item (N) Desecrated A			5					19	Gold 1.5x	14	Act 1 (N) Equip C	19	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
-Blood Raven Item (N) Desecrated B			5					19	Gold 1.5x	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
-Blood Raven Item (N) Desecrated C			5					19	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Blood Raven Item (N) Desecrated A			5					5	Gold 1.5x	14	Act 1 (N) Equip C	19	Act 1 (N) Junk	5	Act 1 (N) Good	3																			0
+Blood Raven Item (N) Desecrated B			5					5	Gold 1.5x	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
+Blood Raven Item (N) Desecrated C			5					5	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Blood Raven Item (H)			5					5	Gold 2.5x	7	Act 1 (H) Equip B	19	Act 1 (H) Junk	5	Act 1 (H) Good	3																			0
-Blood Raven Item (H) Desecrated A			5					19	Gold 2x	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
-Blood Raven Item (H) Desecrated B			5					19	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Blood Raven Item (H) Desecrated C			5					19	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Blood Raven Item (H) Desecrated D			5					19	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Blood Raven Item (H) Desecrated A			5					5	Gold 2x	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
+Blood Raven Item (H) Desecrated B			5					5	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Blood Raven Item (H) Desecrated C			5					5	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Blood Raven Item (H) Desecrated D			5					5	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Blood Raven			-1	800	800	972	1024	0	Blood Raven Item	1																									0
 Blood Raven Desecrated A	30	10	-2	800	800	972	1024	0	Corruption Orb	1	Blood Raven Item Desecrated A	1																							0
 Blood Raven Desecrated B	30	29	-2	800	800	972	1024	0	Corruption Orb	1	Blood Raven Item Desecrated B	1																							0
@@ -1105,23 +1105,23 @@ Blood Raven (H) Desecrated B	30	90	-4	800	800	972	1024	0	Corruption Orb	1	Shadow
 Blood Raven (H) Desecrated C	30	93	-4	800	800	972	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Blood Raven Item (H) Desecrated C	1																			0
 Blood Raven (H) Desecrated D	30	96	-4	800	800	972	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Blood Raven Item (H) Desecrated D	1																			0
 Smith Item			5					5	Act 1 Uitem C	1	Act 1 Melee B	2																							0
-Smith Item Desecrated A			5					19	Act 2 Uitem A	1	Act 2 Melee A	2																							0
-Smith Item Desecrated B			5					19	Act 4 Uitem B	1	Act 4 Melee B	2																							0
-Smith Item Desecrated C			5					19	Act 3 (N) Uitem A	1	Act 3 (N) Melee A	2																							0
+Smith Item Desecrated A			5					5	Act 2 Uitem A	1	Act 2 Melee A	2																							0
+Smith Item Desecrated B			5					5	Act 4 Uitem B	1	Act 4 Melee B	2																							0
+Smith Item Desecrated C			5					5	Act 3 (N) Uitem A	1	Act 3 (N) Melee A	2																							0
 Smith Item (N)			5					5	Act 1 (H) Uitem C	1	Act 1 (N) Melee B	2																							0
-Smith Item (N) Desecrated A			5					19	Act 2 (N) Uitem A	1	Act 2 (N) Melee A	2																							0
-Smith Item (N) Desecrated B			5					19	Act 4 (N) Uitem B	1	Act 4 (N) Melee B	2																							0
-Smith Item (N) Desecrated C			5					19	Act 3 (H) Uitem A	1	Act 3 (H) Melee A	2																							0
+Smith Item (N) Desecrated A			5					5	Act 2 (N) Uitem A	1	Act 2 (N) Melee A	2																							0
+Smith Item (N) Desecrated B			5					5	Act 4 (N) Uitem B	1	Act 4 (N) Melee B	2																							0
+Smith Item (N) Desecrated C			5					5	Act 3 (H) Uitem A	1	Act 3 (H) Melee A	2																							0
 Smith Item (H)			5					5	Act 1 (H) Uitem C	1	Act 1 (H) Melee B	2																							0
-Smith Item (H) Desecrated A			5					19	Act 3 (H) Uitem A	1	Act 3 (H) Melee A	2																							0
-Smith Item (H) Desecrated B			5					19	Act 3 (H) Uitem B	2	Act 3 (H) Melee B	4																							0
-Smith Item (H) Desecrated C			5					19	Act 3 (H) Uitem C	2	Act 3 (H) Melee B	4																							0
-Smith Item (H) Desecrated D			5					19	Act 4 (H) Uitem A	2	Act 4 (H) Melee A	4																							0
-Smith Item (H) Desecrated E			5					19	Act 4 (H) Uitem B	2	Act 4 (H) Melee B	4																							0
-Smith Item (H) Desecrated F			5					19	Act 4 (H) Uitem B	2	Act 4 (H) Melee B	4																							0
-Smith Item (H) Desecrated G			5					19	Act 5 (H) Uitem A	2	Act 5 (H) Melee A	4																							0
-Smith Item (H) Desecrated H			5					19	Act 5 (H) Uitem B	2	Act 5 (H) Melee B	4																							0
-Smith Item (H) Desecrated I			5					19	Act 5 (H) Uitem C	2	Act 5 (H) Melee C	4																							0
+Smith Item (H) Desecrated A			5					5	Act 3 (H) Uitem A	1	Act 3 (H) Melee A	2																							0
+Smith Item (H) Desecrated B			5					5	Act 3 (H) Uitem B	2	Act 3 (H) Melee B	4																							0
+Smith Item (H) Desecrated C			5					5	Act 3 (H) Uitem C	2	Act 3 (H) Melee B	4																							0
+Smith Item (H) Desecrated D			5					5	Act 4 (H) Uitem A	2	Act 4 (H) Melee A	4																							0
+Smith Item (H) Desecrated E			5					5	Act 4 (H) Uitem B	2	Act 4 (H) Melee B	4																							0
+Smith Item (H) Desecrated F			5					5	Act 4 (H) Uitem B	2	Act 4 (H) Melee B	4																							0
+Smith Item (H) Desecrated G			5					5	Act 5 (H) Uitem A	2	Act 5 (H) Melee A	4																							0
+Smith Item (H) Desecrated H			5					5	Act 5 (H) Uitem B	2	Act 5 (H) Melee B	4																							0
+Smith Item (H) Desecrated I			5					5	Act 5 (H) Uitem C	2	Act 5 (H) Melee C	4																							0
 Smith			-1	800	800	972	1024	0	Smith Item	1																									0
 Smith Desecrated A	31	13	-2	800	800	972	1024	0	Corruption Orb	1	Smith Item Desecrated A	1																							0
 Smith Desecrated B	31	32	-2	800	800	972	1024	0	Corruption Orb	1	Smith Item Desecrated B	1																							0
@@ -1141,18 +1141,18 @@ Smith (H) Desecrated G	31	90	-4	800	800	972	1024	0	Corruption Orb	1	Shadow Orb	1
 Smith (H) Desecrated H	31	93	-4	800	800	972	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Smith Item (H) Desecrated H	1																			0
 Smith (H) Desecrated I	31	96	-4	800	800	972	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Smith Item (H) Desecrated I	1																			0
 Izual Item			5					5	Gold 1.5x	7	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
-Izual Item Desecrated A	32	29	5					19	Gold 1.5x	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
-Izual Item Desecrated B	32	38	5					19	Gold 1.5x	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3																			0
-Izual Item Desecrated C	32	48	5					19	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
+Izual Item Desecrated A	32	29	5					5	Gold 1.5x	14	Act 4 Equip B	19	Act 4 Junk	5	Act 4 Good	3																			0
+Izual Item Desecrated B	32	38	5					5	Gold 1.5x	14	Act 5 Equip C	19	Act 5 Junk	5	Act 5 Good	3																			0
+Izual Item Desecrated C	32	48	5					5	Gold 1.5x	14	Act 3 (N) Equip A	19	Act 3 (N) Junk	5	Act 3 (N) Good	3																			0
 Izual Item (N)			5					5	Gold 2x	7	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
-Izual Item (N) Desecrated A	32	60	5					19	Gold 1.5x	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
-Izual Item (N) Desecrated B	32	66	5					19	Gold 1.5x	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
-Izual Item (N) Desecrated C	32	73	5					19	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
+Izual Item (N) Desecrated A	32	60	5					5	Gold 1.5x	14	Act 4 (N) Equip B	19	Act 4 (N) Junk	5	Act 4 (N) Good	3																			0
+Izual Item (N) Desecrated B	32	66	5					5	Gold 1.5x	14	Act 5 (N) Equip C	19	Act 5 (N) Junk	5	Act 5 (N) Good	3																			0
+Izual Item (N) Desecrated C	32	73	5					5	Gold 1.5x	14	Act 3 (H) Equip A	19	Act 3 (H) Junk	5	Act 3 (H) Good	3																			0
 Izual Item (H)			5					5	Gold 2.5x	7	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
-Izual Item (H) Desecrated A			5					19	Gold 2x	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
-Izual Item (H) Desecrated B			5					19	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Izual Item (H) Desecrated C			5					19	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
-Izual Item (H) Desecrated D			5					19	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Izual Item (H) Desecrated A			5					5	Gold 2x	14	Act 4 (H) Equip B	19	Act 4 (H) Junk	5	Act 4 (H) Good	3																			0
+Izual Item (H) Desecrated B			5					5	Gold 2x	14	Act 5 (H) Equip A	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Izual Item (H) Desecrated C			5					5	Gold 2x	14	Act 5 (H) Equip B	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
+Izual Item (H) Desecrated D			5					5	Gold 2x	14	Act 5 (H) Equip C	19	Act 5 (H) Junk	5	Act 5 (H) Good	3																			0
 Izual			-1	800	800	972	1024	0	Izual Item	1																									0
 Izual Desecrated A	32	29	-2	800	800	972	1024	0	Corruption Orb	1	Izual Item Desecrated A	1																							0
 Izual Desecrated B	32	38	-2	800	800	972	1024	0	Corruption Orb	1	Izual Item Desecrated B	1																							0
@@ -1311,18 +1311,18 @@ Cow King (H) Desecrated B	33	90	-4	850	983	983	1024	0	Corruption Orb	1	Shadow Or
 Cow King (H) Desecrated C	33	93	-4	850	983	983	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Cow King Item (H) Desecrated C	1																			0
 Cow King (H) Desecrated D	33	96	-4	850	983	983	1024	0	Corruption Orb	1	Shadow Orb	1	Sunder Charms	1	Cow King Item (H) Desecrated D	1																			0
 Duriel - Base Item			7					5	Gold 1.5x	5	Act 3 Equip A	19	Act 3 Junk	15	Act 3 Good	3																			0
-Duriel - Base Item Desecrated A			7					19	Gold 1.5x	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
-Duriel - Base Item Desecrated B			7					19	Gold 1.5x	11	Act 5 Equip B	19	Act 5 Junk	15	Act 5 Good	3																			0
-Duriel - Base Item Desecrated C			7					19	Gold 1.5x	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
+Duriel - Base Item Desecrated A			7					5	Gold 1.5x	11	Act 3 Equip B	19	Act 3 Junk	15	Act 3 Good	3																			0
+Duriel - Base Item Desecrated B			7					5	Gold 1.5x	11	Act 5 Equip B	19	Act 5 Junk	15	Act 5 Good	3																			0
+Duriel - Base Item Desecrated C			7					5	Gold 1.5x	11	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
 Duriel (N) - Base Item			7					5	Gold 2x	5	Act 3 (N) Equip A	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
-Duriel (N) - Base Item Desecrated A			7					19	Gold 1.5x	11	Act 4 (N) Equip A	19	Act 4 (N) Junk	15	Act 4 (N) Good	3																			0
-Duriel (N) - Base Item Desecrated B			7					19	Gold 1.5x	11	Act 5 (N) Equip B	19	Act 5 (N) Junk	15	Act 5 (N) Good	3																			0
-Duriel (N) - Base Item Desecrated C			7					19	Gold 1.5x	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3																			0
+Duriel (N) - Base Item Desecrated A			7					5	Gold 1.5x	11	Act 4 (N) Equip A	19	Act 4 (N) Junk	15	Act 4 (N) Good	3																			0
+Duriel (N) - Base Item Desecrated B			7					5	Gold 1.5x	11	Act 5 (N) Equip B	19	Act 5 (N) Junk	15	Act 5 (N) Good	3																			0
+Duriel (N) - Base Item Desecrated C			7					5	Gold 1.5x	11	Act 3 (H) Equip A	19	Act 3 (H) Junk	15	Act 3 (H) Good	3																			0
 Duriel (H) - Base Item			7					5	Gold 2.5x	5	Act 3 (H) Equip A	19	Act 3 (H) Junk	10	Act 3 (H) Good	3																			0
-Duriel (H) - Base Item Desecrated A			7					19	Gold 2x	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3																			0
-Duriel (H) - Base Item Desecrated B			7					19	Gold 2x	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
-Duriel (H) - Base Item Desecrated C			7					19	Gold 2x	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
-Duriel (H) - Base Item Desecrated D			7					19	Gold 2x	11	Act 5 (H) Equip C	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Duriel (H) - Base Item Desecrated A			7					5	Gold 2x	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3																			0
+Duriel (H) - Base Item Desecrated B			7					5	Gold 2x	11	Act 5 (H) Equip A	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Duriel (H) - Base Item Desecrated C			7					5	Gold 2x	11	Act 5 (H) Equip B	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
+Duriel (H) - Base Item Desecrated D			7					5	Gold 2x	11	Act 5 (H) Equip C	19	Act 5 (H) Junk	15	Act 5 (H) Good	3																			0
 Durielq - Base Item			7					5	Act 3 Equip A	19	Act 3 Good	3																							0
 Durielq (N) - Base Item			7					5	Act 3 (N) Equip A	19	Act 3 (N) Good	3																							0
 Durielq (H) - Base Item			7					5	Act 3 (H) Equip A	19	Act 3 (H) Good	3																							0
@@ -1351,15 +1351,15 @@ Countess Rune (H)			3					2	Runes 10	15	Runes 11	15	Runes 12	15																	
 Countess Rune Desecrated			3					2	Runes 3	30	Runes 4	15	Runes 5	15																					0
 Countess Rune (N) Desecrated			3					2	Runes 8	15	Runes 9	15	Runes 10	15																					0
 Countess Rune (H) Desecrated			3					2	Runes 11	15	Runes 12	15	Runes 13	15																					0
-Countess Item			5					5	Gold 1.5x	7	Act 1 Equip C	19	Act 2 Junk	15	Act 2 Good	3																			0
+Countess Item			5					10	Gold 1.5x	7	Act 1 Equip C	19	Act 2 Junk	15	Act 2 Good	3																			0
 Countess Item Desecrated A			5					10	Gold 1.5x	11	Act 2 Equip A	19	Act 3 Junk	15	Act 3 Good	3																			0
 Countess Item Desecrated B			5					10	Gold 1.5x	11	Act 5 Equip A	19	Act 1 (N) Junk	15	Act 1 (N) Good	3																			0
 Countess Item Desecrated C			5					10	Gold 1.5x	11	Act 3 (N) Equip A	19	Act 4 (N) Junk	15	Act 4 (N) Good	3																			0
-Countess Item (N)			5					5	Gold 2x	7	Act 1 (N) Equip C	19	Act 2 (N) Junk	15	Act 2 (N) Good	3																			0
+Countess Item (N)			5					10	Gold 2x	7	Act 1 (N) Equip C	19	Act 2 (N) Junk	15	Act 2 (N) Good	3																			0
 Countess Item (N) Desecrated A			5					10	Gold 1.5x	11	Act 2 (N) Equip B	19	Act 3 (N) Junk	15	Act 3 (N) Good	3																			0
 Countess Item (N) Desecrated B			5					10	Gold 1.5x	11	Act 4 (N) Equip B	19	Act 5 (N) Junk	15	Act 5 (N) Good	3																			0
 Countess Item (N) Desecrated C			5					10	Gold 1.5x	11	Act 3 (H) Equip A	19	Act 4 (H) Junk	15	Act 4 (H) Good	3																			0
-Countess Item (H)			5					5	Gold 2.5x	7	Act 1 (H) Equip C	19	Act 2 (H) Junk	15	Act 2 (H) Good	3	pk1	2																	0
+Countess Item (H)			5					10	Gold 2.5x	7	Act 1 (H) Equip C	19	Act 2 (H) Junk	15	Act 2 (H) Good	3	pk1	2																	0
 Countess Item (H) Desecrated A			5					10	Gold 2x	11	Act 4 (H) Equip A	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	2																	0
 Countess Item (H) Desecrated B			5					10	Gold 2x	11	Act 4 (H) Equip B	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	2																	0
 Countess Item (H) Desecrated C			5					10	Gold 2x	11	Act 4 (H) Equip C	19	Act 4 (H) Junk	15	Act 4 (H) Good	3	pk1	2																	0


### PR DESCRIPTION
- Socket orbs are slightly less common due to much higher availability by being included on champion monsters.
- All rune bosses rune table from 0 to 2 nodrop to match countess and give a minor variance.
- All rune bosses non-TZ normalized to 10 base nodrop up from 5 so the rune table should properly trigger when farmed on /p1 no-TZ
- All other bosses TZ normalized to 5 base nodrop to match their non-TZ counterparts.
- H cows brought in line with the rest of Hell 