### PR TITLE
Default skill icons

### DIFF
--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68423daca900746a198fd404213574b810d4b3ad3ffe6f4d8c8fd33fd85debcd
+oid sha256:8144006f9a17a6b6a48269e2064e78f49879247931506cb328a51246f07f7aad
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:999837c37df1367fe9fe6033f0707d59ef40fc9236e323d35519846b8e3c3469
+oid sha256:68423daca900746a198fd404213574b810d4b3ad3ffe6f4d8c8fd33fd85debcd
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52f409e2d5e6100e522976b40a83ed8b6cf044d96e74649c85f4e9fbd8f403d6
+oid sha256:0dce56a5f1138a234908284e74a349780fcf5373be7a7d799bb20655be83aaa1
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b3db90f5b17556c20fe102cbbd277198fb1a42dbf364828a2cc47560d4883bf
+oid sha256:52f409e2d5e6100e522976b40a83ed8b6cf044d96e74649c85f4e9fbd8f403d6
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dce56a5f1138a234908284e74a349780fcf5373be7a7d799bb20655be83aaa1
+oid sha256:4e6baeef4d7a7df9f333caf2cc8c69bfb3c96d4d3fed91e413cb616def5940c1
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e6baeef4d7a7df9f333caf2cc8c69bfb3c96d4d3fed91e413cb616def5940c1
+oid sha256:999837c37df1367fe9fe6033f0707d59ef40fc9236e323d35519846b8e3c3469
 size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.lowend.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b3db90f5b17556c20fe102cbbd277198fb1a42dbf364828a2cc47560d4883bf
+size 696840

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:780ac9f3a4cfe152916412869b7c0a30d954a77ca59ff458056109d67e1ba16d
+oid sha256:ccb001537a8bd168008fcfd4470e914ba3e2079b893f81a58990e7c1f876cdfd
 size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4af069b0f5d6d7679383f2c8f50106e45b7e43216ad6b664599e654d129b3fa
+oid sha256:032d8653b6348a3a0dba7413f0341651be1c8dce063aac371bca23a1a87dff7e
 size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:032d8653b6348a3a0dba7413f0341651be1c8dce063aac371bca23a1a87dff7e
+oid sha256:825881bdcdcc33506fdfc9324d629f6d279e274e6e03950703c619ecdc5858ac
 size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc75bc0beaf32fb2e04b03fdcf9c0553f0a070e8fe0a560d41cfe998632fa885
+oid sha256:780ac9f3a4cfe152916412869b7c0a30d954a77ca59ff458056109d67e1ba16d
 size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc75bc0beaf32fb2e04b03fdcf9c0553f0a070e8fe0a560d41cfe998632fa885
+size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:825881bdcdcc33506fdfc9324d629f6d279e274e6e03950703c619ecdc5858ac
+oid sha256:5de4d041dc6ac736e4c8500d5eabec85bfce28288df91b9f5662c4b7122b67db
 size 2745640

--- a/data/hd/global/ui/spells/submenu/skillicon.sprite
+++ b/data/hd/global/ui/spells/submenu/skillicon.sprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccb001537a8bd168008fcfd4470e914ba3e2079b893f81a58990e7c1f876cdfd
+oid sha256:b4af069b0f5d6d7679383f2c8f50106e45b7e43216ad6b664599e654d129b3fa
 size 2745640


### PR DESCRIPTION
Update default game icons to be in line with Reimagined Icon art.
![image](https://github.com/user-attachments/assets/35c5b18f-70fc-4bdd-abee-68bde2bf13e9)
![image](https://github.com/user-attachments/assets/981d63e2-18e6-4fa6-967d-7a1fa5326a56)
![image](https://github.com/user-attachments/assets/3e5af4c9-73e0-4fd2-9b06-90ba33c6fdd9)