### PR TITLE
Fix Decoy Perma-Beam

### DIFF
--- a/data/global/excel/states.txt
+++ b/data/global/excel/states.txt
@@ -62,7 +62,7 @@ confuse	59						1	1																			1																curseconfuse					curse_hi
 decrepify	60						1	1													1																						cursedecrepify					curse_hit		skill_decrepify												necromancer_decrepify											0
 lowerresist	61						1	1															1	1	1	1																	curselowerresist					curse_hit		lightresist																							0
 openwounds	62								1																										1																																	85					0
-dopplezon	63				1						1																		1	1	1			1						1																								2	0								0
+dopplezon	63				1						1																		1	1	1	1		1						1																								2	0								0
 criticalstrike	64			1																																																																					0
 dodge	65			1																																																																					0
 avoid	66			1																																																																					0
@@ -186,7 +186,7 @@ passive_resistltng	183																																																										
 uberminion	184																												1		1		1	1																												impact_bluemotize_1											0
 cooldown	185																																																																								0
 sharedstash	186																																																																								0
-hidedead	187																											1	1				1																																								0
+hidedead	187																											1	1			1																																									0
 impale	188																																																																								0
 desecrated	189																												1	1																																											0
 markbear	190	4																																					1				bloodlust_state																														0
@@ -246,3 +246,4 @@ Armor_Purple	243																																																						tors	dpur	
 Armor_Orange	244																																																						tors	oran																	0
 polarbear	245	3			1	1				1	1		1	1																											1																10	50	255	255	255	druid_morph	druid_morph	1	428								0
 cowkingelite	246	3			1	1				1	1		1	1																											1																		255	255	255	druid_morph	druid_morph	1	743								0
+barb_ancient	247	3			1	1																																					rabiesplague	valkyrie																													0


### PR DESCRIPTION
So after some tracking of the beam itself it is added to all the player model corpses to make finding them easier.

The decoy is a duplicate of the amazon and thus also received said beam on death.

Flagging the state as hidedead solves the problem.