### PR TITLE
affix fix

### DIFF
--- a/data/global/excel/base/magicprefix.txt
+++ b/data/global/excel/base/magicprefix.txt
@@ -906,45 +906,45 @@ Gaian	+#% to Fire Skill Damage	100	1	0	81		80				2	215	extra-fire		3	5										
 Gaian	+#% to Lightning Skill Damage	100	1	0	81		80				2	215	extra-ltng		3	5										mcha												0	0
 Gaian	+#% to Cold Skill Damage	100	1	0	81		80				2	215	extra-cold		3	5										mcha												0	0
 Gaian	+#% to Poison Skill Damage	100	1	0	81		80				2	215	extra-pois		3	5										mcha												0	0
-Jagged	+#% Enhanced Damage	100	1	0	20	60	10				24	104	dmg%		5	10										lcha												0	0
+Jagged	+#% Enhanced Damage	100	1	1	20	60	10				24	104	dmg%		5	10										lcha												0	0
 Forked	+#% Enhanced Damage	100	1	1	55		50				6	104	dmg%		10	15										lcha												0	0
 Serrated	+#% Enhanced Damage	100	1	1	81		81				3	104	dmg%		20	25										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	1	60	1				24	110	att		6	12										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	7	60	5				24	110	att		13	27										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	13	60	10				24	110	att		28	42										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	19	81	15				12	110	att		43	57										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	25	81	20				12	110	att		58	72										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	31		25				12	110	att		73	87										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	1	60	1				24	110	att		6	12										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	7	60	5				24	110	att		13	27										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	13	60	10				24	110	att		28	42										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	19	81	15				12	110	att		43	57										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	25	81	20				12	110	att		58	72										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	31		25				12	110	att		73	87										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	38		29				6	110	att		88	102										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	61		61				6	110	att		103	117										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	81		81				6	110	att		118	132										lcha												0	0
 Fine	+# to Attack Rating & +# to Maximum Damage	100	1	1	15	60	15				24	110	att		10	20	dmg-max		1	3						lcha												0	0
 Fine	+# to Attack Rating & +# to Maximum Damage	100	1	1	35		35				12	110	att		21	48	dmg-max		4	6						lcha												0	0
 Sharp	+# to Attack Rating & +# to Maximum Damage	100	1	1	61		61				3	110	att		49	76	dmg-max		7	10						lcha												0	0
-Red	+# to Minimum Damage	100	1	0	4	60	3				24	103	dmg-min		1	2										lcha												0	0
-Red	+# to Minimum Damage	100	1	0	16	60	12				24	103	dmg-min		3	4										lcha												0	0
-Sanguinary	+# to Minimum Damage	100	1	0	28	81	21				12	103	dmg-min		5	6										lcha												0	0
-Sanguinary	+# to Minimum Damage	100	1	0	40		32				6	103	dmg-min		7	8										lcha												0	0
-Bloody	+# to Minimum Damage	100	1	0	52		46				3	103	dmg-min		9	10										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	3	60	2				24	103	dmg-max		1	2										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	10	60	7				24	103	dmg-max		3	4										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	17	81	12				24	103	dmg-max		5	6										lcha												0	0
-Forked	+# to Maximum Damage	100	1	0	25		18				24	103	dmg-max		7	8										lcha												0	0
+Red	+# to Minimum Damage	100	1	1	4	60	3				24	103	dmg-min		1	2										lcha												0	0
+Red	+# to Minimum Damage	100	1	1	16	60	12				24	103	dmg-min		3	4										lcha												0	0
+Sanguinary	+# to Minimum Damage	100	1	1	28	81	21				12	103	dmg-min		5	6										lcha												0	0
+Sanguinary	+# to Minimum Damage	100	1	1	40		32				6	103	dmg-min		7	8										lcha												0	0
+Bloody	+# to Minimum Damage	100	1	1	52		46				3	103	dmg-min		9	10										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	3	60	2				24	103	dmg-max		1	2										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	10	60	7				24	103	dmg-max		3	4										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	17	81	12				24	103	dmg-max		5	6										lcha												0	0
+Forked	+# to Maximum Damage	100	1	1	25		18				24	103	dmg-max		7	8										lcha												0	0
 Forked	+# to Maximum Damage	100	1	1	32		24				12	103	dmg-max		9	10										lcha												0	0
 Serrated	+# to Maximum Damage	100	1	1	39		31				6	103	dmg-max		11	12										lcha												0	0
 Serrated	+# to Maximum Damage	100	1	1	47		39				3	103	dmg-max		13	15										lcha												0	0
-Red	+# to Minimum Damage & +# to Maximum Damage	100	1	0	29	60	26				12	103	dmg-min		1	3	dmg-max		4	9						lcha												0	0
+Red	+# to Minimum Damage & +# to Maximum Damage	100	1	1	29	60	26				12	103	dmg-min		1	3	dmg-max		4	9						lcha												0	0
 Sanguinary	+# to Minimum Damage & +# to Maximum Damage	100	1	1	60		60				6	103	dmg-min		4	5	dmg-max		6	12						lcha												0	0
 Bloody	+# to Minimum Damage & +# to Maximum Damage	100	1	1	86		88				3	103	dmg-min		6	8	dmg-max		13	15						lcha												0	0
