### PR TITLE
KOR translation: `Searing Moon`

### DIFF
--- a/data/local/lng/strings/item-runes.json
+++ b/data/local/lng/strings/item-runes.json
@@ -4292,7 +4292,7 @@
         "esES": "Luna Sangrienta",
         "frFR": "Lune de Sang",
         "itIT": "Luna di Sangue",
-        "koKR": "핏빛 달",
+        "koKR": "작열하는 달",
         "plPL": "Krwawy Księżyc",
         "esMX": "Luna Sangrienta",
         "jaJP": "ブラッドムーン",


### PR DESCRIPTION
this name was updated at 2.1.0 release.
but other langauges still use `blood moon`.

related #809