### PR TITLE
frFR "warp"

### DIFF
--- a/data/local/lng/strings/skills.json
+++ b/data/local/lng/strings/skills.json
@@ -39582,7 +39582,7 @@
         "zhTW": "傳送",
         "deDE": "Teleport",
         "esES": "Teletransporte",
-        "frFR": "Téléportation",
+        "frFR": "bréche",
         "itIT": "Teletrasporto",
         "koKR": "점멸",
         "plPL": "Teleportacja",


### PR DESCRIPTION
<img width="850" height="756" alt="image" src="https://github.com/user-attachments/assets/80543377-e6fc-48f5-8cb9-b697c830730a" />
I successfully went to France and back using “brèche” instead of “Warp” to fix this word.
Just kidding. The French users say this word sounds more natural.