-Stout	+# Defense	100	1	0	1	30	1				24	101	ac		3	5	ac-miss		1	2						lcha												0	0
-Stout	+# Defense	100	1	0	7	40	5				24	101	ac		6	10	ac-miss		2	4						lcha												0	0
-Stout	+# Defense	100	1	0	12	50	9				24	101	ac		10	16	ac-miss		4	6						lcha												0	0
-Burly	+# Defense	100	1	0	17	60	12				24	101	ac		16	22	ac-miss		6	8						lcha												0	0
-Burly	+# Defense	100	1	0	22	81	16				12	101	ac		26	34	ac-miss		10	14						lcha												0	0
-Burly	+# Defense	100	1	0	27	81	20				12	101	ac		42	52	ac-miss		16	22						lcha												0	0
-Stalwart	+# Defense	100	1	0	32		24				12	101	ac		56	70	ac-miss		22	30						lcha												0	0
-Stalwart	+# Defense	100	1	0	37		29				12	101	ac		68	80	ac-miss		30	38						lcha												0	0
-Stalwart	+# Defense	100	1	0	42		34				6	101	ac		80	96	ac-miss		42	52						lcha												0	0
+Stout	+# Defense	100	1	1	1	30	1				24	101	ac		3	5	ac-miss		1	2						lcha												0	0
+Stout	+# Defense	100	1	1	7	40	5				24	101	ac		6	10	ac-miss		2	4						lcha												0	0
+Stout	+# Defense	100	1	1	12	50	9				24	101	ac		10	16	ac-miss		4	6						lcha												0	0
+Burly	+# Defense	100	1	1	17	60	12				24	101	ac		16	22	ac-miss		6	8						lcha												0	0
+Burly	+# Defense	100	1	1	22	81	16				12	101	ac		26	34	ac-miss		10	14						lcha												0	0
+Burly	+# Defense	100	1	1	27	81	20				12	101	ac		42	52	ac-miss		16	22						lcha												0	0
+Stalwart	+# Defense	100	1	1	32		24				12	101	ac		56	70	ac-miss		22	30						lcha												0	0
+Stalwart	+# Defense	100	1	1	37		29				12	101	ac		68	80	ac-miss		30	38						lcha												0	0
+Stalwart	+# Defense	100	1	1	42		34				6	101	ac		80	96	ac-miss		42	52						lcha												0	0
 Stalwart	+# Defense	100	1	1	55		48				6	101	ac		92	104	ac-miss		50	62						lcha												0	0
 Stalwart	+# Defense	100	1	1	69		65				3	101	ac		106	122	ac-miss		58	70						lcha												0	0
 Stalwart	+# Defense	100	1	1	81		75				3	101	ac		118	139	ac-miss		66	78						lcha												0	0
@@ -970,58 +970,58 @@ Entrapping	+# to Traps	100	1	1	50		42	ass			2	125	skilltab	18	1	1									blac	l
 Mentalist's	+# to Shadow Disciplines	100	1	1	50		42	ass			2	125	skilltab	19	1	1									blac	lcha												0	0
 Shogukusha's	+# to Martial Arts	100	1	1	50		42	ass			2	125	skilltab	20	1	1									blac	lcha												0	0
 Snowflake	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	5	60	5				24	137	cold-min		2	4	cold-max		4	5						lcha												0	0
-Shivering	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	0	35	60	35				24	137	cold-min		4	6	cold-max		6	8						lcha												0	0
-Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	0	61		61				12	137	cold-min		6	8	cold-max		10	15						lcha												0	0
+Shivering	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	35	60	35				24	137	cold-min		4	6	cold-max		6	8						lcha												0	0
+Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	61		61				12	137	cold-min		6	8	cold-max		10	15						lcha												0	0
 Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	80		80				6	137	cold-min		8	10	cold-max		12	18						lcha												0	0
 Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	81		81				3	137	cold-min		12	14	cold-max		20	25						lcha												0	0
-Ember	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	0	5	60	5				24	137	fire-min		2	4	fire-max		6	8						lcha												0	0
-Smoldering	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	0	35	60	35				12	137	fire-min		4	6	fire-max		10	15						lcha												0	0
+Ember	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	5	60	5				24	137	fire-min		2	4	fire-max		6	8						lcha												0	0
+Smoldering	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	35	60	35				12	137	fire-min		4	6	fire-max		10	15						lcha												0	0
 Smoking	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	61		61				6	137	fire-min		6	8	fire-max		12	18						lcha												0	0
 Flaming	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	81		81				3	137	fire-min		10	15	fire-max		20	25						lcha												0	0
