### PR TITLE
missing string fix

### DIFF
--- a/data/local/lng/strings/item-names.json
+++ b/data/local/lng/strings/item-names.json
@@ -10983,7 +10983,7 @@
     },
     {
         "id": 3245,
-        "Key": "Cain's Gibbet",
+        "Key": "Gibbet",
         "enUS": "Cain's Gibbet",
         "zhTW": "凱恩的絞架",
         "deDE": "Cains Galgen",


### PR DESCRIPTION
vanilla has it as just gibbet, somewhere along the way it got changed and is causing missing string

before

<img width="1265" height="858" alt="image" src="https://github.com/user-attachments/assets/f4d7a181-020d-4dbc-96d3-31ab56f7566c" />


after

<img width="1252" height="785" alt="image" src="https://github.com/user-attachments/assets/405f102a-084e-499e-80d4-fb558fc1ee65" />