-Static	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	0	5	60	5				24	137	ltng-min		2	4	ltng-max		6	8						lcha												0	0
-Glowing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	0	35	60	35				12	137	ltng-min		4	6	ltng-max		10	15						lcha												0	0
+Static	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	5	60	5				24	137	ltng-min		2	4	ltng-max		6	8						lcha												0	0
+Glowing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	35	60	35				12	137	ltng-min		4	6	ltng-max		10	15						lcha												0	0
 Arcing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	61		61				6	137	ltng-min		6	8	ltng-max		12	18						lcha												0	0
 Shocking	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	81		81				3	137	ltng-min		10	15	ltng-max		20	25						lcha												0	0
-Septic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	0	15	60	15				24	137	dmg-pois	75	220	280										lcha												0	0
-Envenomed	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	0	35		35				12	137	dmg-pois	75	280	360										lcha												0	0
+Septic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	15	60	15				24	137	dmg-pois	75	220	280										lcha												0	0
+Envenomed	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	35		35				12	137	dmg-pois	75	280	360										lcha												0	0
 Toxic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	61		61				6	137	dmg-pois	100	360	480										lcha												0	0
 Pestilent	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	81		81				3	137	dmg-pois	125	480	560										lcha												0	0
-Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	0	45		45				2	137	dmg-elem		5	10										lcha												0	0
+Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	45		45				2	137	dmg-elem		5	10										lcha												0	0
 Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	65		65				2	137	dmg-elem		10	20										lcha												0	0
 Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	85		85				1	137	dmg-elem		20	30										lcha												0	0
-Hulking	Adds #-# Damage	100	0	0	45		45				6	143	dmg-norm		10	20										lcha												0	0
+Hulking	Adds #-# Damage	100	0	1	45		45				6	143	dmg-norm		10	20										lcha												0	0
 Hulking	Adds #-# Damage	100	0	1	65		65				6	143	dmg-norm		20	40										lcha												0	0
 Hulking	Adds #-# Damage	100	0	1	85		85				6	143	dmg-norm		40	60										lcha												0	0
-Azure	Cold Resist +#%	100	1	0	10	61	10				24	117	res-cold		7	15										lcha												0	0
-Lapis	Cold Resist +#%	100	1	0	25	81	20				12	117	res-cold		16	20										lcha												0	0
+Azure	Cold Resist +#%	100	1	1	10	61	10				24	117	res-cold		7	15										lcha												0	0
+Lapis	Cold Resist +#%	100	1	1	25	81	20				12	117	res-cold		16	20										lcha												0	0
 Cobalt	Cold Resist +#%	100	1	1	45		40				12	117	res-cold		21	25										lcha												0	0
 Sapphire	Cold Resist +#%	100	1	1	60		55				6	117	res-cold		26	30										lcha												0	0
-Crimson	Fire Resist +#%	100	1	0	10	61	10				24	118	res-fire		7	15										lcha												0	0
-Russet	Fire Resist +#%	100	1	0	25	81	20				12	118	res-fire		16	20										lcha												0	0
+Crimson	Fire Resist +#%	100	1	1	10	61	10				24	118	res-fire		7	15										lcha												0	0
+Russet	Fire Resist +#%	100	1	1	25	81	20				12	118	res-fire		16	20										lcha												0	0
 Garnet	Fire Resist +#%	100	1	1	45		40				12	118	res-fire		21	25										lcha												0	0
 Ruby	Fire Resist +#%	100	1	1	60		55				6	118	res-fire		26	30										lcha												0	0
-Tangerine	Lightning Resist +#%	100	1	0	10	61	10				24	119	res-ltng		7	15										lcha												0	0
-Ocher	Lightning Resist +#%	100	1	0	25	81	20				12	119	res-ltng		16	20										lcha												0	0
+Tangerine	Lightning Resist +#%	100	1	1	10	61	10				24	119	res-ltng		7	15										lcha												0	0
+Ocher	Lightning Resist +#%	100	1	1	25	81	20				12	119	res-ltng		16	20										lcha												0	0
 Coral	Lightning Resist +#%	100	1	1	45		40				12	119	res-ltng		21	25										lcha												0	0
 Amber	Lightning Resist +#%	100	1	1	60		55				6	119	res-ltng		26	30										lcha												0	0
-Beryl	Poison Resist +#%	100	1	0	10	61	10				24	120	res-pois		7	15										lcha												0	0
-Viridian	Poison Resist +#%	100	1	0	25	81	20				12	120	res-pois		16	20										lcha												0	0
+Beryl	Poison Resist +#%	100	1	1	10	61	10				24	120	res-pois		7	15										lcha												0	0
+Viridian	Poison Resist +#%	100	1	1	25	81	20				12	120	res-pois		16	20										lcha												0	0
 Jade	Poison Resist +#%	100	1	1	45		40				12	120	res-pois		21	25										lcha												0	0
 Emerald	Poison Resist +#%	100	1	1	60		55				6	120	res-pois		26	30										lcha												0	0
-Shimmering	All Resistances +#	100	1	0	25	81	20				12	116	res-all		3	5										lcha												0	0
+Shimmering	All Resistances +#	100	1	1	25	81	20				12	116	res-all		3	5										lcha												0	0
 Shimmering	All Resistances +#	100	1	1	45		40				6	116	res-all		5	8										lcha												0	0
 Shimmering	All Resistances +#	100	1	1	65		60				3	116	res-all		8	10										lcha												0	0
-Lizard's	+# to Mana	100	1	0	1	60	1				24	115	mana		3	7										lcha												0	0
-Lizard's	+# to Mana	100	1	0	7	60	5				24	115	mana		8	13										lcha												0	0
-Lizard's	+# to Mana	100	1	0	15	60	10				24	115	mana		14	20										lcha												0	0
-Snake's	+# to Mana	100	1	0	24	81	20				12	115	mana		21	26										lcha												0	0
-Snake's	+# to Mana	100	1	0	31	81	30				12	115	mana		27	33										lcha												0	0
-Snake's	+# to Mana	100	1	0	40		40				12	115	mana		34	39										lcha												0	0
+Lizard's	+# to Mana	100	1	1	1	60	1				24	115	mana		3	7										lcha												0	0
+Lizard's	+# to Mana	100	1	1	7	60	5				24	115	mana		8	13										lcha												0	0
+Lizard's	+# to Mana	100	1	1	15	60	10				24	115	mana		14	20										lcha												0	0
+Snake's	+# to Mana	100	1	1	24	81	20				12	115	mana		21	26										lcha												0	0
+Snake's	+# to Mana	100	1	1	31	81	30				12	115	mana		27	33										lcha												0	0
+Snake's	+# to Mana	100	1	1	40		40				12	115	mana		34	39										lcha												0	0
 Serpent's	+# to Mana	100	1	1	61		61				6	115	mana		40	46										lcha												0	0
 Serpent's	+# to Mana	100	1	1	81		81				6	115	mana		47	52										lcha												0	0
 Serpent's	+# to Mana	100	1	1	85		85				3	115	mana		53	59										lcha												0	0
-Lucky	#% Better Chance of Getting Magic Items	100	1	0	21	61	10				24	114	mag%		10	15	gold%		20	30						lcha												0	0
-Lucky	#% Better Chance of Getting Magic Items	100	1	1	38	81	35				12	114	mag%		15	20	gold%		30	40						lcha												0	0
+Lucky	#% Better Chance of Getting Magic Items	100	1	1	21	81	10				24	114	mag%		10	15	gold%		20	30						lcha												0	0
+Lucky	#% Better Chance of Getting Magic Items	100	1	1	38		35				12	114	mag%		15	20	gold%		30	40						lcha												0	0
 Lucky	#% Better Chance of Getting Magic Items	100	1	1	55		50				6	114	mag%		20	25	gold%		40	50						lcha												0	0
 Shimmering	All Resistances +#	100	1	1	81		81				3	116	res-all		10	12										lcha												0	0
 Virulent	-# Enemy Poison Resistance	100	0	1	92		75				1	307	pierce-pois	1	1	1										scha												0	0

--- a/data/global/excel/base/magicsuffix.txt
+++ b/data/global/excel/base/magicsuffix.txt
@@ -725,9 +725,9 @@ of Life	+# to Life	100	1	0	35	60	35				24	26	hp		20	25										lcha												
 of Substinence	+# to Life	100	1	0	45	81	45				24	26	hp		25	30										lcha												0	0
 of Substinence	+# to Life	100	1	0	55	81	55				12	26	hp		30	35										lcha												0	0
 of Substinence	+# to Life	100	1	0	61		61				12	26	hp		35	40										lcha												0	0
-of Vita	+# to Life	100	1	1	75		70				6	26	hp		40	50										lcha												0	0
-of Vita	+# to Life	100	1	1	81		81				6	26	hp		50	60										lcha												0	0
-of Vita	+# to Life	100	1	1	88		88				6	26	hp		60	70										lcha												0	0
+of Vita	+# to Life	100	1	0	75		70				6	26	hp		40	50										lcha												0	0
+of Vita	+# to Life	100	1	0	81		81				6	26	hp		50	60										lcha												0	0
+of Vita	+# to Life	100	1	0	88		88				6	26	hp		60	70										lcha												0	0
 of Inertia	+#% Faster Run/Walk	100	1	1	15		15				6	35	move3		5	5										lcha												0	0
 of Balance	+#% Faster Hit Recovery	100	1	1	10		10				6	18	balance3		5	5										lcha												0	0
 of Mosaic	+#% chance for finishing moves to not consume charges	100	1	1	30		30		ass	30	64	81	charge-noconsume		50	50										h2h												0	0

--- a/data/global/excel/magicprefix.txt
+++ b/data/global/excel/magicprefix.txt
@@ -906,45 +906,45 @@ Gaian	+#% to Fire Skill Damage	100	1	0	81		80				2	215	extra-fire		3	5										
 Gaian	+#% to Lightning Skill Damage	100	1	0	81		80				2	215	extra-ltng		3	5										mcha												0	0
 Gaian	+#% to Cold Skill Damage	100	1	0	81		80				2	215	extra-cold		3	5										mcha												0	0
 Gaian	+#% to Poison Skill Damage	100	1	0	81		80				2	215	extra-pois		3	5										mcha												0	0
-Jagged	+#% Enhanced Damage	100	1	0	20	60	10				24	104	dmg%		5	10										lcha												0	0
+Jagged	+#% Enhanced Damage	100	1	1	20	60	10				24	104	dmg%		5	10										lcha												0	0
 Forked	+#% Enhanced Damage	100	1	1	55		50				6	104	dmg%		10	15										lcha												0	0
 Serrated	+#% Enhanced Damage	100	1	1	81		81				3	104	dmg%		20	25										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	1	60	1				24	110	att		6	12										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	7	60	5				24	110	att		13	27										lcha												0	0
-Bronze	+# to Attack Rating	100	1	0	13	60	10				24	110	att		28	42										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	19	81	15				12	110	att		43	57										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	25	81	20				12	110	att		58	72										lcha												0	0
-Iron	+# to Attack Rating	100	1	0	31		25				12	110	att		73	87										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	1	60	1				24	110	att		6	12										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	7	60	5				24	110	att		13	27										lcha												0	0
+Bronze	+# to Attack Rating	100	1	1	13	60	10				24	110	att		28	42										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	19	81	15				12	110	att		43	57										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	25	81	20				12	110	att		58	72										lcha												0	0
+Iron	+# to Attack Rating	100	1	1	31		25				12	110	att		73	87										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	38		29				6	110	att		88	102										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	61		61				6	110	att		103	117										lcha												0	0
 Steel	+# to Attack Rating	100	1	1	81		81				6	110	att		118	132										lcha												0	0
 Fine	+# to Attack Rating & +# to Maximum Damage	100	1	1	15	60	15				24	110	att		10	20	dmg-max		1	3						lcha												0	0
 Fine	+# to Attack Rating & +# to Maximum Damage	100	1	1	35		35				12	110	att		21	48	dmg-max		4	6						lcha												0	0
 Sharp	+# to Attack Rating & +# to Maximum Damage	100	1	1	61		61				3	110	att		49	76	dmg-max		7	10						lcha												0	0
-Red	+# to Minimum Damage	100	1	0	4	60	3				24	103	dmg-min		1	2										lcha												0	0
-Red	+# to Minimum Damage	100	1	0	16	60	12				24	103	dmg-min		3	4										lcha												0	0
-Sanguinary	+# to Minimum Damage	100	1	0	28	81	21				12	103	dmg-min		5	6										lcha												0	0
-Sanguinary	+# to Minimum Damage	100	1	0	40		32				6	103	dmg-min		7	8										lcha												0	0
-Bloody	+# to Minimum Damage	100	1	0	52		46				3	103	dmg-min		9	10										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	3	60	2				24	103	dmg-max		1	2										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	10	60	7				24	103	dmg-max		3	4										lcha												0	0
-Jagged	+# to Maximum Damage	100	1	0	17	81	12				24	103	dmg-max		5	6										lcha												0	0
-Forked	+# to Maximum Damage	100	1	0	25		18				24	103	dmg-max		7	8										lcha												0	0
+Red	+# to Minimum Damage	100	1	1	4	60	3				24	103	dmg-min		1	2										lcha												0	0
+Red	+# to Minimum Damage	100	1	1	16	60	12				24	103	dmg-min		3	4										lcha												0	0
+Sanguinary	+# to Minimum Damage	100	1	1	28	81	21				12	103	dmg-min		5	6										lcha												0	0
+Sanguinary	+# to Minimum Damage	100	1	1	40		32				6	103	dmg-min		7	8										lcha												0	0
+Bloody	+# to Minimum Damage	100	1	1	52		46				3	103	dmg-min		9	10										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	3	60	2				24	103	dmg-max		1	2										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	10	60	7				24	103	dmg-max		3	4										lcha												0	0
+Jagged	+# to Maximum Damage	100	1	1	17	81	12				24	103	dmg-max		5	6										lcha												0	0
+Forked	+# to Maximum Damage	100	1	1	25		18				24	103	dmg-max		7	8										lcha												0	0
 Forked	+# to Maximum Damage	100	1	1	32		24				12	103	dmg-max		9	10										lcha												0	0
 Serrated	+# to Maximum Damage	100	1	1	39		31				6	103	dmg-max		11	12										lcha												0	0
 Serrated	+# to Maximum Damage	100	1	1	47		39				3	103	dmg-max		13	15										lcha												0	0
-Red	+# to Minimum Damage & +# to Maximum Damage	100	1	0	29	60	26				12	103	dmg-min		1	3	dmg-max		4	9						lcha												0	0
+Red	+# to Minimum Damage & +# to Maximum Damage	100	1	1	29	60	26				12	103	dmg-min		1	3	dmg-max		4	9						lcha												0	0
 Sanguinary	+# to Minimum Damage & +# to Maximum Damage	100	1	1	60		60				6	103	dmg-min		4	5	dmg-max		6	12						lcha												0	0
 Bloody	+# to Minimum Damage & +# to Maximum Damage	100	1	1	86		88				3	103	dmg-min		6	8	dmg-max		13	15						lcha												0	0
-Stout	+# Defense	100	1	0	1	30	1				24	101	ac		3	5	ac-miss		1	2						lcha												0	0
-Stout	+# Defense	100	1	0	7	40	5				24	101	ac		6	10	ac-miss		2	4						lcha												0	0
-Stout	+# Defense	100	1	0	12	50	9				24	101	ac		10	16	ac-miss		4	6						lcha												0	0
-Burly	+# Defense	100	1	0	17	60	12				24	101	ac		16	22	ac-miss		6	8						lcha												0	0
-Burly	+# Defense	100	1	0	22	81	16				12	101	ac		26	34	ac-miss		10	14						lcha												0	0
-Burly	+# Defense	100	1	0	27	81	20				12	101	ac		42	52	ac-miss		16	22						lcha												0	0
-Stalwart	+# Defense	100	1	0	32		24				12	101	ac		56	70	ac-miss		22	30						lcha												0	0
-Stalwart	+# Defense	100	1	0	37		29				12	101	ac		68	80	ac-miss		30	38						lcha												0	0
-Stalwart	+# Defense	100	1	0	42		34				6	101	ac		80	96	ac-miss		42	52						lcha												0	0
+Stout	+# Defense	100	1	1	1	30	1				24	101	ac		3	5	ac-miss		1	2						lcha												0	0
+Stout	+# Defense	100	1	1	7	40	5				24	101	ac		6	10	ac-miss		2	4						lcha												0	0
+Stout	+# Defense	100	1	1	12	50	9				24	101	ac		10	16	ac-miss		4	6						lcha												0	0
+Burly	+# Defense	100	1	1	17	60	12				24	101	ac		16	22	ac-miss		6	8						lcha												0	0
+Burly	+# Defense	100	1	1	22	81	16				12	101	ac		26	34	ac-miss		10	14						lcha												0	0
+Burly	+# Defense	100	1	1	27	81	20				12	101	ac		42	52	ac-miss		16	22						lcha												0	0
+Stalwart	+# Defense	100	1	1	32		24				12	101	ac		56	70	ac-miss		22	30						lcha												0	0
+Stalwart	+# Defense	100	1	1	37		29				12	101	ac		68	80	ac-miss		30	38						lcha												0	0
+Stalwart	+# Defense	100	1	1	42		34				6	101	ac		80	96	ac-miss		42	52						lcha												0	0
 Stalwart	+# Defense	100	1	1	55		48				6	101	ac		92	104	ac-miss		50	62						lcha												0	0
 Stalwart	+# Defense	100	1	1	69		65				3	101	ac		106	122	ac-miss		58	70						lcha												0	0
 Stalwart	+# Defense	100	1	1	81		75				3	101	ac		118	139	ac-miss		66	78						lcha												0	0
@@ -970,58 +970,58 @@ Entrapping	+# to Traps	100	1	1	50		42	ass			2	125	skilltab	18	1	1									blac	l
 Mentalist's	+# to Shadow Disciplines	100	1	1	50		42	ass			2	125	skilltab	19	1	1									blac	lcha												0	0
 Shogukusha's	+# to Martial Arts	100	1	1	50		42	ass			2	125	skilltab	20	1	1									blac	lcha												0	0
 Snowflake	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	5	60	5				24	137	cold-min		2	4	cold-max		4	5						lcha												0	0
-Shivering	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	0	35	60	35				24	137	cold-min		4	6	cold-max		6	8						lcha												0	0
-Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	0	61		61				12	137	cold-min		6	8	cold-max		10	15						lcha												0	0
+Shivering	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	35	60	35				24	137	cold-min		4	6	cold-max		6	8						lcha												0	0
+Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	61		61				12	137	cold-min		6	8	cold-max		10	15						lcha												0	0
 Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	80		80				6	137	cold-min		8	10	cold-max		12	18						lcha												0	0
 Boreal	+# to Minimum Cold Damage & +# to Maximum Cold Damage	100	1	1	81		81				3	137	cold-min		12	14	cold-max		20	25						lcha												0	0
-Ember	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	0	5	60	5				24	137	fire-min		2	4	fire-max		6	8						lcha												0	0
-Smoldering	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	0	35	60	35				12	137	fire-min		4	6	fire-max		10	15						lcha												0	0
+Ember	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	5	60	5				24	137	fire-min		2	4	fire-max		6	8						lcha												0	0
+Smoldering	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	35	60	35				12	137	fire-min		4	6	fire-max		10	15						lcha												0	0
 Smoking	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	61		61				6	137	fire-min		6	8	fire-max		12	18						lcha												0	0
 Flaming	+# to Minimum Fire Damage & +# to Maximum Fire Damage	100	1	1	81		81				3	137	fire-min		10	15	fire-max		20	25						lcha												0	0
-Static	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	0	5	60	5				24	137	ltng-min		2	4	ltng-max		6	8						lcha												0	0
-Glowing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	0	35	60	35				12	137	ltng-min		4	6	ltng-max		10	15						lcha												0	0
+Static	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	5	60	5				24	137	ltng-min		2	4	ltng-max		6	8						lcha												0	0
+Glowing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	35	60	35				12	137	ltng-min		4	6	ltng-max		10	15						lcha												0	0
 Arcing	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	61		61				6	137	ltng-min		6	8	ltng-max		12	18						lcha												0	0
 Shocking	+# to Minimum Lightning Damage & +# to Maximum Lightning Damage	100	1	1	81		81				3	137	ltng-min		10	15	ltng-max		20	25						lcha												0	0
-Septic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	0	15	60	15				24	137	dmg-pois	75	220	280										lcha												0	0
-Envenomed	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	0	35		35				12	137	dmg-pois	75	280	360										lcha												0	0
+Septic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	15	60	15				24	137	dmg-pois	75	220	280										lcha												0	0
+Envenomed	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	35		35				12	137	dmg-pois	75	280	360										lcha												0	0
 Toxic	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	61		61				6	137	dmg-pois	100	360	480										lcha												0	0
 Pestilent	+# to Minimum Poison Damage & +# to Maximum Poison Damage	100	1	1	81		81				3	137	dmg-pois	125	480	560										lcha												0	0
-Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	0	45		45				2	137	dmg-elem		5	10										lcha												0	0
+Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	45		45				2	137	dmg-elem		5	10										lcha												0	0
 Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	65		65				2	137	dmg-elem		10	20										lcha												0	0
 Avatar	Adds #-# Fire/Lightning/Cold Damage	100	1	1	85		85				1	137	dmg-elem		20	30										lcha												0	0
-Hulking	Adds #-# Damage	100	0	0	45		45				6	143	dmg-norm		10	20										lcha												0	0
+Hulking	Adds #-# Damage	100	0	1	45		45				6	143	dmg-norm		10	20										lcha												0	0
 Hulking	Adds #-# Damage	100	0	1	65		65				6	143	dmg-norm		20	40										lcha												0	0
 Hulking	Adds #-# Damage	100	0	1	85		85				6	143	dmg-norm		40	60										lcha												0	0
-Azure	Cold Resist +#%	100	1	0	10	61	10				24	117	res-cold		7	15										lcha												0	0
-Lapis	Cold Resist +#%	100	1	0	25	81	20				12	117	res-cold		16	20										lcha												0	0
+Azure	Cold Resist +#%	100	1	1	10	61	10				24	117	res-cold		7	15										lcha												0	0
+Lapis	Cold Resist +#%	100	1	1	25	81	20				12	117	res-cold		16	20										lcha												0	0
 Cobalt	Cold Resist +#%	100	1	1	45		40				12	117	res-cold		21	25										lcha												0	0
 Sapphire	Cold Resist +#%	100	1	1	60		55				6	117	res-cold		26	30										lcha												0	0
-Crimson	Fire Resist +#%	100	1	0	10	61	10				24	118	res-fire		7	15										lcha												0	0
-Russet	Fire Resist +#%	100	1	0	25	81	20				12	118	res-fire		16	20										lcha												0	0
+Crimson	Fire Resist +#%	100	1	1	10	61	10				24	118	res-fire		7	15										lcha												0	0
+Russet	Fire Resist +#%	100	1	1	25	81	20				12	118	res-fire		16	20										lcha												0	0
 Garnet	Fire Resist +#%	100	1	1	45		40				12	118	res-fire		21	25										lcha												0	0
 Ruby	Fire Resist +#%	100	1	1	60		55				6	118	res-fire		26	30										lcha												0	0
-Tangerine	Lightning Resist +#%	100	1	0	10	61	10				24	119	res-ltng		7	15										lcha												0	0
-Ocher	Lightning Resist +#%	100	1	0	25	81	20				12	119	res-ltng		16	20										lcha												0	0
+Tangerine	Lightning Resist +#%	100	1	1	10	61	10				24	119	res-ltng		7	15										lcha												0	0
+Ocher	Lightning Resist +#%	100	1	1	25	81	20				12	119	res-ltng		16	20										lcha												0	0
 Coral	Lightning Resist +#%	100	1	1	45		40				12	119	res-ltng		21	25										lcha												0	0
 Amber	Lightning Resist +#%	100	1	1	60		55				6	119	res-ltng		26	30										lcha												0	0
-Beryl	Poison Resist +#%	100	1	0	10	61	10				24	120	res-pois		7	15										lcha												0	0
-Viridian	Poison Resist +#%	100	1	0	25	81	20				12	120	res-pois		16	20										lcha												0	0
+Beryl	Poison Resist +#%	100	1	1	10	61	10				24	120	res-pois		7	15										lcha												0	0
+Viridian	Poison Resist +#%	100	1	1	25	81	20				12	120	res-pois		16	20										lcha												0	0
 Jade	Poison Resist +#%	100	1	1	45		40				12	120	res-pois		21	25										lcha												0	0
 Emerald	Poison Resist +#%	100	1	1	60		55				6	120	res-pois		26	30										lcha												0	0
-Shimmering	All Resistances +#	100	1	0	25	81	20				12	116	res-all		3	5										lcha												0	0
+Shimmering	All Resistances +#	100	1	1	25	81	20				12	116	res-all		3	5										lcha												0	0
 Shimmering	All Resistances +#	100	1	1	45		40				6	116	res-all		5	8										lcha												0	0
 Shimmering	All Resistances +#	100	1	1	65		60				3	116	res-all		8	10										lcha												0	0
-Lizard's	+# to Mana	100	1	0	1	60	1				24	115	mana		3	7										lcha												0	0
-Lizard's	+# to Mana	100	1	0	7	60	5				24	115	mana		8	13										lcha												0	0
-Lizard's	+# to Mana	100	1	0	15	60	10				24	115	mana		14	20										lcha												0	0
-Snake's	+# to Mana	100	1	0	24	81	20				12	115	mana		21	26										lcha												0	0
-Snake's	+# to Mana	100	1	0	31	81	30				12	115	mana		27	33										lcha												0	0
-Snake's	+# to Mana	100	1	0	40		40				12	115	mana		34	39										lcha												0	0
+Lizard's	+# to Mana	100	1	1	1	60	1				24	115	mana		3	7										lcha												0	0
+Lizard's	+# to Mana	100	1	1	7	60	5				24	115	mana		8	13										lcha												0	0
+Lizard's	+# to Mana	100	1	1	15	60	10				24	115	mana		14	20										lcha												0	0
+Snake's	+# to Mana	100	1	1	24	81	20				12	115	mana		21	26										lcha												0	0
+Snake's	+# to Mana	100	1	1	31	81	30				12	115	mana		27	33										lcha												0	0
+Snake's	+# to Mana	100	1	1	40		40				12	115	mana		34	39										lcha												0	0
 Serpent's	+# to Mana	100	1	1	61		61				6	115	mana		40	46										lcha												0	0
 Serpent's	+# to Mana	100	1	1	81		81				6	115	mana		47	52										lcha												0	0
 Serpent's	+# to Mana	100	1	1	85		85				3	115	mana		53	59										lcha												0	0
-Lucky	#% Better Chance of Getting Magic Items	100	1	0	21	61	10				24	114	mag%		10	15	gold%		20	30						lcha												0	0
-Lucky	#% Better Chance of Getting Magic Items	100	1	1	38	81	35				12	114	mag%		15	20	gold%		30	40						lcha												0	0
+Lucky	#% Better Chance of Getting Magic Items	100	1	1	21	81	10				24	114	mag%		10	15	gold%		20	30						lcha												0	0
+Lucky	#% Better Chance of Getting Magic Items	100	1	1	38		35				12	114	mag%		15	20	gold%		30	40						lcha												0	0
 Lucky	#% Better Chance of Getting Magic Items	100	1	1	55		50				6	114	mag%		20	25	gold%		40	50						lcha												0	0
 Shimmering	All Resistances +#	100	1	1	81		81				3	116	res-all		10	12										lcha												0	0
 Virulent	-# Enemy Poison Resistance	100	0	1	92		75				1	307	pierce-pois	1	1	1										scha												0	0

--- a/data/global/excel/magicsuffix.txt
+++ b/data/global/excel/magicsuffix.txt
@@ -725,9 +725,9 @@ of Life	+# to Life	100	1	0	35	60	35				24	26	hp		20	25										lcha												
 of Substinence	+# to Life	100	1	0	45	81	45				24	26	hp		25	30										lcha												0	0
 of Substinence	+# to Life	100	1	0	55	81	55				12	26	hp		30	35										lcha												0	0
 of Substinence	+# to Life	100	1	0	61		61				12	26	hp		35	40										lcha												0	0
-of Vita	+# to Life	100	1	1	75		70				6	26	hp		40	50										lcha												0	0
-of Vita	+# to Life	100	1	1	81		81				6	26	hp		50	60										lcha												0	0
-of Vita	+# to Life	100	1	1	88		88				6	26	hp		60	70										lcha												0	0
+of Vita	+# to Life	100	1	0	75		70				6	26	hp		40	50										lcha												0	0
+of Vita	+# to Life	100	1	0	81		81				6	26	hp		50	60										lcha												0	0
+of Vita	+# to Life	100	1	0	88		88				6	26	hp		60	70										lcha												0	0
 of Inertia	+#% Faster Run/Walk	100	1	1	15		15				6	35	move3		5	5										lcha												0	0
 of Balance	+#% Faster Hit Recovery	100	1	1	10		10				6	18	balance3		5	5										lcha												0	0
 of Mosaic	+#% chance for finishing moves to not consume charges	100	1	1	30		30		ass	30	64	81	charge-noconsume		50	50										h2h												0	0


### PR DESCRIPTION
- fix life affix that was causing sunders to roll 99
- enable the random lower tier affixes that werent able to roll on crafted charms
  - seemed odd that the higher lvl req affixes of the same prop could roll but not the lower tiers even tho some of them have max level set